### PR TITLE
feat: add balances value to useWidget

### DIFF
--- a/queue-manager/rango-preset/src/actions/executeTransaction.ts
+++ b/queue-manager/rango-preset/src/actions/executeTransaction.ts
@@ -1,29 +1,25 @@
-import { ExecuterActions } from '@rango-dev/queue-manager-core';
+import type { SwapActionTypes, SwapQueueContext, SwapStorage } from '../types';
+import type { ExecuterActions } from '@rango-dev/queue-manager-core';
+
 import {
   ERROR_MESSAGE_DEPENDS_ON_OTHER_QUEUES,
   ERROR_MESSAGE_WAIT_FOR_CHANGE_NETWORK,
   ERROR_MESSAGE_WAIT_FOR_WALLET_DESCRIPTION,
   ERROR_MESSAGE_WAIT_FOR_WALLET_DESCRIPTION_WRONG_WALLET,
 } from '../constants';
-
 import {
+  claimQueue,
   getCurrentStep,
-  isNetworkMatchedForTransaction,
-  isRequiredWalletConnected,
-  updateNetworkStatus,
-  singTransaction,
-  resetNetworkStatus,
   getRequiredWallet,
   isNeedBlockQueueForParallel,
-  claimQueue,
+  isNetworkMatchedForTransaction,
+  isRequiredWalletConnected,
+  resetNetworkStatus,
+  signTransaction,
+  updateNetworkStatus,
 } from '../helpers';
 import { getCurrentBlockchainOf, PendingSwapNetworkStatus } from '../shared';
-import {
-  BlockReason,
-  SwapActionTypes,
-  SwapQueueContext,
-  SwapStorage,
-} from '../types';
+import { BlockReason } from '../types';
 
 /**
  * Excecute a created transaction.
@@ -105,19 +101,18 @@ export async function executeTransaction(
     };
     requestBlock(blockedFor);
     return;
-  } else {
-    // Update network to mark it as network changed successfully.
-    updateNetworkStatus(actions, {
-      message: '',
-      details: 'Wallet network changed successfully',
-      status: PendingSwapNetworkStatus.NetworkChanged,
-    });
   }
+  // Update network to mark it as network changed successfully.
+  updateNetworkStatus(actions, {
+    message: '',
+    details: 'Wallet network changed successfully',
+    status: PendingSwapNetworkStatus.NetworkChanged,
+  });
 
-  /* 
-  For avoiding conflict by making too many requests to wallet, we need to make sure
-  We only run one request at a time (In parallel mode).
-  */
+  /*
+   *For avoiding conflict by making too many requests to wallet, we need to make sure
+   *We only run one request at a time (In parallel mode).
+   */
   const needsToBlockQueue = isNeedBlockQueueForParallel(currentStep);
 
   if (needsToBlockQueue && !isClaimed) {
@@ -131,5 +126,5 @@ export async function executeTransaction(
   }
 
   // All the conditions are met. We can safely send the tx to wallet for sign.
-  singTransaction(actions);
+  signTransaction(actions);
 }

--- a/queue-manager/rango-preset/src/helpers.ts
+++ b/queue-manager/rango-preset/src/helpers.ts
@@ -1019,7 +1019,7 @@ export function isRequiredWalletConnected(
   return { ok: matched, reason: 'account_miss_match' };
 }
 
-export function singTransaction(
+export function signTransaction(
   actions: ExecuterActions<SwapStorage, SwapActionTypes, SwapQueueContext>
 ): void {
   const { setTransactionDataByHash } = inMemoryTransactionsData();

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
@@ -1,9 +1,11 @@
 import type { WidgetInfoContextInterface } from './WidgetInfo.types';
 
 import { useManager } from '@rango-dev/queue-manager-react';
-import React, { createContext, useContext, useMemo } from 'react';
+import React, { createContext, useContext } from 'react';
 
+import { useWalletsStore } from '../../store/wallets';
 import { getPendingSwaps } from '../../utils/queue';
+import { calculateWalletUsdValue } from '../../utils/wallets';
 
 export const WidgetInfoContext = createContext<
   WidgetInfoContextInterface | undefined
@@ -12,11 +14,20 @@ export const WidgetInfoContext = createContext<
 export function WidgetInfo(props: React.PropsWithChildren) {
   const { manager } = useManager();
   const swaps = getPendingSwaps(manager);
-  const value = useMemo(() => {
-    return {
-      swaps,
-    };
-  }, [manager, swaps]);
+  const details = useWalletsStore.use.connectedWallets();
+  const isLoading = useWalletsStore.use.loading();
+  const totalBalance = calculateWalletUsdValue(details);
+  const refetch = useWalletsStore.use.getWalletsDetails();
+  // eslint-disable-next-line react/jsx-no-constructed-context-values
+  const value = {
+    swaps,
+    wallets: {
+      isLoading,
+      details,
+      totalBalance,
+      refetch,
+    },
+  };
 
   return (
     <WidgetInfoContext.Provider value={value}>

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.types.ts
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.types.ts
@@ -1,5 +1,14 @@
+import type { ConnectedWallet } from '../../store/wallets';
+import type { Wallet } from '../../types';
 import type { PendingSwapWithQueueID } from '@rango-dev/queue-manager-rango-preset';
+import type { Token } from 'rango-sdk';
 
 export interface WidgetInfoContextInterface {
-  swaps?: PendingSwapWithQueueID[];
+  swaps: PendingSwapWithQueueID[];
+  wallets: {
+    details: ConnectedWallet[];
+    totalBalance: string;
+    isLoading: boolean;
+    refetch: (accounts: Wallet[], tokens: Token[]) => void;
+  };
 }

--- a/widget/embedded/src/index.ts
+++ b/widget/embedded/src/index.ts
@@ -1,4 +1,5 @@
 import type { WidgetProps } from './containers/Widget';
+import type { ConnectedWallet } from './store/wallets';
 import type {
   BlockchainAndTokenConfig,
   WidgetColors,
@@ -70,6 +71,7 @@ export type {
   StepApprovalTxSucceededEvent,
   StepOutputRevealedEvent,
   HandleWalletsUpdate,
+  ConnectedWallet,
 };
 export {
   Widget,

--- a/widget/embedded/src/store/wallets.ts
+++ b/widget/embedded/src/store/wallets.ts
@@ -186,6 +186,7 @@ export const useWalletsStore = createSelectors(
                           retrievedBalanceAccount,
                           tokens
                         ),
+                        loading: false,
                       }
                     : connectedWallet;
                 }


### PR DESCRIPTION
# Summary

In some steps we are getting the balance of the user, in this task we need to propagate the received data to dApp (like external wallets). It helps us to reduce network requests and make the widget a single source of truth for wallet balance.

Fixes # (issue)


# How did you test this change?
these values are used in this PR https://github.com/rango-exchange/app/pull/12 and with linking it can be tested.

# Checklist:

- [x] I have performed a self-review of my code
