### PR TITLE
fix: fix wallet button state in swap details page

### DIFF
--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.WalletState.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.WalletState.tsx
@@ -1,30 +1,36 @@
 import type { WalletStateContentProps } from './SwapDetailsModal.types';
 
-import { MessageBox, Wallet, WalletState } from '@rango-dev/ui';
+import { MessageBox, Wallet } from '@rango-dev/ui';
 import { useWallets } from '@rango-dev/wallets-react';
 import React from 'react';
 
 import { getContainer } from '../../utils/common';
+import { mapStatusToWalletState } from '../../utils/wallets';
 
 import { WalletContainer } from './SwapDetailsModal.styles';
 
 export const WalletStateContent = (props: WalletStateContentProps) => {
   const { type, title, currentStepWallet, message, showWalletButton } = props;
-  const { connect, getWalletInfo, state: walletState } = useWallets();
+  const { connect, getWalletInfo, state } = useWallets();
   const walletType = currentStepWallet?.walletType;
-  const isConnected = walletType && walletState(walletType).connected;
-  const state = isConnected ? WalletState.CONNECTED : WalletState.DISCONNECTED;
+  const walletState = walletType
+    ? mapStatusToWalletState(state(walletType))
+    : null;
+  const walletInfo = walletType ? getWalletInfo(walletType) : null;
+  const shouldShowWallet =
+    showWalletButton && !!walletType && !!walletState && !!walletInfo;
   return (
     <>
       <MessageBox type={type} title={title} description={message} />
-      {showWalletButton && walletType && (
+      {shouldShowWallet && (
         <WalletContainer>
           <Wallet
             container={getContainer()}
-            title={getWalletInfo(walletType).name}
-            image={getWalletInfo(walletType).img}
+            title={walletInfo.name}
+            image={walletInfo.img}
             type={walletType}
-            state={state}
+            state={walletState}
+            link={walletInfo.installLink}
             onClick={async () => connect(walletType)}
           />
         </WalletContainer>

--- a/widget/ui/src/components/Wallet/Wallet.types.ts
+++ b/widget/ui/src/components/Wallet/Wallet.types.ts
@@ -21,26 +21,6 @@ export interface Info {
   tooltipText: string;
 }
 
-interface StateConnected {
-  state: WalletState.CONNECTED;
-}
-interface StateDisconnected {
-  state: WalletState.DISCONNECTED;
-}
-interface StateConnecting {
-  state: WalletState.CONNECTING;
-}
-interface StateNotInstalled {
-  state: WalletState.NOT_INSTALLED;
-  link: InstallObjects | string;
-}
-
-type State =
-  | StateConnected
-  | StateDisconnected
-  | StateConnecting
-  | StateNotInstalled;
-
 export interface ContentProps {
   image: string;
   title: string;
@@ -48,9 +28,11 @@ export interface ContentProps {
   descriptionColor?: string;
 }
 
-interface WalletProps {
+export interface WalletPropTypes {
+  state: WalletState;
   title: string;
   image: string;
+  link: InstallObjects | string;
   type: WalletType;
   onClick: (type: WalletType) => void;
   selected?: boolean;
@@ -58,8 +40,6 @@ interface WalletProps {
   isLoading?: boolean;
   container?: HTMLElement;
 }
-
-export type WalletPropTypes = State & WalletProps;
 
 export type SelectablePropTypes = WalletPropTypes & {
   selected: boolean;


### PR DESCRIPTION
# Summary

On Swap page, when we are showing the button for connecting the required wallet, if you click on connect wallet twice (when the wallet is on connecting state), it will crash.
We should disable the button, when we are connecting the wallet.

Fixes # (issue)

pass wallet-core state to wallet button

# How did you test this change?

On Swap page, when we are showing the button for connecting the required wallet, if you click on connect wallet twice (when the wallet is on connecting state), It should not prompt any errors.
