### PR TITLE
fix: display transaction url after refreshing

### DIFF
--- a/wallets/provider-safe/src/evm-signer.ts
+++ b/wallets/provider-safe/src/evm-signer.ts
@@ -1,9 +1,11 @@
-import { GenericSigner } from 'rango-types';
-import { EvmTransaction } from 'rango-types/lib/api/main';
-import { TransactionResponse } from '@ethersproject/abstract-provider';
+import type { TransactionResponse } from '@ethersproject/abstract-provider';
+import type { OffChainSignMessageResponse } from '@safe-global/safe-apps-sdk';
+import type { GenericSigner } from 'rango-types';
+import type { EvmTransaction } from 'rango-types/lib/api/main';
+
 import { DefaultEvmSigner } from '@rango-dev/signer-evm';
-import { sdk, getTxHash } from './helpers';
-import { OffChainSignMessageResponse } from '@safe-global/safe-apps-sdk';
+
+import { getTxHash, sdk } from './helpers';
 
 export class CustomEvmSigner implements GenericSigner<EvmTransaction> {
   private signer;
@@ -28,10 +30,14 @@ export class CustomEvmSigner implements GenericSigner<EvmTransaction> {
     hash: string;
     response: TransactionResponse & { hashRequiringUpdate: boolean };
   }> {
-    const result = await this.signer.signAndSendTx(tx, address, chainId);
+    const { hash, response } = await this.signer.signAndSendTx(
+      tx,
+      address,
+      chainId
+    );
     return {
-      hash: result.hash,
-      response: { ...result.response, hashRequiringUpdate: true },
+      hash,
+      response: { ...response, hashRequiringUpdate: true },
     };
   }
 
@@ -41,20 +47,13 @@ export class CustomEvmSigner implements GenericSigner<EvmTransaction> {
     response: TransactionResponse
   ): Promise<{
     hash: string;
-    response: TransactionResponse & {
-      hashWasUpdated: boolean;
-      isMultiSig: true;
-    };
+    response: TransactionResponse;
     chainId: string;
   }> {
-    const result = await getTxHash(safeHash);
+    const { txHash: hash } = await getTxHash(safeHash);
     return {
-      hash: result.txHash,
-      response: {
-        ...response,
-        hashWasUpdated: result.hashWasUpdated,
-        isMultiSig: true,
-      },
+      hash,
+      response,
       chainId,
     };
   }

--- a/wallets/provider-safe/src/helpers.ts
+++ b/wallets/provider-safe/src/helpers.ts
@@ -30,11 +30,8 @@ export async function getSafeInstance(): Promise<any> {
   return accountInfo ? new SafeAppProvider(accountInfo, sdk as any) : null;
 }
 
-export async function getTxHash(
-  safeHash: string
-): Promise<{ txHash: string; hashWasUpdated: boolean }> {
+export async function getTxHash(safeHash: string): Promise<{ txHash: string }> {
   let txHash;
-  let hashWasUpdated = false;
   const timeout = 5_000;
 
   while (!txHash) {
@@ -50,12 +47,10 @@ export async function getTxHash(
       } else if (queued.txHash) {
         /** The txStatus is in an end-state (e.g. success) so we probably have a valid, on chain txHash*/
         txHash = queued.txHash;
-        hashWasUpdated = true;
       }
     } catch {
       txHash = safeHash;
-      hashWasUpdated = true;
     }
   }
-  return { txHash, hashWasUpdated };
+  return { txHash };
 }


### PR DESCRIPTION
# Summary

The transaction URL during the 'checkStatus' step disappeared after refreshing when the wallet was either not connected or disconnected midway through the process.

Fixes # (issue)
# How did you test this change?
The test can be conducted by restoring the removed condition and disconnecting the wallet in the middle of a bridge check-status.


# Checklist:

- [x] I have performed a self-review of my code
