### PR TITLE
feat(widget-v2): support experimental features

### DIFF
--- a/widget/embedded/src/QueueManager.tsx
+++ b/widget/embedded/src/QueueManager.tsx
@@ -30,6 +30,7 @@ function QueueManager(props: PropsWithChildren<{ apiKey?: string }>) {
   const swapQueueDef = useMemo(() => {
     return makeQueueDefinition({
       API_KEY: props.apiKey || getConfig('API_KEY'),
+      BASE_URL: getConfig('BASE_URL'),
     });
   }, [props.apiKey]);
 

--- a/widget/embedded/src/constants/index.ts
+++ b/widget/embedded/src/constants/index.ts
@@ -1,1 +1,2 @@
 export const RANGO_PUBLIC_API_KEY = 'c6381a79-2817-4602-83bf-6a641a409e32';
+export const DEFAULT_BASE_URL = 'https://api.rango.exchange';

--- a/widget/embedded/src/containers/App/App.tsx
+++ b/widget/embedded/src/containers/App/App.tsx
@@ -1,7 +1,7 @@
 import type { WalletType } from '@rango-dev/wallets-shared';
 
 import { I18nManager } from '@rango-dev/ui';
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
 import { AppRouter } from '../../components/AppRouter';
 import { AppRoutes } from '../../components/AppRoutes';
@@ -12,7 +12,6 @@ import { useTheme } from '../../hooks/useTheme';
 import { useAppStore } from '../../store/AppStore';
 import { useNotificationStore } from '../../store/notification';
 import { useSettingsStore } from '../../store/settings';
-import { initConfig } from '../../utils/configs';
 import { WidgetContext } from '../Wallets';
 
 import { MainContainer } from './App.styles';
@@ -28,13 +27,6 @@ export function Main() {
   const [disconnectedWallet, setDisconnectedWallet] = useState<WalletType>();
   const widgetContext = useContext(WidgetContext);
 
-  useMemo(() => {
-    if (config?.apiKey) {
-      initConfig({
-        API_KEY: config?.apiKey,
-      });
-    }
-  }, [config]);
   useEffect(() => {
     void fetchMeta().catch();
     void useSettingsStore.persist.rehydrate();

--- a/widget/embedded/src/containers/WidgetProvider/WidgetProvider.tsx
+++ b/widget/embedded/src/containers/WidgetProvider/WidgetProvider.tsx
@@ -1,14 +1,23 @@
 import type { PropTypes } from './WidgetProvider.types';
 import type { PropsWithChildren } from 'react';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
+import { DEFAULT_BASE_URL, RANGO_PUBLIC_API_KEY } from '../../constants';
 import QueueManager from '../../QueueManager';
+import { initConfig } from '../../utils/configs';
 import { WidgetWallets } from '../Wallets';
 import { WidgetInfo } from '../WidgetInfo';
 
 export function WidgetProvider(props: PropsWithChildren<PropTypes>) {
   const { onUpdateState, config } = props;
+
+  useMemo(() => {
+    initConfig({
+      API_KEY: config?.apiKey || RANGO_PUBLIC_API_KEY,
+      BASE_URL: config?.apiUrl || DEFAULT_BASE_URL,
+    });
+  }, [config]);
   return (
     <WidgetWallets config={config} onUpdateState={onUpdateState}>
       <QueueManager apiKey={config.apiKey}>

--- a/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.ts
+++ b/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.ts
@@ -42,7 +42,7 @@ export function useConfirmSwap(): ConfirmSwap {
   const { connectedWallets } = useWalletsStore();
   const blockchains = useAppStore().blockchains();
   const tokens = useAppStore().tokens();
-
+  const { experimental } = useAppStore().config;
   const userSlippage = customSlippage || slippage;
 
   const { fetch: fetchQuote, cancelFetch, loading } = useFetchQuote();
@@ -77,7 +77,9 @@ export function useConfirmSwap(): ConfirmSwap {
       initialQuote: initialQuote,
       destination: customDestination,
     });
-
+    if (experimental?.routing) {
+      requestBody.experimental = true;
+    }
     let currentQuote: BestRouteResponse;
     try {
       currentQuote = await fetchQuote(requestBody).then((response) =>

--- a/widget/embedded/src/hooks/useSwapInput.ts
+++ b/widget/embedded/src/hooks/useSwapInput.ts
@@ -33,7 +33,8 @@ type UseSwapInput = {
  */
 export function useSwapInput(): UseSwapInput {
   const { fetch: fetchQuote, cancelFetch } = useFetchQuote();
-  const { liquiditySources, enableNewLiquiditySources } = useAppStore().config;
+  const { liquiditySources, enableNewLiquiditySources, experimental } =
+    useAppStore().config;
   const tokens = useAppStore().tokens();
   const {
     fromToken,
@@ -86,6 +87,9 @@ export function useSwapInput(): UseSwapInput {
         affiliatePercent,
         affiliateWallets,
       });
+      if (experimental?.routing) {
+        requestBody.experimental = true;
+      }
       fetchQuote(requestBody)
         .then((res) => {
           setLoading(false);

--- a/widget/embedded/src/services/httpService.ts
+++ b/widget/embedded/src/services/httpService.ts
@@ -8,6 +8,6 @@ export const httpService = () => {
   if (rango) {
     return rango;
   }
-  rango = new RangoClient(getConfig('API_KEY'));
+  rango = new RangoClient(getConfig('API_KEY'), getConfig('BASE_URL'));
   return rango;
 };

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -86,11 +86,22 @@ export type BlockchainAndTokenConfig = {
 };
 
 /**
+ * `ExperimentalFeatures`
+ *
+ * @property {boolean} routing
+ *- This property is optional and sets experimental in quote api.
+ */
+type ExperimentalFeatures = {
+  routing?: boolean;
+};
+
+/**
  * The type WidgetConfig defines the configuration options for a widget, including API key, affiliate
  * reference, amount, blockchain and token configurations, liquidity sources, wallet types, language,
  * and theme.
  *
  * @property {string} apiKey - The API key used to communicate with Rango API
+ * @property {string} apiUrl - The API url used to set custom API url
  * @property {WidgetAffiliate} affiliate - If you want to charge users fee per transaction, you should
  * pass `WidgetAffiliate` including affiliateRef, affiliatePercent, and affiliateWallets.
  * @property {number} amount - The default input amount.
@@ -123,9 +134,12 @@ export type BlockchainAndTokenConfig = {
  * you could use to pin tokens of your choice to the top of the token list.
  * @property {boolean} enableNewLiquiditySources - The `enableNewLiquiditySources` property is a boolean value that when you
  * set it to true, whenever a new liquidity source is added, it will be added to your list as well.
+ * @property {ExperimentalFeatures} experimental - The `experimental` property is an optional object that specifies some experimental features.
  */
+
 export type WidgetConfig = {
   apiKey: string;
+  apiUrl?: string;
   walletConnectProjectId?: string;
   affiliate?: WidgetAffiliate;
   amount?: number;
@@ -140,4 +154,5 @@ export type WidgetConfig = {
   externalWallets?: boolean;
   pinnedTokens?: Asset[];
   enableNewLiquiditySources?: boolean;
+  experimental?: ExperimentalFeatures;
 };

--- a/widget/embedded/src/utils/configs.ts
+++ b/widget/embedded/src/utils/configs.ts
@@ -2,6 +2,7 @@ import { RANGO_PUBLIC_API_KEY } from '../constants';
 
 export interface Configs {
   API_KEY: string;
+  BASE_URL?: string;
 }
 
 let configs: Configs = {
@@ -9,7 +10,7 @@ let configs: Configs = {
 };
 
 export function getConfig(name: keyof Configs) {
-  return configs[name];
+  return configs[name] || '';
 }
 
 export function setConfig(name: keyof Configs, value: any) {


### PR DESCRIPTION
# Summary
In this task, we were supposed to support experimental features. These Items are set in the dapp & storage and in the widget, we read apiUrl or experimental best route from config. 

# How did you test this change?
For testing, we can manually set config values for experimentalFeatures & apiUrl to change the request body of best route & apiUrl in our fetches.


# Checklist:

- [x] I have performed a self-review of my code
