### PR TITLE
fix(widget-v2): fix retry logic in failed swaps

### DIFF
--- a/queue-manager/rango-preset/src/index.ts
+++ b/queue-manager/rango-preset/src/index.ts
@@ -1,5 +1,7 @@
-import { Configs, initConfig } from './configs';
-import { SwapQueueDef } from './types';
+import type { Configs } from './configs';
+import type { SwapQueueDef } from './types';
+
+import { initConfig } from './configs';
 import { swapQueueDef } from './queueDef';
 
 export { PrettyError, prettifyErrorMessage } from './shared-errors';
@@ -56,6 +58,7 @@ export {
   splitWalletNetwork,
   resetRunningSwapNotifsOnPageLoad,
   isApprovalTX,
+  getLastSuccessfulStep,
 } from './helpers';
 export { useMigration, useQueueManager, useEvents } from './hooks';
 

--- a/widget/embedded/src/utils/meta.ts
+++ b/widget/embedded/src/utils/meta.ts
@@ -1,4 +1,6 @@
-import type { BlockchainMeta } from 'rango-sdk';
+import type { Asset, BlockchainMeta, Token } from 'rango-sdk';
+
+import { tokensAreEqual } from './wallets';
 
 export function getBlockchainDisplayNameFor(
   blockchainName: string,
@@ -13,4 +15,12 @@ export function getBlockchainShortNameFor(
 ): string | undefined {
   return blockchains.find((blockchain) => blockchain.name === blockchainName)
     ?.shortName;
+}
+
+export function findToken(t: Asset, tokens: Token[]) {
+  return tokens.find((token) => tokensAreEqual(token, t)) ?? null;
+}
+
+export function findBlockchain(name: string, blockchains: BlockchainMeta[]) {
+  return blockchains.find((blockchain) => blockchain.name === name) ?? null;
 }


### PR DESCRIPTION
If a swap consists of multiple steps and fails at any one step, the retry mechanism should continue from the failed step and proceed with the remaining steps