### PR TITLE
fix(widget-v2): fix navigation in notification component

### DIFF
--- a/widget/embedded/src/components/NotificationContent/NotificationContent.tsx
+++ b/widget/embedded/src/components/NotificationContent/NotificationContent.tsx
@@ -10,6 +10,7 @@ import {
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { navigationRoutes } from '../../constants/navigationRoutes';
 import { useAppStore } from '../../store/AppStore';
 import { useNotificationStore } from '../../store/notification';
 import { useUiStore } from '../../store/ui';
@@ -34,7 +35,7 @@ export function NotificationContent() {
 
   const handleOnClick = (requestId: Notification['requestId']) => {
     setSelectedSwap(requestId);
-    navigate(`${requestId}`);
+    navigate(`${navigationRoutes.swaps}/${requestId}`);
   };
 
   return (


### PR DESCRIPTION
# Summary

A blank screen is displayed when clicking on a notification in the home page

# How did you test this change?

Create a new swap and sign the transaction. After the transaction becomes successful, click on the notification in the home page.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
