### PR TITLE
fix(widget-v2): zustand store in context

### DIFF
--- a/widget/embedded/src/QueueManager.tsx
+++ b/widget/embedded/src/QueueManager.tsx
@@ -33,7 +33,7 @@ function QueueManager(props: PropsWithChildren) {
     });
   }, []);
 
-  const blockchains = useAppStore().use.blockchains()();
+  const blockchains = useAppStore().blockchains();
   const connectedWallets = useWalletsStore.use.connectedWallets();
 
   const wallets = {

--- a/widget/embedded/src/Wallets.tsx
+++ b/widget/embedded/src/Wallets.tsx
@@ -35,9 +35,9 @@ function Main(
     config: WidgetConfig;
   }>
 ) {
-  const updateConfig = useAppStore().use.updateConfig();
-  const blockchains = useAppStore().use.blockchains()();
-  const tokens = useAppStore().use.tokens()();
+  const updateConfig = useAppStore().updateConfig;
+  const blockchains = useAppStore().blockchains();
+  const tokens = useAppStore().tokens();
   const { providers } = useWalletProviders(props.providers, props?.options);
   const disconnectWallet = useWalletsStore.use.disconnectWallet();
   const connectWallet = useWalletsStore.use.connectWallet();

--- a/widget/embedded/src/Widget.tsx
+++ b/widget/embedded/src/Widget.tsx
@@ -43,7 +43,7 @@ export type WidgetProps = {
 export function Main() {
   globalFont();
 
-  const { fetch: fetchMeta, config } = useAppStore()();
+  const { fetch: fetchMeta, config } = useAppStore();
   const { activeTheme } = useTheme(config?.theme || {});
   const { activeLanguage, changeLanguage } = useLanguage();
   const [lastConnectedWalletWithNetwork, setLastConnectedWalletWithNetwork] =
@@ -69,6 +69,7 @@ export function Main() {
       changeLanguage(config.language);
     }
   }, [config?.language]);
+
   return (
     <I18nManager language={activeLanguage}>
       <MainContainer id="swap-container" className={activeTheme()}>

--- a/widget/embedded/src/components/AppRouter.tsx
+++ b/widget/embedded/src/components/AppRouter.tsx
@@ -46,7 +46,7 @@ export function AppRouter({
 }) {
   const isRouterInContext = useInRouterContext();
   const Router = isRouterInContext ? Route : MemoryRouter;
-  const blockchains = useAppStore().use.blockchains()();
+  const blockchains = useAppStore().blockchains();
   const { canSwitchNetworkTo } = useWallets();
 
   const evmChains = blockchains.filter(isEvmBlockchain);

--- a/widget/embedded/src/components/BlockchainList/BlockchainList.tsx
+++ b/widget/embedded/src/components/BlockchainList/BlockchainList.tsx
@@ -20,7 +20,7 @@ import { LoadingBlockchainList } from './LoadingBlockchainList';
 export function BlockchainList(props: PropTypes) {
   const { list, searchedFor, onChange, blockchainCategory } = props;
   const [blockchains, setBlockchains] = useState<BlockchainMeta[]>(list);
-  const { fetchStatus } = useAppStore()();
+  const { fetchStatus } = useAppStore();
 
   useEffect(() => {
     setBlockchains([

--- a/widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx
+++ b/widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx
@@ -27,7 +27,7 @@ export function BlockchainsSection(props: PropTypes) {
     selected: blockchain?.name,
   });
 
-  const { fetchStatus } = useAppStore()();
+  const { fetchStatus } = useAppStore();
   const resetToBlockchain = useQuoteStore.use.resetToBlockchain();
   const resetFromBlockchain = useQuoteStore.use.resetFromBlockchain();
   const hasMoreItemsInList = blockchainsList.more.length > 0;

--- a/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
@@ -51,8 +51,8 @@ const NUMBER_OF_WALLETS_TO_DISPLAY = 2;
 export function ConfirmWalletsModal(props: PropTypes) {
   //TODO: move component's logics to a custom hook
   const { open, onClose, onCancel, onCheckBalance, loading } = props;
-  const config = useAppStore().use.config();
-  const blockchains = useAppStore().use.blockchains()();
+  const config = useAppStore().config;
+  const blockchains = useAppStore().blockchains();
   const {
     quote,
     setSelectedWallets: selectQuoteWallets,

--- a/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
@@ -42,10 +42,10 @@ import {
 
 export function WalletList(props: PropTypes) {
   const { chain, isSelected, selectWallet, limit, onShowMore } = props;
-  const { config } = useAppStore()();
+  const { config } = useAppStore();
 
   const connectedWallets = useWalletsStore.use.connectedWallets();
-  const { blockchains } = useAppStore()();
+  const { blockchains } = useAppStore();
   const [openWalletStateModal, setOpenWalletStateModal] =
     useState<WalletType>('');
   const [experimentalChainWallet, setExperimentalChainWallet] =

--- a/widget/embedded/src/components/NoResult/NoResult.tsx
+++ b/widget/embedded/src/components/NoResult/NoResult.tsx
@@ -24,7 +24,7 @@ export function NoResult(props: PropTypes) {
   const toggleAllLiquiditySources =
     useSettingsStore.use.toggleAllLiquiditySources();
 
-  const swappers = useAppStore().use.swappers()();
+  const swappers = useAppStore().swappers();
 
   const info = makeInfo(
     error,

--- a/widget/embedded/src/components/NotificationContent/NotificationContent.tsx
+++ b/widget/embedded/src/components/NotificationContent/NotificationContent.tsx
@@ -26,8 +26,8 @@ export function NotificationContent() {
   const { getUnreadNotifications } = useNotificationStore();
 
   const notifications: Notification[] = getUnreadNotifications();
-  const blockchains = useAppStore().use.blockchains()();
-  const tokens = useAppStore().use.tokens()();
+  const blockchains = useAppStore().blockchains();
+  const tokens = useAppStore().tokens();
   const sortedNotification = notifications
     .sort((a, b) => b.creationTime - a.creationTime)
     .slice(0, MAX_NOTIFICATIONS_DISPLAYED);

--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -62,7 +62,7 @@ export function Quote(props: QuoteProps) {
     type,
     recommended = true,
   } = props;
-  const tokens = useAppStore().use.tokens()();
+  const tokens = useAppStore().tokens();
 
   const [expanded, setExpanded] = useState(props.expanded);
   const quoteRef = useRef<HTMLButtonElement | null>(null);

--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -64,8 +64,8 @@ import { Container, HeaderDetails, StepsList } from './SwapDetails.styles';
 export function SwapDetails(props: SwapDetailsProps) {
   const { swap, requestId, onDelete, onCancel: onCancelProps } = props;
   const { canSwitchNetworkTo, connect, getWalletInfo } = useWallets();
-  const blockchains = useAppStore().use.blockchains()();
-  const tokens = useAppStore().use.tokens()();
+  const blockchains = useAppStore().blockchains();
+  const tokens = useAppStore().tokens();
   const retry = useQuoteStore.use.retry();
   const navigate = useNavigate();
   const { navigateBackFrom } = useNavigateBack();

--- a/widget/embedded/src/components/TokenList/TokenList.tsx
+++ b/widget/embedded/src/components/TokenList/TokenList.tsx
@@ -86,11 +86,11 @@ export function TokenList(props: PropTypes) {
   const { list, searchedFor = '', onChange, selectedBlockchain } = props;
 
   const [tokens, setTokens] = useState<TokenWithBalance[]>(list);
-  const fetchStatus = useAppStore().use.fetchStatus();
-  const blockchains = useAppStore().use.blockchains()();
+  const fetchStatus = useAppStore().fetchStatus;
+  const blockchains = useAppStore().blockchains();
   const [hasNextPage, setHasNextPage] = useState<boolean>(true);
   const loadingWallet = useWalletsStore.use.loading();
-  const { isTokenPinned } = useAppStore()();
+  const { isTokenPinned } = useAppStore();
 
   // eslint-disable-next-line react/display-name
   const innerElementType: React.FC<CommonProps> = forwardRef((render, ref) => {

--- a/widget/embedded/src/components/UpdateUrl.tsx
+++ b/widget/embedded/src/components/UpdateUrl.tsx
@@ -29,9 +29,9 @@ export function UpdateUrl() {
   const setToToken = useQuoteStore.use.setToToken();
   const inputAmount = useQuoteStore.use.inputAmount();
   const setInputAmount = useQuoteStore.use.setInputAmount();
-  const fetchMetaStatus = useAppStore().use.fetchStatus();
-  const blockchains = useAppStore().use.blockchains()();
-  const tokens = useAppStore().use.tokens()();
+  const fetchMetaStatus = useAppStore().fetchStatus;
+  const blockchains = useAppStore().blockchains();
+  const tokens = useAppStore().tokens();
   const setSelectedSwap = useUiStore.use.setSelectedSwap();
   useSyncStoresWithConfig();
 

--- a/widget/embedded/src/components/WidgetEvents.tsx
+++ b/widget/embedded/src/components/WidgetEvents.tsx
@@ -14,7 +14,7 @@ import { useWalletsStore } from '../store/wallets';
 import { validBlockedStatuses } from '../types/notification';
 
 export function WidgetEvents() {
-  const tokens = useAppStore().use.tokens()();
+  const tokens = useAppStore().tokens();
   const connectedWallets = useWalletsStore.use.connectedWallets();
   const getWalletsDetails = useWalletsStore.use.getWalletsDetails();
   const setNotification = useNotificationStore.use.setNotification();

--- a/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.ts
+++ b/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.ts
@@ -40,8 +40,8 @@ export function useConfirmSwap(): ConfirmSwap {
     disabledLiquiditySources,
   } = useSettingsStore();
   const { connectedWallets } = useWalletsStore();
-  const blockchains = useAppStore().use.blockchains()();
-  const tokens = useAppStore().use.tokens()();
+  const blockchains = useAppStore().blockchains();
+  const tokens = useAppStore().tokens();
 
   const userSlippage = customSlippage || slippage;
 

--- a/widget/embedded/src/hooks/useSwapInput.ts
+++ b/widget/embedded/src/hooks/useSwapInput.ts
@@ -33,9 +33,8 @@ type UseSwapInput = {
  */
 export function useSwapInput(): UseSwapInput {
   const { fetch: fetchQuote, cancelFetch } = useFetchQuote();
-  const { liquiditySources, enableNewLiquiditySources } =
-    useAppStore().use.config();
-  const tokens = useAppStore().use.tokens()();
+  const { liquiditySources, enableNewLiquiditySources } = useAppStore().config;
+  const tokens = useAppStore().tokens();
   const {
     fromToken,
     toToken,

--- a/widget/embedded/src/hooks/useSyncStoresWithConfig.ts
+++ b/widget/embedded/src/hooks/useSyncStoresWithConfig.ts
@@ -20,10 +20,10 @@ export function useSyncStoresWithConfig() {
     toBlockchain,
   } = useQuoteStore();
 
-  const config = useAppStore().use.config();
-  const fetchMetaStatus = useAppStore().use.fetchStatus();
-  const blockchains = useAppStore().use.blockchains()();
-  const tokens = useAppStore().use.tokens()();
+  const config = useAppStore().config;
+  const fetchMetaStatus = useAppStore().fetchStatus;
+  const blockchains = useAppStore().blockchains();
+  const tokens = useAppStore().tokens();
 
   const { setAffiliateRef, setAffiliatePercent, setAffiliateWallets } =
     useSettingsStore();

--- a/widget/embedded/src/hooks/useWalletList.ts
+++ b/widget/embedded/src/hooks/useWalletList.ts
@@ -37,7 +37,7 @@ export function useWalletList(params: Params) {
   const { config, chain, onBeforeConnect, onConnect } = params;
   const { state, disconnect, getWalletInfo, connect } = useWallets();
   const { connectedWallets } = useWalletsStore();
-  const blockchains = useAppStore().use.blockchains()();
+  const blockchains = useAppStore().blockchains();
 
   /** It can be what has been set by widget config or as a fallback we use all the supported wallets by our library */
   const listAvailableWalletTypes =

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -76,7 +76,7 @@ export function Home() {
     setQuoteWarningsConfirmed,
   } = useQuoteStore();
 
-  const fetchMetaStatus = useAppStore().use.fetchStatus();
+  const fetchMetaStatus = useAppStore().fetchStatus;
 
   const connectedWallets = useWalletsStore.use.connectedWallets();
   const setCurrentPage = useUiStore.use.setCurrentPage();

--- a/widget/embedded/src/pages/LiquiditySourcePage.tsx
+++ b/widget/embedded/src/pages/LiquiditySourcePage.tsx
@@ -35,8 +35,8 @@ interface PropTypes {
 }
 
 export function LiquiditySourcePage({ sourceType }: PropTypes) {
-  const fetchStatus = useAppStore().use.fetchStatus();
-  const swappers = useAppStore().use.swappers()();
+  const fetchStatus = useAppStore().fetchStatus;
+  const swappers = useAppStore().swappers();
   const [searchedFor, setSearchedFor] = useState<string>('');
   const toggleLiquiditySource = useSettingsStore.use.toggleLiquiditySource();
   const { navigateBackFrom } = useNavigateBack();

--- a/widget/embedded/src/pages/SelectBlockchainPage.tsx
+++ b/widget/embedded/src/pages/SelectBlockchainPage.tsx
@@ -21,9 +21,9 @@ export function SelectBlockchainPage(props: PropTypes) {
   const [blockchainCategory, setBlockchainCategory] = useState<string>('ALL');
   const setToBlockchain = useQuoteStore.use.setToBlockchain();
   const setFromBlockchain = useQuoteStore.use.setFromBlockchain();
-  const fetchStatus = useAppStore().use.fetchStatus();
+  const fetchStatus = useAppStore().fetchStatus;
 
-  const blockchains = useAppStore().use.blockchains()({
+  const blockchains = useAppStore().blockchains({
     type: type,
   });
   const routeKey = type === 'source' ? 'fromBlockchain' : 'toBlockchain';

--- a/widget/embedded/src/pages/SelectSwapItemsPage.tsx
+++ b/widget/embedded/src/pages/SelectSwapItemsPage.tsx
@@ -39,10 +39,10 @@ export function SelectSwapItemsPage(props: PropTypes) {
   const selectedBlockchainName = selectedBlockchain?.name ?? '';
 
   // Tokens & Blockchains list
-  const blockchains = useAppStore().use.blockchains()({
+  const blockchains = useAppStore().blockchains({
     type: type,
   });
-  const tokens = useAppStore().use.tokens()({
+  const tokens = useAppStore().tokens({
     type,
     blockchain: selectedBlockchainName,
     searchFor: searchedFor,

--- a/widget/embedded/src/pages/SettingsPage.tsx
+++ b/widget/embedded/src/pages/SettingsPage.tsx
@@ -26,9 +26,9 @@ import { getUniqueSwappersGroups } from '../utils/settings';
 
 export function SettingsPage() {
   const navigate = useNavigate();
-  const { theme } = useAppStore().use.config();
-  const fetchStatus = useAppStore().use.fetchStatus();
-  const swappers = useAppStore().use.swappers()();
+  const { theme } = useAppStore().config;
+  const fetchStatus = useAppStore().fetchStatus;
+  const swappers = useAppStore().swappers();
   const { navigateBackFrom } = useNavigateBack();
 
   const infiniteApprove = useSettingsStore.use.infiniteApprove();

--- a/widget/embedded/src/pages/SwapDetailsPage.tsx
+++ b/widget/embedded/src/pages/SwapDetailsPage.tsx
@@ -16,7 +16,7 @@ export function SwapDetailsPage() {
   const pendingSwaps = getPendingSwaps(manager);
   const requestId = useUiStore.use.selectedSwapRequestId();
   const { navigateBackFrom } = useNavigateBack();
-  const { fetchStatus: fetchMetaStatus } = useAppStore()();
+  const { fetchStatus: fetchMetaStatus } = useAppStore();
 
   const showSkeleton = loading || fetchMetaStatus === 'loading';
 

--- a/widget/embedded/src/pages/WalletsPage.tsx
+++ b/widget/embedded/src/pages/WalletsPage.tsx
@@ -29,7 +29,7 @@ export const TIME_TO_CLOSE_MODAL = 3_000;
 export const TIME_TO_IGNORE_MODAL = 300;
 
 export function WalletsPage() {
-  const { config, fetchStatus: fetchMetaStatus } = useAppStore()();
+  const { config, fetchStatus: fetchMetaStatus } = useAppStore();
   const { navigateBackFrom } = useNavigateBack();
   const [openModal, setOpenModal] = useState(false);
   const [selectedWalletType, setSelectedWalletType] = useState<WalletType>('');

--- a/widget/embedded/src/store/AppStore.tsx
+++ b/widget/embedded/src/store/AppStore.tsx
@@ -17,7 +17,7 @@ export function useAppStore() {
     throw new Error('Missing AppStoreContext.Provider in the tree');
   }
 
-  return store;
+  return store();
 }
 
 export function AppStoreProvider(props: AppStoreProviderProps) {

--- a/widget/embedded/src/store/app.ts
+++ b/widget/embedded/src/store/app.ts
@@ -5,7 +5,6 @@ import type { StateCreator } from 'zustand';
 
 import { create } from 'zustand';
 
-import createSelectors from './selectors';
 import { createConfigSlice } from './slices/config';
 import { createDataSlice } from './slices/data';
 
@@ -21,10 +20,8 @@ export type StateCreatorWithInitialData<
 export type AppStoreState = DataSlice & ConfigSlice;
 
 export function createAppStore(initialData?: WidgetConfig) {
-  return createSelectors(
-    create<AppStoreState>()((...a) => ({
-      ...createDataSlice(...a),
-      ...createConfigSlice(initialData, ...a),
-    }))
-  );
+  return create<AppStoreState>()((...a) => ({
+    ...createDataSlice(...a),
+    ...createConfigSlice(initialData, ...a),
+  }));
 }


### PR DESCRIPTION
# Summary

After merging [init config](https://github.com/rango-exchange/rango-client/pull/442), We've encountered some unexpexted behaviors like not updating the wallet state after connecting. The problem was after fetching the meta, the data inside context hasn't been updating.

The problem is we should call the store and return the App state in useAppStore hooks, if not, the component will not be re-rendered correctly and state has stale data inside it.


# How did you test this change?

In Playground I tried to connect the wallet from `Connect Wallet` page then try to connect a wallet and go back to home.

# Checklist:

- [x] I have performed a self-review of my code

