### PR TITLE
feat: implement pin tokens in From and To

### DIFF
--- a/widget/embedded/src/components/TokenList/TokenList.tsx
+++ b/widget/embedded/src/components/TokenList/TokenList.tsx
@@ -176,7 +176,7 @@ export function TokenList(props: PropTypes) {
                 start={
                   <ImageSection>
                     <Image src={token.image} size={30} />
-                    {isTokenPinned(token) && (
+                    {isTokenPinned(token, props.type) && (
                       <Pin>
                         <PinIcon size={12} color="gray" />
                       </Pin>

--- a/widget/embedded/src/components/TokenList/TokenList.types.ts
+++ b/widget/embedded/src/components/TokenList/TokenList.types.ts
@@ -5,6 +5,7 @@ export interface PropTypes {
   searchedFor?: string;
   onChange: (token: Token) => void;
   selectedBlockchain?: string;
+  type: 'source' | 'destination';
 }
 
 export interface LoadingTokenListProps {

--- a/widget/embedded/src/pages/SelectSwapItemsPage.tsx
+++ b/widget/embedded/src/pages/SelectSwapItemsPage.tsx
@@ -14,7 +14,7 @@ import { useNavigateBack } from '../hooks/useNavigateBack';
 import { useAppStore } from '../store/AppStore';
 import { useQuoteStore } from '../store/quote';
 import { useWalletsStore } from '../store/wallets';
-import { sortTokensByBalance } from '../utils/wallets';
+import { sortTokens } from '../utils/wallets';
 
 interface PropTypes {
   type: 'source' | 'destination';
@@ -34,22 +34,25 @@ export function SelectSwapItemsPage(props: PropTypes) {
   } = useQuoteStore();
   const getBalanceFor = useWalletsStore.use.getBalanceFor();
   const [searchedFor, setSearchedFor] = useState<string>('');
+  const { isTokenPinned } = useAppStore();
 
   const selectedBlockchain = type === 'source' ? fromBlockchain : toBlockchain;
   const selectedBlockchainName = selectedBlockchain?.name ?? '';
 
   // Tokens & Blockchains list
   const blockchains = useAppStore().blockchains({
-    type: type,
+    type,
   });
   const tokens = useAppStore().tokens({
     type,
     blockchain: selectedBlockchainName,
     searchFor: searchedFor,
   });
-  const tokensList = sortTokensByBalance(tokens, getBalanceFor);
 
-  // Actions
+  const checkIsTokenPinned = (token: Token) => isTokenPinned(token, type);
+
+  const tokensList = sortTokens(tokens, getBalanceFor, checkIsTokenPinned);
+
   const updateBlockchain = (blockchain: BlockchainMeta) => {
     if (type === 'source') {
       setFromBlockchain(blockchain);
@@ -96,6 +99,7 @@ export function SelectSwapItemsPage(props: PropTypes) {
         list={tokensList}
         selectedBlockchain={selectedBlockchainName}
         searchedFor={searchedFor}
+        type={type}
         onChange={(token) => {
           updateToken(token);
 

--- a/widget/embedded/src/store/slices/data.ts
+++ b/widget/embedded/src/store/slices/data.ts
@@ -14,7 +14,7 @@ type BlockchainOptions = {
 };
 
 type TokenOptions = {
-  type?: 'source' | 'destination';
+  type: 'source' | 'destination';
   // filter by an specific blockchain
   blockchain?: string;
   searchFor?: string;
@@ -29,7 +29,7 @@ export interface DataSlice {
   blockchains: (options?: BlockchainOptions) => BlockchainMeta[];
   tokens: (options?: TokenOptions) => Token[];
   swappers: () => SwapperMeta[];
-  isTokenPinned: (token: Token) => boolean;
+  isTokenPinned: (token: Token, type: 'source' | 'destination') => boolean;
 
   fetch: () => Promise<void>;
 }
@@ -131,10 +131,10 @@ export const createDataSlice: StateCreator<
       })
       .sort((a, b) => {
         // Check pinned tokens
-        if (get().isTokenPinned(a)) {
+        if (get().isTokenPinned(a, options.type)) {
           return -1;
         }
-        if (get().isTokenPinned(b)) {
+        if (get().isTokenPinned(b, options.type)) {
           return 1;
         }
 
@@ -159,8 +159,12 @@ export const createDataSlice: StateCreator<
 
     return list;
   },
-  isTokenPinned: (token) => {
-    const pinned = !!get().config.pinnedTokens?.some((pinnedToken) =>
+  isTokenPinned: (token, type) => {
+    const pinnedTokens =
+      type === 'source'
+        ? get().config.from?.pinnedTokens
+        : get().config.to?.pinnedTokens;
+    const pinned = !!pinnedTokens?.some((pinnedToken) =>
       tokensAreEqual(pinnedToken, token)
     );
     return pinned;

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -77,12 +77,15 @@ export type WidgetAffiliate = {
  * blockchains. e.g. ['BSC','ETHEREUM']
  * @property {Asset[]} tokens - The `tokens` property is an optional array of `Asset` objects that
  * you could use that to limit tokens to some limited ones.
+ * @property {Asset} pinnedTokens - The `pinnedTokens` property is an optional array of `Asset` objects that
+ * you could use to pin tokens of your choice to the top of the token list.
  */
 export type BlockchainAndTokenConfig = {
   blockchain?: string;
   token?: Asset;
   blockchains?: string[];
   tokens?: Asset[];
+  pinnedTokens?: Asset[];
 };
 
 /**
@@ -130,8 +133,6 @@ type ExperimentalFeatures = {
  * that defines the various properties of the theme, such as colors, fonts, and others.
  * @property {boolean} externalWallets
  * If `externalWallets` is `true`, you should add `WidgetWallets` to your app.
- * @property {Asset} pinnedTokens - The `pinnedTokens` property is an optional array of `Asset` objects that
- * you could use to pin tokens of your choice to the top of the token list.
  * @property {boolean} enableNewLiquiditySources - The `enableNewLiquiditySources` property is a boolean value that when you
  * set it to true, whenever a new liquidity source is added, it will be added to your list as well.
  * @property {ExperimentalFeatures} experimental - The `experimental` property is an optional object that specifies some experimental features.
@@ -152,7 +153,6 @@ export type WidgetConfig = {
   language?: Language;
   theme?: WidgetTheme;
   externalWallets?: boolean;
-  pinnedTokens?: Asset[];
   enableNewLiquiditySources?: boolean;
   experimental?: ExperimentalFeatures;
 };

--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -380,35 +380,64 @@ export function formatBalance(balance: Balance | null): Balance | null {
   return formattedBalance;
 }
 
-export function sortTokensByBalance(
+function sortTokensByBalance(
+  token1Balance: Balance | null,
+  token2Balance: Balance | null
+): number {
+  if (token1Balance?.usdValue && token2Balance?.usdValue) {
+    return (
+      parseFloat(token2Balance.usdValue) - parseFloat(token1Balance.usdValue)
+    );
+  }
+
+  if (!token1Balance?.usdValue && token2Balance?.usdValue) {
+    return 1;
+  }
+
+  if (token1Balance?.usdValue && !token2Balance?.usdValue) {
+    return -1;
+  }
+
+  if (!token1Balance?.usdValue && !token2Balance?.usdValue) {
+    return (
+      parseFloat(token2Balance?.amount || '0') -
+      parseFloat(token1Balance?.amount || '0')
+    );
+  }
+
+  return 0;
+}
+
+function sortTokensByPinnedToken(
+  token1: Token,
+  token2: Token,
+  isTokenPinned: (token: Token) => boolean
+): number {
+  const isToken1Pinned = isTokenPinned(token1);
+  const isToken2Pinned = isTokenPinned(token2);
+
+  if (isToken1Pinned === isToken2Pinned) {
+    return 0;
+  }
+  if (isToken1Pinned) {
+    return -1;
+  }
+  return 1;
+}
+export function sortTokens(
   tokens: Token[],
-  getBalanceFor: (token: Token) => Balance | null
+  getBalanceFor: (token: Token) => Balance | null,
+  isTokenPinned: (token: Token) => boolean
 ) {
   tokens.sort((token1, token2) => {
     const token1Balance = getBalanceFor(token1);
     const token2Balance = getBalanceFor(token2);
-    if (token1Balance?.usdValue && token2Balance?.usdValue) {
-      return (
-        parseFloat(token2Balance.usdValue) - parseFloat(token1Balance.usdValue)
-      );
-    }
+    // Check pinned tokens
+    const isTokenPin = sortTokensByPinnedToken(token1, token2, isTokenPinned);
 
-    if (!token1Balance?.usdValue && token2Balance?.usdValue) {
-      return 1;
-    }
-
-    if (token1Balance?.usdValue && !token2Balance?.usdValue) {
-      return -1;
-    }
-
-    if (!token1Balance?.usdValue && !token2Balance?.usdValue) {
-      return (
-        parseFloat(token2Balance?.amount || '0') -
-        parseFloat(token1Balance?.amount || '0')
-      );
-    }
-
-    return 0;
+    return isTokenPin !== 0
+      ? isTokenPin
+      : sortTokensByBalance(token1Balance, token2Balance);
   });
 
   return tokens;

--- a/widget/playground/src/components/MultiSelect/MultiSelect.tsx
+++ b/widget/playground/src/components/MultiSelect/MultiSelect.tsx
@@ -87,8 +87,8 @@ export function MultiSelect(props: MuliSelectPropTypes) {
           ) : (
             <TokensPanel
               list={list}
-              onChange={(items) => {
-                props.onChange(items);
+              onChange={(selectedTokens, pinnedTokens) => {
+                props.onChange(selectedTokens, pinnedTokens);
                 onBack();
               }}
               selectedBlockchains={props.selectedBlockchains}

--- a/widget/playground/src/components/MultiSelect/MultiSelect.types.ts
+++ b/widget/playground/src/components/MultiSelect/MultiSelect.types.ts
@@ -1,4 +1,4 @@
-import type { Asset, Token } from 'rango-sdk';
+import type { TokenType } from '../TokensPanel/TokensPanel.types';
 
 export interface CommonListProps {
   type: 'Blockchains' | 'Bridges' | 'DEXs' | 'Wallets';
@@ -9,9 +9,9 @@ export interface CommonListProps {
 
 export interface TokensListProps {
   type: 'Tokens';
-  list: (Token & { checked: boolean })[];
+  list: TokenType[];
   selectedBlockchains: string[];
-  onChange: (items?: Asset[]) => void;
+  onChange: (selectedTokens?: TokenType[], pinnedTokens?: TokenType[]) => void;
 }
 export type MuliSelectPropTypes = (TokensListProps | CommonListProps) & {
   value?: string[];

--- a/widget/playground/src/components/TokensPanel/TokensPanel.List.tsx
+++ b/widget/playground/src/components/TokensPanel/TokensPanel.List.tsx
@@ -8,6 +8,7 @@ import {
   Image,
   ListItemButton,
   NotFound,
+  PinIcon,
   SearchIcon,
   Switch,
   TextField,
@@ -66,7 +67,7 @@ export function TokensList(props: TokensListProps) {
   };
 
   const toggleTokenSelection = (token: TokenType) => {
-    onChange(token);
+    onChange(token, 'checked');
   };
 
   // Toggle displaying selected tokens
@@ -75,6 +76,11 @@ export function TokensList(props: TokensListProps) {
   };
 
   const resultsNotFound = !virtualList.length && !!searchValue;
+
+  //Change the list of pinned tokens
+  const togglePinToken = (token: TokenType) => {
+    onChange(token, 'pinned');
+  };
 
   return (
     <>
@@ -157,7 +163,31 @@ export function TokensList(props: TokensListProps) {
                       }
                       hasDivider
                       onClick={() => toggleTokenSelection(virtualList[index])}
-                      end={<Checkbox checked={virtualList[index].checked} />}
+                      end={
+                        <>
+                          {virtualList[index].checked && (
+                            <>
+                              <IconButton
+                                variant="ghost"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  togglePinToken(virtualList[index]);
+                                }}>
+                                <PinIcon
+                                  color={
+                                    virtualList[index].pinned
+                                      ? 'secondary'
+                                      : 'gray'
+                                  }
+                                  size={16}
+                                />
+                              </IconButton>
+                              <Divider direction="horizontal" size={12} />
+                            </>
+                          )}
+                          <Checkbox checked={virtualList[index].checked} />
+                        </>
+                      }
                       title={
                         <Typography variant="title" size="small">
                           {virtualList[index].symbol}

--- a/widget/playground/src/components/TokensPanel/TokensPanel.tsx
+++ b/widget/playground/src/components/TokensPanel/TokensPanel.tsx
@@ -27,18 +27,19 @@ export function TokensPanel(props: PropTypes) {
     selectedBlockchains: selectedBlockchainsProps,
     onChange,
   } = props;
-
   const [selectedBlockchain, setSelectedBlockchain] = useState(
     selectedBlockchainsProps[0]
   );
   const [list, setList] = useState(listProps);
   const [showSelectedTokens, setShowSelectedTokens] = useState(false);
 
-  const handleChange = (token: TokenType) => {
+  const handleChange = (token: TokenType, type: 'checked' | 'pinned') => {
     setList((prev) =>
       prev.map((item) => {
         if (tokensAreEqual(token, item)) {
-          return { ...item, checked: !item.checked };
+          const pinnedValue =
+            type === 'checked' && item.checked ? { pinned: false } : {};
+          return { ...item, ...pinnedValue, [type]: !item[type] };
         }
         return item;
       })
@@ -69,7 +70,9 @@ export function TokensPanel(props: PropTypes) {
   const handleConfirmAllList = () => {
     const allChecked = list.filter((item) => item.checked);
     const allSelected = listProps.length === allChecked.length;
-    onChange(allSelected ? undefined : allChecked);
+    const allPinned = list.filter((item) => item.pinned);
+
+    onChange(allSelected ? undefined : allChecked, allPinned);
   };
 
   return (

--- a/widget/playground/src/components/TokensPanel/TokensPanel.types.ts
+++ b/widget/playground/src/components/TokensPanel/TokensPanel.types.ts
@@ -1,14 +1,14 @@
-import type { Asset, Token } from 'rango-sdk';
+import type { Token } from 'rango-sdk';
 
-export type TokenType = Token & { checked: boolean };
+export type TokenType = Token & { checked: boolean; pinned: boolean };
 export interface PropTypes {
   list: TokenType[];
   selectedBlockchains: string[];
-  onChange: (items?: Asset[]) => void;
+  onChange: (selectedTokens?: TokenType[], pinnedTokens?: TokenType[]) => void;
 }
 
 export interface TokensListProps {
-  onChange: (item: TokenType) => void;
+  onChange: (item: TokenType, type: 'checked' | 'pinned') => void;
   onChangeAll: (selected: boolean) => void;
   showSelectedTokens: boolean;
   setShowSelectedTokens: (show: boolean) => void;

--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.From.tsx
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.From.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { useConfigStore } from '../../store/config';
 import { DefaultChainAndToken } from '../DefaultChainAndToken';
 import { SupportedBlockchains } from '../SupportedBlockchains';
-// import { SupportedTokens } from '../SupportedTokens';
+import { SupportedTokens } from '../SupportedTokens';
 
 import { FromAmount, FromToContainer } from './FunctionalLayout.styles';
 
@@ -24,11 +24,8 @@ export function FromSection() {
     <>
       <SupportedBlockchains type="Source" />
       <Divider size={12} />
-
-      {/* 
-        // TODO: uncomment when the structure of the supportedTokens config is changed
       <SupportedTokens type="Source" />
-      <Divider size={12} /> */}
+      <Divider size={12} />
       <FromToContainer>
         <DefaultChainAndToken type="Source" />
         <Divider size={12} />

--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.To.tsx
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.To.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { DefaultChainAndToken } from '../DefaultChainAndToken/DefaultChainAndToken';
 import { SupportedBlockchains } from '../SupportedBlockchains';
-// import { SupportedTokens } from '../SupportedTokens';
+import { SupportedTokens } from '../SupportedTokens';
 
 import { FromToContainer } from './FunctionalLayout.styles';
 
@@ -13,10 +13,8 @@ export function ToSection() {
       <SupportedBlockchains type="Destination" />
       <Divider size={12} />
 
-      {/* 
-        // TODO: uncomment when the structure of the supportedTokens config is changed
       <SupportedTokens type="Destination" />
-      <Divider size={12} /> */}
+      <Divider size={12} />
 
       <FromToContainer>
         <DefaultChainAndToken type="Destination" />

--- a/widget/playground/src/containers/SupportedTokens/SupportedTokens.tsx
+++ b/widget/playground/src/containers/SupportedTokens/SupportedTokens.tsx
@@ -13,6 +13,7 @@ export function SupportedTokens({ type }: { type: Type }) {
     config: { from, to },
     onChangeTokens,
     onChangeToken,
+    onChangePinnedTokens,
   } = useConfigStore();
   const {
     meta: { tokens, blockchains },
@@ -21,6 +22,7 @@ export function SupportedTokens({ type }: { type: Type }) {
   const selectedType = type === 'Source' ? from : to;
 
   const configTokens = selectedType?.tokens;
+  const pinnedTokens = selectedType?.pinnedTokens;
 
   const seletedBlockchains = selectedType?.blockchains;
   const allTokens = seletedBlockchains
@@ -34,6 +36,8 @@ export function SupportedTokens({ type }: { type: Type }) {
       ...token,
       checked:
         !configTokens || configTokens.some((ct) => tokensAreEqual(ct, token)),
+      pinned:
+        !!pinnedTokens && pinnedTokens.some((ct) => tokensAreEqual(ct, token)),
     };
   });
 
@@ -53,9 +57,17 @@ export function SupportedTokens({ type }: { type: Type }) {
             )
       }
       list={list}
-      onChange={(items) => {
+      onChange={(selectedTokens, pinnedTokens) => {
+        onChangePinnedTokens(
+          pinnedTokens?.map(({ symbol, blockchain, address }) => ({
+            symbol,
+            blockchain,
+            address,
+          })),
+          type
+        );
         onChangeTokens(
-          items?.map(({ symbol, blockchain, address }) => ({
+          selectedTokens?.map(({ symbol, blockchain, address }) => ({
             symbol,
             blockchain,
             address,

--- a/widget/playground/src/store/config.ts
+++ b/widget/playground/src/store/config.ts
@@ -26,6 +26,7 @@ interface ConfigState {
   onChangeSources: (sources?: string[]) => void;
   onChangeBlockChains: (chains?: string[], type?: Type) => void;
   onChangeTokens: (tokens?: Asset[], type?: Type) => void;
+  onChangePinnedTokens: (tokens?: Asset[], type?: Type) => void;
   onChangeBooleansConfig: (
     name:
       | 'multiWallets'
@@ -78,12 +79,14 @@ export const initialConfig: WidgetConfig = {
     token: undefined,
     blockchains: undefined,
     tokens: undefined,
+    pinnedTokens: undefined,
   },
   to: {
     blockchain: undefined,
     token: undefined,
     blockchains: undefined,
     tokens: undefined,
+    pinnedTokens: undefined,
   },
   liquiditySources: undefined,
   wallets: undefined,
@@ -133,6 +136,18 @@ export const useConfigStore = createSelectors(
             } else {
               if (state.config.to) {
                 state.config.to.tokens = tokens;
+              }
+            }
+          }),
+        onChangePinnedTokens: (tokens, type) =>
+          set((state) => {
+            if (type === 'Source') {
+              if (state.config.from) {
+                state.config.from.pinnedTokens = tokens;
+              }
+            } else {
+              if (state.config.to) {
+                state.config.to.pinnedTokens = tokens;
               }
             }
           }),


### PR DESCRIPTION
# Summary

We should have added the pinnedToken feature to the playground and changed its structure

# How did you test this change?

You can test this feature through Playground in the Supported Tokens section

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
- [x] From & To has separate pinned tokens.
- [x] We should add a Pin button besides of tokens in Supported Tokens section
- [x] We should remove the old pinned tokens (it was a single list for from and to).