### PR TITLE
feat(widget): handle wallet referrer in widget

### DIFF
--- a/widget/embedded/src/components/AppRouter.tsx
+++ b/widget/embedded/src/components/AppRouter.tsx
@@ -9,6 +9,8 @@ import { MemoryRouter, useInRouterContext } from 'react-router';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { navigationRoutes } from '../constants/navigationRoutes';
+import { SearchParams } from '../constants/searchParams';
+import { useForceAutoConnect } from '../hooks/useForceAutoConnect';
 import { Home } from '../pages/Home';
 import { useAppStore } from '../store/AppStore';
 
@@ -48,6 +50,14 @@ export function AppRouter({
   const Router = isRouterInContext ? Route : MemoryRouter;
   const blockchains = useAppStore().blockchains();
   const { canSwitchNetworkTo } = useWallets();
+  const { loadingStatus } = useMetaStore();
+  const referrerWalletType =
+    new URLSearchParams(location.search).get(SearchParams.REFERRER) ||
+    undefined;
+  useForceAutoConnect({
+    walletType: referrerWalletType,
+    loadingStatus,
+  });
 
   const evmChains = blockchains.filter(isEvmBlockchain);
 

--- a/widget/embedded/src/components/AppRouter.tsx
+++ b/widget/embedded/src/components/AppRouter.tsx
@@ -9,7 +9,6 @@ import { MemoryRouter, useInRouterContext } from 'react-router';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { navigationRoutes } from '../constants/navigationRoutes';
-import { SearchParams } from '../constants/searchParams';
 import { useForceAutoConnect } from '../hooks/useForceAutoConnect';
 import { Home } from '../pages/Home';
 import { useAppStore } from '../store/AppStore';
@@ -50,14 +49,8 @@ export function AppRouter({
   const Router = isRouterInContext ? Route : MemoryRouter;
   const blockchains = useAppStore().blockchains();
   const { canSwitchNetworkTo } = useWallets();
-  const { loadingStatus } = useMetaStore();
-  const referrerWalletType =
-    new URLSearchParams(location.search).get(SearchParams.REFERRER) ||
-    undefined;
-  useForceAutoConnect({
-    walletType: referrerWalletType,
-    loadingStatus,
-  });
+
+  useForceAutoConnect();
 
   const evmChains = blockchains.filter(isEvmBlockchain);
 

--- a/widget/embedded/src/components/UpdateUrl.tsx
+++ b/widget/embedded/src/components/UpdateUrl.tsx
@@ -57,7 +57,7 @@ export function UpdateUrl() {
         toChainString = '',
         toTokenString = '',
         fromAmount = '';
-      const referrer = searchParamsRef.current[SearchParams.REFERRER];
+      const autoConnect = searchParamsRef.current[SearchParams.AUTO_CONNECT];
       if (fetchMetaStatus !== 'success') {
         fromChainString = searchParamsRef.current[SearchParams.FROM_CHAIN];
         fromTokenString = searchParamsRef.current[SearchParams.FROM_TOKEN];
@@ -92,8 +92,8 @@ export function UpdateUrl() {
           ...(fromAmount && {
             [SearchParams.FROM_AMOUNT]: fromAmount.toString(),
           }),
-          ...(referrer && {
-            [SearchParams.REFERRER]: referrer,
+          ...(autoConnect && {
+            [SearchParams.AUTO_CONNECT]: autoConnect,
           }),
         },
         { replace: true }

--- a/widget/embedded/src/components/UpdateUrl.tsx
+++ b/widget/embedded/src/components/UpdateUrl.tsx
@@ -57,6 +57,7 @@ export function UpdateUrl() {
         toChainString = '',
         toTokenString = '',
         fromAmount = '';
+      const referrer = searchParamsRef.current[SearchParams.REFERRER];
       if (fetchMetaStatus !== 'success') {
         fromChainString = searchParamsRef.current[SearchParams.FROM_CHAIN];
         fromTokenString = searchParamsRef.current[SearchParams.FROM_TOKEN];
@@ -90,6 +91,9 @@ export function UpdateUrl() {
           ...(toTokenString && { [SearchParams.TO_TOKEN]: toTokenString }),
           ...(fromAmount && {
             [SearchParams.FROM_AMOUNT]: fromAmount.toString(),
+          }),
+          ...(referrer && {
+            [SearchParams.REFERRER]: referrer,
           }),
         },
         { replace: true }

--- a/widget/embedded/src/constants/searchParams.ts
+++ b/widget/embedded/src/constants/searchParams.ts
@@ -4,4 +4,5 @@ export enum SearchParams {
   'TO_CHAIN' = 'toBlockchain',
   'TO_TOKEN' = 'toToken',
   'FROM_AMOUNT' = 'fromAmount',
+  'REFERRER' = 'referrer',
 }

--- a/widget/embedded/src/constants/searchParams.ts
+++ b/widget/embedded/src/constants/searchParams.ts
@@ -4,5 +4,5 @@ export enum SearchParams {
   'TO_CHAIN' = 'toBlockchain',
   'TO_TOKEN' = 'toToken',
   'FROM_AMOUNT' = 'fromAmount',
-  'REFERRER' = 'referrer',
+  'AUTO_CONNECT' = 'autoConnect',
 }

--- a/widget/embedded/src/hooks/useForceAutoConnect.ts
+++ b/widget/embedded/src/hooks/useForceAutoConnect.ts
@@ -1,0 +1,37 @@
+import type { MetaState } from '../store/meta';
+import type { WalletType } from '@rango-dev/wallets-shared';
+
+import { useWallets } from '@rango-dev/wallets-react';
+import { useEffect, useRef } from 'react';
+
+type forceAutoConnectParams = {
+  loadingStatus: MetaState['loadingStatus'];
+  walletType?: WalletType;
+};
+
+export function useForceAutoConnect(params: forceAutoConnectParams): void {
+  const { loadingStatus, walletType = '' } = params;
+  const { connect, state } = useWallets();
+  const initiated = useRef(false);
+
+  const walletState = state(walletType);
+
+  useEffect(() => {
+    const shouldTryConnect =
+      loadingStatus === 'success' &&
+      walletType &&
+      walletState &&
+      walletState.installed &&
+      !walletState.connecting &&
+      !walletState.connected;
+
+    if (shouldTryConnect && !initiated.current) {
+      initiated.current = true;
+      connect(walletType)
+        .then()
+        .catch((error: any) => {
+          console.error(error);
+        });
+    }
+  }, [walletState, loadingStatus]);
+}


### PR DESCRIPTION
# Summary

A new feature has been added to the widget so that we can connect to the wallet by adding it as a autoConnect to the URL.


# How did you test this change?

You can test this feature by running the widget and adding a autoConnect to the URL, the wallet should request a connection.
For example: http://localhost:3002/?autoConnect=braavos


# Checklist:

- [x] I have performed a self-review of my code
