### PR TITLE
fix: add wallets-core to rango-preset package dependencies

### DIFF
--- a/queue-manager/rango-preset/package.json
+++ b/queue-manager/rango-preset/package.json
@@ -23,6 +23,7 @@
   "peerDependencies": {
     "@rango-dev/queue-manager-core": "*",
     "@rango-dev/queue-manager-react": "*",
+    "@rango-dev/wallets-core": "*",
     "@rango-dev/wallets-shared": "*",
     "@sentry/browser": "*",
     "bignumber.js": "*",


### PR DESCRIPTION
# Summary

In our build, we have a problem because of queue-manager dependencies. 

# Checklist:

- [ ] I have performed a self-review of my code
