### PR TITLE
fix(widget): fix safe accounts issue

### DIFF
--- a/wallets/provider-safe/src/index.ts
+++ b/wallets/provider-safe/src/index.ts
@@ -84,6 +84,6 @@ export const getWalletInfo: (allBlockChains: BlockchainMeta[]) => WalletInfo = (
     },
     color: '#ffffff',
     supportedChains: evms,
-    hideWhenNotInstalled: true,
+    isContractWallet: true,
   };
 };

--- a/wallets/react/src/provider.tsx
+++ b/wallets/react/src/provider.tsx
@@ -32,6 +32,7 @@ function Provider(props: ProviderProps) {
   const wallets = checkWalletProviders(listOfProviders);
 
   // Final API we put in context and it will be available to use for users.
+  // eslint-disable-next-line react/jsx-no-constructed-context-values
   const api: ProviderContext = {
     async connect(type, network) {
       const wallet = wallets.get(type);
@@ -41,7 +42,7 @@ function Provider(props: ProviderProps) {
       const walletInstance = getWalletInstance(wallet);
       const result = await walletInstance.connect(network);
       if (props.autoConnect) {
-        tryPersistWallet({
+        void tryPersistWallet({
           type,
           walletActions: wallet.actions,
           getState: api.state,
@@ -185,10 +186,13 @@ function Provider(props: ProviderProps) {
     if (allBlockChains) {
       wallets.forEach((wallet) => {
         const walletInstance = getWalletInstance(wallet);
-        const supportedChains = walletInstance.getWalletInfo(
+        const walletInfo = walletInstance.getWalletInfo(
           props.allBlockChains || []
-        ).supportedChains;
-        walletInstance.setMeta(supportedChains);
+        );
+        walletInstance.setInfo({
+          supportedBlockchains: walletInfo.supportedChains,
+          isContractWallet: !!walletInfo.isContractWallet,
+        });
       });
     }
   }, [props.allBlockChains]);
@@ -211,7 +215,7 @@ function Provider(props: ProviderProps) {
 
     if (shouldTryAutoConnect) {
       autoConnectInitiated.current = true;
-      (async () => {
+      void (async () => {
         await autoConnect(wallets, getWalletInstance);
       })();
     }

--- a/wallets/shared/src/rango.ts
+++ b/wallets/shared/src/rango.ts
@@ -287,7 +287,7 @@ export type WalletInfo = {
   color: string;
   supportedChains: BlockchainMeta[];
   showOnMobile?: boolean;
-  hideWhenNotInstalled?: boolean;
+  isContractWallet?: boolean;
   mobileWallet?: boolean;
 };
 

--- a/widget/embedded/src/Wallets.tsx
+++ b/widget/embedded/src/Wallets.tsx
@@ -44,22 +44,17 @@ export function WidgetWallets(
     .filter(isEvmBlockchain)
     .map((chain) => chain.name);
 
-  const onUpdateState: EventHandler = (
-    type,
-    event,
-    value,
-    state,
-    supportedBlockchains
-  ) => {
+  const onUpdateState: EventHandler = (type, event, value, state, meta) => {
     if (event === Events.ACCOUNTS) {
       if (value) {
         const supportedChainNames: Network[] | null =
-          walletAndSupportedChainsNames(supportedBlockchains);
+          walletAndSupportedChainsNames(meta.supportedBlockchains);
         const data = prepareAccountsForWalletStore(
           type,
           value,
           evmBasedChainNames,
-          supportedChainNames
+          supportedChainNames,
+          meta.isContractWallet
         );
         connectWallet(data);
       } else {
@@ -91,7 +86,7 @@ export function WidgetWallets(
 
     // propagate updates for Dapps using external wallets
     if (props.onUpdateState) {
-      props.onUpdateState(type, event, value, state, supportedBlockchains);
+      props.onUpdateState(type, event, value, state, meta);
     }
   };
   return (


### PR DESCRIPTION
- [x] When safe provider is not connected, we shouldn't show it in list of selectable wallet for evm blockchains. (in confirm wallet step during the swap process in widget)
- [x] When safe provider is connected to an evm network, we should only populate account for that specific network not all evm chains.