### PR TITLE
 fix: showing real prices, amount and dates

### DIFF
--- a/translations/en.po
+++ b/translations/en.po
@@ -14,6 +14,46 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:6
+msgid "Sunday"
+msgstr "Sunday"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:7
+msgid "Monday"
+msgstr "Monday"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:8
+msgid "Tuesday"
+msgstr "Tuesday"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:9
+msgid "Wednesday"
+msgstr "Wednesday"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:10
+msgid "Thursday"
+msgstr "Thursday"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:11
+msgid "Friday"
+msgstr "Friday"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:12
+msgid "Saturday"
+msgstr "Saturday"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:22
+msgid "Today"
+msgstr "Today"
+
+#. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
 #: widget/embedded/src/components/TokenList/TokenList.tsx:135
 #: widget/embedded/src/pages/HistoryPage.tsx:94
@@ -165,7 +205,7 @@ msgstr "Connect Wallet"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:348
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:365
 msgid "Swaps steps"
 msgstr "Swaps steps"
 
@@ -185,17 +225,17 @@ msgid "You have no notification"
 msgstr "You have no notification"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:198
+#: widget/embedded/src/components/Quote/Quote.tsx:213
 msgid "Slippage Error:"
 msgstr "Slippage Error:"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:222
+#: widget/embedded/src/components/Quote/Quote.tsx:237
 msgid "Yours: {amount} {symbol}"
 msgstr "Yours: {amount} {symbol}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:243
+#: widget/embedded/src/components/Quote/Quote.tsx:258
 msgid "Minimum required slippage is {minRequiredSlippage}"
 msgstr "Minimum required slippage is {minRequiredSlippage}"
 
@@ -299,19 +339,18 @@ msgstr "This setting is applied per step, e.g. 1Inch, Thorchain, etc. and only t
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:31
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:228
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:241
 msgid "Swap and Bridge"
 msgstr "Swap and Bridge"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:39
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:268
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:281
 msgid "Request ID"
 msgstr "Request ID"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:52
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:283
 msgid "Created at"
 msgstr "Created at"
 
@@ -327,27 +366,27 @@ msgid "Swap with request ID = {requestId} not found."
 msgstr "Swap with request ID = {requestId} not found."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:195
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:208
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
 msgstr "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:211
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:224
 msgid "Transaction was not sent."
 msgstr "Transaction was not sent."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:213
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:226
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
 msgstr "{amount} {symbol} on {blockchain} remain in your wallet"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:239
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:252
 msgid "Delete"
 msgstr "Delete"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:260
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:273
 msgid "Try again"
 msgstr "Try again"
 
@@ -363,27 +402,27 @@ msgid "Connect"
 msgstr "Connect"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:36
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:40
 msgid "Swap Successful"
 msgstr "Swap Successful"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:61
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:68
 msgid "Transaction Failed"
 msgstr "Transaction Failed"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:76
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:83
 msgid "Done"
 msgstr "Done"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:89
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:96
 msgid "Diagnosis"
 msgstr "Diagnosis"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:97
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:104
 msgid "See Details"
 msgstr "See Details"
 
@@ -554,7 +593,7 @@ msgstr "Confirm USD Price Unknown"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
-#: widget/embedded/src/pages/Home.tsx:159
+#: widget/embedded/src/pages/Home.tsx:160
 msgid "Swap"
 msgstr "Swap"
 
@@ -614,12 +653,12 @@ msgid "Search Transaction"
 msgstr "Search Transaction"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:173
+#: widget/embedded/src/pages/Home.tsx:174
 msgid "From"
 msgstr "From"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:212
+#: widget/embedded/src/pages/Home.tsx:217
 msgid "To"
 msgstr "To"
 
@@ -767,72 +806,6 @@ msgid "Waiting for changing wallet network"
 msgstr "Waiting for changing wallet network"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:20
-msgid "year"
-msgstr "year"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:21
-msgid "years"
-msgstr "years"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:25
-msgid "month"
-msgstr "month"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:26
-msgid "months"
-msgstr "months"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:30
-msgid "day"
-msgstr "day"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:31
-msgid "days"
-msgstr "days"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:35
-msgid "hour"
-msgstr "hour"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:36
-msgid "hours"
-msgstr "hours"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:40
-msgid "minute"
-msgstr "minute"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:41
-msgid "minutes"
-msgstr "minutes"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:61
-msgid "seconds"
-msgstr "seconds"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:64
-msgid "second"
-msgstr "second"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:69
-#: widget/embedded/src/utils/time.ts:73
-msgid "{time} ago"
-msgstr "{time} ago"
-
-#. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
 msgstr " Error connecting server, please reload the app and try again."
@@ -863,7 +836,7 @@ msgid "{blockchainCategory}"
 msgstr "{blockchainCategory}"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/components/StepDetails/StepDetails.tsx:58
+#: widget/ui/src/components/StepDetails/StepDetails.tsx:66
 msgid "Swap on {fromChain} via {swapper}"
 msgstr "Swap on {fromChain} via {swapper}"
 
@@ -888,7 +861,7 @@ msgid "In progress"
 msgstr "In progress"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/components/SwapListItem/SwapToken.tsx:118
+#: widget/ui/src/components/SwapListItem/SwapToken.tsx:121
 msgid "Waiting for bridge transaction"
 msgstr "Waiting for bridge transaction"
 
@@ -948,13 +921,13 @@ msgid "SWAP"
 msgstr "SWAP"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/containers/SwapInput/SwapInput.tsx:42
+#: widget/ui/src/containers/SwapInput/SwapInput.tsx:48
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
 msgstr "Balance"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/containers/SwapInput/SwapInput.tsx:49
+#: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 msgid "Max"
 msgstr "Max"
 
@@ -962,6 +935,72 @@ msgstr "Max"
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
 msgstr " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:20
+#~ msgid "year"
+#~ msgstr "year"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:21
+#~ msgid "years"
+#~ msgstr "years"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:25
+#~ msgid "month"
+#~ msgstr "month"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:26
+#~ msgid "months"
+#~ msgstr "months"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:30
+#~ msgid "day"
+#~ msgstr "day"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:31
+#~ msgid "days"
+#~ msgstr "days"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:35
+#~ msgid "hour"
+#~ msgstr "hour"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:36
+#~ msgid "hours"
+#~ msgstr "hours"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:40
+#~ msgid "minute"
+#~ msgstr "minute"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:41
+#~ msgid "minutes"
+#~ msgstr "minutes"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:61
+#~ msgid "seconds"
+#~ msgstr "seconds"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:64
+#~ msgid "second"
+#~ msgstr "second"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:69
+#: widget/embedded/src/utils/time.ts:73
+#~ msgid "{time} ago"
+#~ msgstr "{time} ago"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:147

--- a/translations/es.po
+++ b/translations/es.po
@@ -19,6 +19,46 @@ msgstr ""
 "X-Crowdin-File-ID: 20\n"
 
 #. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:6
+msgid "Sunday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:7
+msgid "Monday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:8
+msgid "Tuesday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:9
+msgid "Wednesday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:10
+msgid "Thursday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:11
+msgid "Friday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:12
+msgid "Saturday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:22
+msgid "Today"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
 #: widget/embedded/src/components/TokenList/TokenList.tsx:135
 #: widget/embedded/src/pages/HistoryPage.tsx:94
@@ -170,7 +210,7 @@ msgstr "Conectar cartera"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:348
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:365
 msgid "Swaps steps"
 msgstr "Intercambiar pasos"
 
@@ -190,17 +230,17 @@ msgid "You have no notification"
 msgstr "No tiene ninguna notificación"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:198
+#: widget/embedded/src/components/Quote/Quote.tsx:213
 msgid "Slippage Error:"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:222
+#: widget/embedded/src/components/Quote/Quote.tsx:237
 msgid "Yours: {amount} {symbol}"
 msgstr "Tu: {amount} {symbol}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:243
+#: widget/embedded/src/components/Quote/Quote.tsx:258
 msgid "Minimum required slippage is {minRequiredSlippage}"
 msgstr ""
 
@@ -304,19 +344,18 @@ msgstr "Este ajuste se aplica por paso, p. ej., 1pulgada, Thorchain, etc. y sól
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:31
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:228
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:241
 msgid "Swap and Bridge"
 msgstr "Intercambiar y Puente"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:39
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:268
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:281
 msgid "Request ID"
 msgstr "ID de Solicitud"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:52
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:283
 msgid "Created at"
 msgstr "Creado el"
 
@@ -332,27 +371,27 @@ msgid "Swap with request ID = {requestId} not found."
 msgstr "Intercambio con ID de solicitud = {requestId} no encontrado."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:195
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:208
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
 msgstr "Ha recibido {amount} {token} en el monedero {conciseAddress} de la cadena {chain}."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:211
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:224
 msgid "Transaction was not sent."
 msgstr "La transacción no fue enviada."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:213
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:226
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
 msgstr "{amount} {symbol} en {blockchain} permanecen en su cartera"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:239
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:252
 msgid "Delete"
 msgstr "Eliminar"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:260
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:273
 msgid "Try again"
 msgstr "Inténtalo de nuevo"
 
@@ -368,27 +407,27 @@ msgid "Connect"
 msgstr "Conectar"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:36
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:40
 msgid "Swap Successful"
 msgstr "Intercambio exitoso"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:61
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:68
 msgid "Transaction Failed"
 msgstr "Transacción fallida"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:76
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:83
 msgid "Done"
 msgstr "Hecho"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:89
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:96
 msgid "Diagnosis"
 msgstr "Diagnóstico"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:97
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:104
 msgid "See Details"
 msgstr "Ver detalles"
 
@@ -559,7 +598,7 @@ msgstr "Confirmar el precio de USD desconocido"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
-#: widget/embedded/src/pages/Home.tsx:159
+#: widget/embedded/src/pages/Home.tsx:160
 msgid "Swap"
 msgstr "Intercambiar"
 
@@ -619,12 +658,12 @@ msgid "Search Transaction"
 msgstr "Buscar transacción"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:173
+#: widget/embedded/src/pages/Home.tsx:174
 msgid "From"
 msgstr "De"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:212
+#: widget/embedded/src/pages/Home.tsx:217
 msgid "To"
 msgstr "A"
 
@@ -772,72 +811,6 @@ msgid "Waiting for changing wallet network"
 msgstr "Esperando a cambiar la red del monedero"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:20
-msgid "year"
-msgstr "año"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:21
-msgid "years"
-msgstr "años"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:25
-msgid "month"
-msgstr "mes"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:26
-msgid "months"
-msgstr "meses"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:30
-msgid "day"
-msgstr "día"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:31
-msgid "days"
-msgstr "días"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:35
-msgid "hour"
-msgstr "hora"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:36
-msgid "hours"
-msgstr "horas"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:40
-msgid "minute"
-msgstr "minuto"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:41
-msgid "minutes"
-msgstr "minutos"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:61
-msgid "seconds"
-msgstr "segundos"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:64
-msgid "second"
-msgstr "segundo"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:69
-#: widget/embedded/src/utils/time.ts:73
-msgid "{time} ago"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
 msgstr " Error al conectar el servidor, por favor vuelva a cargar la aplicación y vuelva a intentarlo."
@@ -868,7 +841,7 @@ msgid "{blockchainCategory}"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: widget/ui/src/components/StepDetails/StepDetails.tsx:58
+#: widget/ui/src/components/StepDetails/StepDetails.tsx:66
 msgid "Swap on {fromChain} via {swapper}"
 msgstr "Intercambiar por {fromChain} vía {swapper}"
 
@@ -893,7 +866,7 @@ msgid "In progress"
 msgstr "En progreso"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/components/SwapListItem/SwapToken.tsx:118
+#: widget/ui/src/components/SwapListItem/SwapToken.tsx:121
 msgid "Waiting for bridge transaction"
 msgstr "Esperando una transacción de puente"
 
@@ -953,13 +926,13 @@ msgid "SWAP"
 msgstr "SWAP"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/containers/SwapInput/SwapInput.tsx:42
+#: widget/ui/src/containers/SwapInput/SwapInput.tsx:48
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
 msgstr "Saldo"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/containers/SwapInput/SwapInput.tsx:49
+#: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 msgid "Max"
 msgstr "Máx"
 
@@ -967,6 +940,72 @@ msgstr "Máx"
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
 msgstr " Precaución, su deslizamiento es alto (={selectedSlippage}). Su operación puede ser inicial."
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:20
+#~ msgid "year"
+#~ msgstr "año"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:21
+#~ msgid "years"
+#~ msgstr "años"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:25
+#~ msgid "month"
+#~ msgstr "mes"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:26
+#~ msgid "months"
+#~ msgstr "meses"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:30
+#~ msgid "day"
+#~ msgstr "día"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:31
+#~ msgid "days"
+#~ msgstr "días"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:35
+#~ msgid "hour"
+#~ msgstr "hora"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:36
+#~ msgid "hours"
+#~ msgstr "horas"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:40
+#~ msgid "minute"
+#~ msgstr "minuto"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:41
+#~ msgid "minutes"
+#~ msgstr "minutos"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:61
+#~ msgid "seconds"
+#~ msgstr "segundos"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:64
+#~ msgid "second"
+#~ msgstr "segundo"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:69
+#: widget/embedded/src/utils/time.ts:73
+#~ msgid "{time} ago"
+#~ msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:147

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -19,6 +19,46 @@ msgstr ""
 "X-Crowdin-File-ID: 20\n"
 
 #. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:6
+msgid "Sunday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:7
+msgid "Monday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:8
+msgid "Tuesday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:9
+msgid "Wednesday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:10
+msgid "Thursday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:11
+msgid "Friday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:12
+msgid "Saturday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:22
+msgid "Today"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
 #: widget/embedded/src/components/TokenList/TokenList.tsx:135
 #: widget/embedded/src/pages/HistoryPage.tsx:94
@@ -170,7 +210,7 @@ msgstr "Connecter le portefeuille"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:348
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:365
 msgid "Swaps steps"
 msgstr "Étapes d'échange"
 
@@ -190,17 +230,17 @@ msgid "You have no notification"
 msgstr "Vous n'avez aucune notification"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:198
+#: widget/embedded/src/components/Quote/Quote.tsx:213
 msgid "Slippage Error:"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:222
+#: widget/embedded/src/components/Quote/Quote.tsx:237
 msgid "Yours: {amount} {symbol}"
 msgstr "Vous: {amount} {symbol}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:243
+#: widget/embedded/src/components/Quote/Quote.tsx:258
 msgid "Minimum required slippage is {minRequiredSlippage}"
 msgstr ""
 
@@ -304,19 +344,18 @@ msgstr "Ce paramètre est appliqué par étape, par exemple 1 pouce, Thorchain, 
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:31
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:228
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:241
 msgid "Swap and Bridge"
 msgstr "Échanger et Pont"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:39
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:268
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:281
 msgid "Request ID"
 msgstr "ID de la requête"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:52
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:283
 msgid "Created at"
 msgstr "Créé le"
 
@@ -332,27 +371,27 @@ msgid "Swap with request ID = {requestId} not found."
 msgstr "L'échange avec la requête ID = {requestId} est introuvable."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:195
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:208
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
 msgstr ""
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:211
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:224
 msgid "Transaction was not sent."
 msgstr "La transaction n'a pas été envoyée."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:213
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:226
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
 msgstr "{amount} {symbol} sur {blockchain} restent dans votre portefeuille"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:239
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:252
 msgid "Delete"
 msgstr "Supprimez"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:260
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:273
 msgid "Try again"
 msgstr "Réessayez"
 
@@ -368,27 +407,27 @@ msgid "Connect"
 msgstr "Connecter"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:36
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:40
 msgid "Swap Successful"
 msgstr "Echange Réussi"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:61
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:68
 msgid "Transaction Failed"
 msgstr "La transaction a échoué"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:76
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:83
 msgid "Done"
 msgstr "Fait"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:89
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:96
 msgid "Diagnosis"
 msgstr "Diagnostic"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:97
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:104
 msgid "See Details"
 msgstr "Voir les détails"
 
@@ -559,7 +598,7 @@ msgstr "Confirmer le prix en USD inconnu"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
-#: widget/embedded/src/pages/Home.tsx:159
+#: widget/embedded/src/pages/Home.tsx:160
 msgid "Swap"
 msgstr "Permuter"
 
@@ -619,12 +658,12 @@ msgid "Search Transaction"
 msgstr "Rechercher une transaction"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:173
+#: widget/embedded/src/pages/Home.tsx:174
 msgid "From"
 msgstr "A partir de"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:212
+#: widget/embedded/src/pages/Home.tsx:217
 msgid "To"
 msgstr "À"
 
@@ -772,72 +811,6 @@ msgid "Waiting for changing wallet network"
 msgstr "En attente de changement de réseau du portefeuille"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:20
-msgid "year"
-msgstr "Année"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:21
-msgid "years"
-msgstr "Années"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:25
-msgid "month"
-msgstr "mois"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:26
-msgid "months"
-msgstr "mois"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:30
-msgid "day"
-msgstr "jour"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:31
-msgid "days"
-msgstr "Jours"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:35
-msgid "hour"
-msgstr "heure"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:36
-msgid "hours"
-msgstr "heures"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:40
-msgid "minute"
-msgstr "minute"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:41
-msgid "minutes"
-msgstr "minutes"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:61
-msgid "seconds"
-msgstr "secondes"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:64
-msgid "second"
-msgstr "seconde"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:69
-#: widget/embedded/src/utils/time.ts:73
-msgid "{time} ago"
-msgstr ""
-
-#. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
 msgstr " Erreur de connexion au serveur, veuillez recharger l'application et réessayer."
@@ -868,7 +841,7 @@ msgid "{blockchainCategory}"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: widget/ui/src/components/StepDetails/StepDetails.tsx:58
+#: widget/ui/src/components/StepDetails/StepDetails.tsx:66
 msgid "Swap on {fromChain} via {swapper}"
 msgstr "Échanger sur {fromChain} via {swapper}"
 
@@ -893,7 +866,7 @@ msgid "In progress"
 msgstr "En cours"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/components/SwapListItem/SwapToken.tsx:118
+#: widget/ui/src/components/SwapListItem/SwapToken.tsx:121
 msgid "Waiting for bridge transaction"
 msgstr "En attente de la transaction de pont"
 
@@ -953,13 +926,13 @@ msgid "SWAP"
 msgstr "ÉCHANGER"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/containers/SwapInput/SwapInput.tsx:42
+#: widget/ui/src/containers/SwapInput/SwapInput.tsx:48
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
 msgstr "Solde"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/containers/SwapInput/SwapInput.tsx:49
+#: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 msgid "Max"
 msgstr "Max."
 
@@ -967,6 +940,72 @@ msgstr "Max."
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
 msgstr " Attention, votre slippage est élevé (={selectedSlippage}). Votre échange peut être frontal."
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:20
+#~ msgid "year"
+#~ msgstr "Année"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:21
+#~ msgid "years"
+#~ msgstr "Années"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:25
+#~ msgid "month"
+#~ msgstr "mois"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:26
+#~ msgid "months"
+#~ msgstr "mois"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:30
+#~ msgid "day"
+#~ msgstr "jour"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:31
+#~ msgid "days"
+#~ msgstr "Jours"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:35
+#~ msgid "hour"
+#~ msgstr "heure"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:36
+#~ msgid "hours"
+#~ msgstr "heures"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:40
+#~ msgid "minute"
+#~ msgstr "minute"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:41
+#~ msgid "minutes"
+#~ msgstr "minutes"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:61
+#~ msgid "seconds"
+#~ msgstr "secondes"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:64
+#~ msgid "second"
+#~ msgstr "seconde"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:69
+#: widget/embedded/src/utils/time.ts:73
+#~ msgid "{time} ago"
+#~ msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:147

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -19,6 +19,46 @@ msgstr ""
 "X-Crowdin-File-ID: 20\n"
 
 #. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:6
+msgid "Sunday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:7
+msgid "Monday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:8
+msgid "Tuesday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:9
+msgid "Wednesday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:10
+msgid "Thursday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:11
+msgid "Friday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:12
+msgid "Saturday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:22
+msgid "Today"
+msgstr ""
+
+#. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
 #: widget/embedded/src/components/TokenList/TokenList.tsx:135
 #: widget/embedded/src/pages/HistoryPage.tsx:94
@@ -170,7 +210,7 @@ msgstr "ウォレットに接続"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:348
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:365
 msgid "Swaps steps"
 msgstr "ステップを入れ替えます"
 
@@ -190,17 +230,17 @@ msgid "You have no notification"
 msgstr "通知がありません"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:198
+#: widget/embedded/src/components/Quote/Quote.tsx:213
 msgid "Slippage Error:"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:222
+#: widget/embedded/src/components/Quote/Quote.tsx:237
 msgid "Yours: {amount} {symbol}"
 msgstr "あなたの: {amount} {symbol}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:243
+#: widget/embedded/src/components/Quote/Quote.tsx:258
 msgid "Minimum required slippage is {minRequiredSlippage}"
 msgstr ""
 
@@ -304,19 +344,18 @@ msgstr "この設定はステップごとに適用されます。例えば、1In
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:31
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:228
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:241
 msgid "Swap and Bridge"
 msgstr "スワップとブリッジ"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:39
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:268
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:281
 msgid "Request ID"
 msgstr "要求ID"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:52
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:283
 msgid "Created at"
 msgstr "作成日時"
 
@@ -332,27 +371,27 @@ msgid "Swap with request ID = {requestId} not found."
 msgstr "リクエスト ID = {requestId} でスワップが見つかりません。"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:195
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:208
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
 msgstr "{amount} チェーンの {token} ウォレットで {conciseAddress} {chain} Anamed@@4 を受け取りました。"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:211
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:224
 msgid "Transaction was not sent."
 msgstr "トランザクションは送信されませんでした。"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:213
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:226
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
 msgstr "{amount} {symbol} の {blockchain} はウォレットに残ります"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:239
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:252
 msgid "Delete"
 msgstr "削除"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:260
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:273
 msgid "Try again"
 msgstr "もう一度やり直してください"
 
@@ -368,27 +407,27 @@ msgid "Connect"
 msgstr "接続する"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:36
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:40
 msgid "Swap Successful"
 msgstr "交代成功"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:61
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:68
 msgid "Transaction Failed"
 msgstr "トランザクション失敗"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:76
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:83
 msgid "Done"
 msgstr "完了"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:89
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:96
 msgid "Diagnosis"
 msgstr "診断"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:97
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:104
 msgid "See Details"
 msgstr "詳細を見る"
 
@@ -559,7 +598,7 @@ msgstr "不明なUSD価格を確認"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
-#: widget/embedded/src/pages/Home.tsx:159
+#: widget/embedded/src/pages/Home.tsx:160
 msgid "Swap"
 msgstr "入れ替え"
 
@@ -619,12 +658,12 @@ msgid "Search Transaction"
 msgstr "トランザクションを検索"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:173
+#: widget/embedded/src/pages/Home.tsx:174
 msgid "From"
 msgstr "差出人:"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:212
+#: widget/embedded/src/pages/Home.tsx:217
 msgid "To"
 msgstr "終了日"
 
@@ -772,72 +811,6 @@ msgid "Waiting for changing wallet network"
 msgstr "ウォレットネットワークの変更を待っています"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:20
-msgid "year"
-msgstr "年"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:21
-msgid "years"
-msgstr "年"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:25
-msgid "month"
-msgstr "月"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:26
-msgid "months"
-msgstr "ヶ月"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:30
-msgid "day"
-msgstr "日"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:31
-msgid "days"
-msgstr "日"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:35
-msgid "hour"
-msgstr "時"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:36
-msgid "hours"
-msgstr "時間"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:40
-msgid "minute"
-msgstr "分"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:41
-msgid "minutes"
-msgstr "分"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:61
-msgid "seconds"
-msgstr "秒"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:64
-msgid "second"
-msgstr "秒"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/utils/time.ts:69
-#: widget/embedded/src/utils/time.ts:73
-msgid "{time} ago"
-msgstr "{time} 前"
-
-#. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
 msgstr " サーバー接続中にエラーが発生しました。アプリを再読み込みしてもう一度お試しください。"
@@ -868,7 +841,7 @@ msgid "{blockchainCategory}"
 msgstr ""
 
 #. js-lingui-explicit-id
-#: widget/ui/src/components/StepDetails/StepDetails.tsx:58
+#: widget/ui/src/components/StepDetails/StepDetails.tsx:66
 msgid "Swap on {fromChain} via {swapper}"
 msgstr "{fromChain} で {swapper}を入れ替え"
 
@@ -893,7 +866,7 @@ msgid "In progress"
 msgstr "進行中"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/components/SwapListItem/SwapToken.tsx:118
+#: widget/ui/src/components/SwapListItem/SwapToken.tsx:121
 msgid "Waiting for bridge transaction"
 msgstr "ブリッジトランザクションを待っています"
 
@@ -953,13 +926,13 @@ msgid "SWAP"
 msgstr "SWAP"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/containers/SwapInput/SwapInput.tsx:42
+#: widget/ui/src/containers/SwapInput/SwapInput.tsx:48
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
 msgstr "残高"
 
 #. js-lingui-explicit-id
-#: widget/ui/src/containers/SwapInput/SwapInput.tsx:49
+#: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 msgid "Max"
 msgstr "最大値"
 
@@ -967,6 +940,72 @@ msgstr "最大値"
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
 msgstr " 注意、あなたの滑りが高いです (={selectedSlippage}). あなたの取引は、前払いされる可能性があります。"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:20
+#~ msgid "year"
+#~ msgstr "年"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:21
+#~ msgid "years"
+#~ msgstr "年"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:25
+#~ msgid "month"
+#~ msgstr "月"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:26
+#~ msgid "months"
+#~ msgstr "ヶ月"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:30
+#~ msgid "day"
+#~ msgstr "日"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:31
+#~ msgid "days"
+#~ msgstr "日"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:35
+#~ msgid "hour"
+#~ msgstr "時"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:36
+#~ msgid "hours"
+#~ msgstr "時間"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:40
+#~ msgid "minute"
+#~ msgstr "分"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:41
+#~ msgid "minutes"
+#~ msgstr "分"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:61
+#~ msgid "seconds"
+#~ msgstr "秒"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:64
+#~ msgid "second"
+#~ msgstr "秒"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:69
+#: widget/embedded/src/utils/time.ts:73
+#~ msgid "{time} ago"
+#~ msgstr "{time} 前"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:147

--- a/widget/embedded/src/components/Quote/Quote.styles.ts
+++ b/widget/embedded/src/components/Quote/Quote.styles.ts
@@ -243,8 +243,12 @@ export const FrameIcon = styled('div', {
 });
 
 export const BasicInfoOutput = styled(Typography, {
-  width: '100%',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   letterSpacing: 0.4,
+});
+
+export const ContainerInfoOutput = styled('div', {
+  display: 'flex',
+  flexWrap: 'wrap',
 });

--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -16,6 +16,7 @@ import {
   Tooltip,
   Typography,
 } from '@rango-dev/ui';
+import BigNumber from 'bignumber.js';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 
 import {
@@ -40,6 +41,7 @@ import {
   getSwapperDisplayName,
 } from '../../utils/meta';
 import {
+  formatTooltipNumbers,
   numberToString,
   secondsToString,
   totalArrivalTime,
@@ -52,6 +54,7 @@ import {
   basicInfoStyles,
   ChainImageContainer,
   Chains,
+  ContainerInfoOutput,
   Content,
   EXPANDABLE_QUOTE_TRANSITION_DURATION,
   FrameIcon,
@@ -162,6 +165,14 @@ export function Quote(props: QuoteProps) {
               USD_VALUE_MIN_DECIMALS,
               USD_VALUE_MAX_DECIMALS
             ),
+            realValue: formatTooltipNumbers(
+              index === 0 ? input.value : swap.fromAmount
+            ),
+            realUsdValue: formatTooltipNumbers(
+              new BigNumber(swap.from.usdPrice ?? 0).multipliedBy(
+                swap.fromAmount
+              )
+            ),
           },
         },
         to: {
@@ -183,6 +194,10 @@ export function Quote(props: QuoteProps) {
               (swap.to.usdPrice ?? 0) * parseFloat(swap.toAmount),
               USD_VALUE_MIN_DECIMALS,
               USD_VALUE_MAX_DECIMALS
+            ),
+            realValue: formatTooltipNumbers(swap.toAmount),
+            realUsdValue: formatTooltipNumbers(
+              new BigNumber(swap.to.usdPrice ?? 0).multipliedBy(swap.toAmount)
             ),
           },
         },
@@ -291,27 +306,49 @@ export function Quote(props: QuoteProps) {
               <FrameIcon>
                 <InfoIcon size={12} color="gray" />
               </FrameIcon>
-              <BasicInfoOutput size="small" variant="body">
-                {`${roundedInput} ${
-                  steps[0].from.token.displayName
-                } = ${roundedOutput} ${
-                  steps[steps.length - 1].to.token.displayName
-                }`}
-              </BasicInfoOutput>
-              <Typography
-                color="$neutral600"
-                ml={2}
-                size="xsmall"
-                variant="body">
-                {`($${roundedOutputUsdValue})`}
-              </Typography>
+              <ContainerInfoOutput>
+                <BasicInfoOutput size="small" variant="body">
+                  {`${roundedInput} ${steps[0].from.token.displayName} = `}
+                </BasicInfoOutput>
+                <Tooltip
+                  content={formatTooltipNumbers(output.value)}
+                  container={tooltipContainer}
+                  open={!output.value ? false : undefined}>
+                  <BasicInfoOutput size="small" variant="body">
+                    &nbsp;
+                    {`${roundedOutput} ${
+                      steps[steps.length - 1].to.token.displayName
+                    }`}
+                  </BasicInfoOutput>
+                </Tooltip>
+              </ContainerInfoOutput>
+              <Tooltip
+                content={formatTooltipNumbers(output.usdValue)}
+                container={tooltipContainer}
+                style={{
+                  display: 'flex',
+                }}>
+                <Typography
+                  color="$neutral600"
+                  ml={2}
+                  size="xsmall"
+                  variant="body">
+                  {`($${roundedOutputUsdValue})`}
+                </Typography>
+              </Tooltip>
             </div>
           )}
           {type === 'list-item' && (
             <TokenAmount
               type="output"
               direction="vertical"
-              price={{ value: roundedOutput, usdValue: roundedOutputUsdValue }}
+              tooltipContainer={tooltipContainer}
+              price={{
+                value: roundedOutput,
+                usdValue: roundedOutputUsdValue,
+                realValue: formatTooltipNumbers(output.value),
+                realUsdValue: formatTooltipNumbers(output.usdValue),
+              }}
               token={{
                 displayName: steps[numberOfSteps - 1].to.token.displayName,
                 image: steps[numberOfSteps - 1].to.token.image,
@@ -402,6 +439,7 @@ export function Quote(props: QuoteProps) {
                     step={step}
                     hasSeparator={index !== steps.length - 1}
                     state={step.state}
+                    tooltipContainer={tooltipContainer}
                   />
                 );
               })}

--- a/widget/embedded/src/components/Quote/QuoteSummary.tsx
+++ b/widget/embedded/src/components/Quote/QuoteSummary.tsx
@@ -3,6 +3,8 @@ import type { PriceImpactWarningLevel, Step } from '@rango-dev/ui';
 import { TokenAmount } from '@rango-dev/ui';
 import React from 'react';
 
+import { getContainer } from '../../utils/common';
+
 import { Container, separatorStyles } from './QuoteSummary.styles';
 
 type PropTypes = {
@@ -14,13 +16,20 @@ type PropTypes = {
 
 export function QuoteSummary(props: PropTypes) {
   const { from, to, percentageChange, warningLevel } = props;
+
   return (
     <Container>
       <TokenAmount
         direction="horizontal"
         label="Swap input"
         type="input"
-        price={{ value: from.price.value, usdValue: from.price.usdValue }}
+        tooltipContainer={getContainer()}
+        price={{
+          value: from.price.value,
+          usdValue: from.price.usdValue,
+          realValue: from.price.realValue,
+          realUsdValue: from.price.realUsdValue,
+        }}
         token={{
           displayName: from.token.displayName,
           image: from.token.image,
@@ -31,8 +40,14 @@ export function QuoteSummary(props: PropTypes) {
       <TokenAmount
         direction="horizontal"
         label="Estimated output"
+        tooltipContainer={getContainer()}
         type="output"
-        price={{ value: to.price.value, usdValue: to.price.usdValue }}
+        price={{
+          value: to.price.value,
+          usdValue: to.price.usdValue,
+          realValue: to.price.realValue,
+          realUsdValue: to.price.realUsdValue,
+        }}
         token={{
           displayName: to.token.displayName,
           image: to.token.image,

--- a/widget/embedded/src/components/SwapDetails/SwapDetails.helpers.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.helpers.tsx
@@ -20,7 +20,10 @@ export const getSteps = ({ swap, blockchains, ...args }: GetStep): Step[] => {
   const hasAlreadyProceededToSign = swap.hasAlreadyProceededToSign !== false;
   return swap.steps.map((step, index) => {
     const amountToConvert =
-      index === 0 ? swap.inputAmount : swap.steps[index - 1].outputAmount;
+      index === 0
+        ? swap.inputAmount
+        : swap.steps[index - 1].outputAmount ||
+          swap.steps[index - 1].expectedOutputAmountHumanReadable;
     return {
       from: {
         token: { displayName: step.fromSymbol, image: step.fromLogo ?? '' },
@@ -35,6 +38,7 @@ export const getSteps = ({ swap, blockchains, ...args }: GetStep): Step[] => {
             TOKEN_AMOUNT_MIN_DECIMALS,
             TOKEN_AMOUNT_MAX_DECIMALS
           ),
+          realValue: amountToConvert,
         },
       },
       to: {
@@ -50,6 +54,8 @@ export const getSteps = ({ swap, blockchains, ...args }: GetStep): Step[] => {
             TOKEN_AMOUNT_MIN_DECIMALS,
             TOKEN_AMOUNT_MAX_DECIMALS
           ),
+          realValue:
+            step.outputAmount || step.expectedOutputAmountHumanReadable,
         },
       },
       swapper: { displayName: step.swapperId, image: step.swapperLogo ?? '' },

--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -18,6 +18,7 @@ import {
   useCopyToClipboard,
 } from '@rango-dev/ui';
 import { useWallets } from '@rango-dev/wallets-react';
+import BigNumber from 'bignumber.js';
 import { PendingSwapNetworkStatus } from 'rango-types';
 import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -35,7 +36,9 @@ import {
 import { useAppStore } from '../../store/AppStore';
 import { useNotificationStore } from '../../store/notification';
 import { useQuoteStore } from '../../store/quote';
+import { getContainer } from '../../utils/common';
 import {
+  formatTooltipNumbers,
   numberToString,
   secondsToString,
   totalArrivalTime,
@@ -188,6 +191,16 @@ export function SwapDetails(props: SwapDetailsProps) {
     USD_VALUE_MAX_DECIMALS
   );
 
+  const realOutputUsdValue = outputAmount
+    ? formatTooltipNumbers(
+        new BigNumber(outputAmount).multipliedBy(lastStep.toUsdPrice || 0)
+      )
+    : '';
+
+  const realInputUsdValue = formatTooltipNumbers(
+    new BigNumber(swap.inputAmount).multipliedBy(firstStep.fromUsdPrice || 0)
+  );
+
   const percentageChange = getPriceImpact(inputUsdValue, outputUsdValue);
 
   const completeModalDesc =
@@ -280,7 +293,7 @@ export function SwapDetails(props: SwapDetailsProps) {
           </div>
           <div className={rowStyles()}>
             <Typography variant="label" size="large" color="neutral700">
-              {`${i18n.t('Created at')}:`}
+              {`${i18n.t(swap.finishTime ? 'Finished at' : 'Created at')}:`}
             </Typography>
             <Typography variant="label" size="small" color="neutral700">
               {swapDate}
@@ -307,6 +320,8 @@ export function SwapDetails(props: SwapDetailsProps) {
                   TOKEN_AMOUNT_MAX_DECIMALS
                 ),
                 usdValue: inputUsdValue,
+                realUsdValue: realInputUsdValue,
+                realValue: swap.inputAmount,
               },
               token: {
                 displayName: steps[0].from.token.displayName,
@@ -325,6 +340,8 @@ export function SwapDetails(props: SwapDetailsProps) {
                   TOKEN_AMOUNT_MAX_DECIMALS
                 ),
                 usdValue: outputUsdValue,
+                realUsdValue: realOutputUsdValue,
+                realValue: outputAmount,
               },
               token: {
                 displayName: steps[numberOfSteps - 1].to.token.displayName,
@@ -368,6 +385,7 @@ export function SwapDetails(props: SwapDetailsProps) {
                 hasSeparator={index !== 0}
                 tabIndex={key}
                 isFocused={isFocused}
+                tooltipContainer={getContainer()}
               />
             );
           })}
@@ -393,6 +411,8 @@ export function SwapDetails(props: SwapDetailsProps) {
           TOKEN_AMOUNT_MAX_DECIMALS
         )}
         usdValue={outputUsdValue}
+        realUsdValue={realOutputUsdValue}
+        realValue={formatTooltipNumbers(outputAmount)}
         percentageChange={numberToString(
           percentageChange,
           PERCENTAGE_CHANGE_MIN_DECIMALS,

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx
@@ -13,6 +13,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { RANGO_SWAP_BOX_ID } from '../../constants';
+import { getContainer } from '../../utils/common';
 
 export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
   const {
@@ -21,6 +22,8 @@ export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
     status,
     priceValue,
     usdValue,
+    realUsdValue,
+    realValue,
     token,
     chain,
     percentageChange,
@@ -38,11 +41,14 @@ export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
         <MessageBox type="success" title={i18n.t('Swap Successful')}>
           <TokenAmount
             direction="vertical"
+            tooltipContainer={getContainer()}
             type="output"
             centerAlign={true}
             price={{
               value: priceValue,
               usdValue,
+              realUsdValue,
+              realValue,
             }}
             token={token}
             chain={chain}

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.types.ts
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.types.ts
@@ -24,7 +24,9 @@ export interface CompleteModalPropTypes {
   onClose: () => void;
   status: 'success' | 'failed';
   priceValue: string;
+  realValue: string;
   usdValue: string;
+  realUsdValue: string;
   percentageChange: string;
   chain: {
     displayName?: string;

--- a/widget/embedded/src/components/SwapsGroup/SwapsGroup.tsx
+++ b/widget/embedded/src/components/SwapsGroup/SwapsGroup.tsx
@@ -4,7 +4,8 @@ import { i18n } from '@lingui/core';
 import { Divider, SwapListItem, Typography } from '@rango-dev/ui';
 import React from 'react';
 
-import { limitDecimalPlaces } from '../../utils/numbers';
+import { getContainer } from '../../utils/common';
+import { formatTooltipNumbers, numberToString } from '../../utils/numbers';
 
 import { Group, groupStyles, SwapList, Time } from './SwapsGroup.styles';
 
@@ -21,7 +22,7 @@ export function SwapsGroup(props: PropTypes) {
         swaps,
       },
       {
-        title: 'Last month',
+        title: 'This month',
         swaps,
       },
     ];
@@ -75,6 +76,7 @@ export function SwapsGroup(props: PropTypes) {
               <SwapList>
                 {group.swaps.map((swap) => {
                   const firstStep = swap.steps[0];
+
                   const lastStep = swap.steps[swap.steps.length - 1];
                   return (
                     <React.Fragment key={swap.requestId}>
@@ -84,6 +86,7 @@ export function SwapsGroup(props: PropTypes) {
                         status={swap.status}
                         onClick={onSwapClick}
                         onlyShowTime={group.title === 'Today'}
+                        tooltipContainer={getContainer()}
                         swapTokenData={{
                           from: {
                             token: {
@@ -93,7 +96,7 @@ export function SwapsGroup(props: PropTypes) {
                             blockchain: {
                               image: firstStep.fromBlockchainLogo || '',
                             },
-                            amount: limitDecimalPlaces(swap.inputAmount),
+                            amount: swap.inputAmount,
                           },
                           to: {
                             token: {
@@ -103,11 +106,14 @@ export function SwapsGroup(props: PropTypes) {
                             blockchain: {
                               image: lastStep.toBlockchainLogo || '',
                             },
-                            amount: limitDecimalPlaces(
-                              lastStep.outputAmount || ''
+                            amount: numberToString(
+                              lastStep.outputAmount ||
+                                lastStep.expectedOutputAmountHumanReadable ||
+                                ''
                             ),
-                            estimatedAmount: limitDecimalPlaces(
-                              lastStep.expectedOutputAmountHumanReadable || ''
+                            realAmount: formatTooltipNumbers(
+                              lastStep.outputAmount ||
+                                lastStep.expectedOutputAmountHumanReadable
                             ),
                           },
                         }}

--- a/widget/embedded/src/constants/routing.ts
+++ b/widget/embedded/src/constants/routing.ts
@@ -15,3 +15,5 @@ export const PERCENTAGE_CHANGE_MAX_DECIMALS = 2;
 
 export const BALANCE_MIN_DECIMALS = 8;
 export const BALANCE_MAX_DECIMALS = 8;
+
+export const TOOLTIP_DECIMALS = 12;

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -22,7 +22,8 @@ import { useAppStore } from '../store/AppStore';
 import { useQuoteStore } from '../store/quote';
 import { useUiStore } from '../store/ui';
 import { useWalletsStore } from '../store/wallets';
-import { numberToString } from '../utils/numbers';
+import { getContainer } from '../utils/common';
+import { formatTooltipNumbers, numberToString } from '../utils/numbers';
 import { getPriceImpact, getPriceImpactLevel } from '../utils/quote';
 import { canComputePriceImpact, getSwapButtonState } from '../utils/swap';
 import { formatBalance, isFetchingBalance } from '../utils/wallets';
@@ -192,6 +193,9 @@ export function Home() {
                       USD_VALUE_MIN_DECIMALS,
                       USD_VALUE_MAX_DECIMALS
                     ),
+                realUsdValue: priceImpactInputCanNotBeComputed
+                  ? undefined
+                  : formatTooltipNumbers(inputUsdValue),
                 error: priceImpactInputCanNotBeComputed
                   ? errorMessages().unknownPriceError.impactTitle
                   : undefined,
@@ -199,6 +203,7 @@ export function Home() {
               disabled={fetchMetaStatus === 'failed'}
               loading={fetchMetaStatus === 'loading'}
               loadingBalance={fetchingBalance}
+              tooltipContainer={getContainer()}
               onSelectMaxBalance={() => {
                 if (fromTokenFormattedBalance !== '0') {
                   setInputAmount(tokenBalanceReal.split(',').join(''));
@@ -239,6 +244,10 @@ export function Home() {
                     USD_VALUE_MIN_DECIMALS,
                     USD_VALUE_MAX_DECIMALS
                   ),
+              realValue: formatTooltipNumbers(outputAmount),
+              realUsdValue: priceImpactOutputCanNotBeComputed
+                ? undefined
+                : formatTooltipNumbers(outputUsdValue),
               error: priceImpactOutputCanNotBeComputed
                 ? errorMessages().unknownPriceError.impactTitle
                 : undefined,
@@ -246,6 +255,7 @@ export function Home() {
             onClickToken={() => navigate(navigationRoutes.toSwap)}
             disabled={fetchMetaStatus === 'failed'}
             loading={fetchMetaStatus === 'loading'}
+            tooltipContainer={getContainer()}
           />
         </InputsContainer>
         <div className="quote__container">

--- a/widget/embedded/src/utils/date.ts
+++ b/widget/embedded/src/utils/date.ts
@@ -19,39 +19,53 @@ export const groupSwapsByDate: GroupBy = (swaps) => {
       },
     ],
     [
+      'week',
+      {
+        title: 'This week',
+        swaps: [],
+      },
+    ],
+    [
       'month',
       {
-        title: 'Last month',
+        title: 'This month',
         swaps: [],
       },
     ],
     [
       'year',
       {
-        title: 'Last year',
-        swaps: [],
-      },
-    ],
-    [
-      'history',
-      {
-        title: 'History',
+        title: 'This year',
         swaps: [],
       },
     ],
   ]);
 
+  function addYearsToOutput(key: string, swap: PendingSwap) {
+    if (!output.has(key)) {
+      output.set(key, {
+        title: key,
+        swaps: [],
+      });
+    }
+    output.get(key)?.swaps.push(swap);
+  }
+
   const now = dayjs();
   swaps.forEach((swap) => {
-    const swapDate = dayjs(Number(swap.creationTime));
+    const time = Number(swap.creationTime);
+    const swapDate = dayjs(time);
     if (now.isSame(swapDate, 'day')) {
       output.get('today')?.swaps.push(swap);
+    } else if (now.isSame(swapDate, 'week')) {
+      output.get('week')?.swaps.push(swap);
     } else if (now.isSame(swapDate, 'month')) {
       output.get('month')?.swaps.push(swap);
     } else if (now.isSame(swapDate, 'year')) {
       output.get('year')?.swaps.push(swap);
     } else {
-      output.get('history')?.swaps.push(swap);
+      const year = new Date(time).getFullYear().toString();
+      addYearsToOutput(year, swap);
     }
   });
 

--- a/widget/embedded/src/utils/numbers.ts
+++ b/widget/embedded/src/utils/numbers.ts
@@ -4,8 +4,7 @@ import type { BestRouteResponse } from 'rango-sdk';
 
 import { BigNumber } from 'bignumber.js';
 
-export const percentToString = (p: number, fractions = 0): string =>
-  (p * 100).toFixed(fractions);
+import { TOOLTIP_DECIMALS } from '../constants/routing';
 
 export const secondsToString = (s: number): string => {
   const seconds = (s % 60).toString().padStart(2, '0');
@@ -96,56 +95,12 @@ export const numberToString = (
   );
 };
 
-export const convertBigNumberToHex = (
-  value: BigNumber,
-  decimals: number
-): string => {
-  return '0x' + value.shiftedBy(decimals).toString(16);
-};
-
 export const uint8ArrayToHex = (buffer: Uint8Array): string => {
   // buffer is an ArrayBuffer
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   return [...buffer].map((x) => x.toString(16).padStart(2, '0')).join('');
 };
-
-export function dollarToConciseString(num: number | undefined): string {
-  if (!num) {
-    return '-';
-  }
-  if (num < 1) {
-    return ' < 1$';
-  }
-  if (num < 1000) {
-    return numberToString(new BigNumber(num)) + '$';
-  }
-  if (num < 10_000) {
-    return parseInt((num / 100).toString()) / 10 + 'K';
-  }
-  if (num < 1_000_000) {
-    return parseInt((num / 1000).toString()) + 'K';
-  }
-  if (num < 100_000_000) {
-    return parseInt((num / 100000).toString()) / 10 + 'M';
-  }
-  return parseInt((num / 1000000).toString()) + 'M';
-}
-
-export function removeExtraDecimals(num: string, maxDecimals: number): string {
-  try {
-    if (!num.includes('.')) {
-      return num;
-    }
-    const [b, f] = num.split('.');
-    if (f && f.length > maxDecimals) {
-      return `${b}.${f.substring(0, maxDecimals)}`;
-    }
-    return num;
-  } catch (e) {
-    return num;
-  }
-}
 
 export const totalArrivalTime = (
   data: { estimatedTimeInSeconds: number | null }[] | undefined
@@ -167,16 +122,11 @@ export const isPositiveNumber = (text?: string) =>
   !!text && parseFloat(text) > 0;
 10;
 
-export function limitDecimalPlaces(
-  numberString: string,
-  maxDecimalPlaces = 4
-): string {
-  const number = parseFloat(numberString);
-  if (isNaN(number)) {
-    return numberString;
-  } // Return the original string if it's not a valid number
-
-  const multiplier = Math.pow(10, maxDecimalPlaces);
-  const roundedNumber = Math.round(number * multiplier) / multiplier;
-  return roundedNumber.toString();
+export function formatTooltipNumbers(
+  number: BigNumber | string | number | null | undefined
+) {
+  return numberToString(number, TOOLTIP_DECIMALS, TOOLTIP_DECIMALS).replace(
+    /(?:\.0*|(\.\d+?)0*)$/,
+    '$1'
+  );
 }

--- a/widget/embedded/src/utils/time.ts
+++ b/widget/embedded/src/utils/time.ts
@@ -2,76 +2,32 @@ import type { PendingSwap } from 'rango-types';
 
 import { i18n } from '@lingui/core';
 
-const MILLISECOND_PER_SECOND = 1000;
-const SECONDS_PER_YEAR = 31536000;
-const SECONDS_PER_MONTH = 2592000;
-const SECONDS_PER_DAY = 86400;
-const SECONDS_PER_HOUR = 3600;
-const SECONDS_PER_MINUTE = 60;
+const daysOfWeek = [
+  i18n.t('Sunday'),
+  i18n.t('Monday'),
+  i18n.t('Tuesday'),
+  i18n.t('Wednesday'),
+  i18n.t('Thursday'),
+  i18n.t('Friday'),
+  i18n.t('Saturday'),
+];
 
-export function timeSince(millisecond: number): string {
-  const seconds = Math.floor(
-    (Date.now() - millisecond) / MILLISECOND_PER_SECOND
-  );
+export function timeSince(millisecond: number) {
+  const date = new Date(millisecond);
+  const day = date.getDate();
+  const month = date.toLocaleString('default', { month: 'long' });
+  const year = date.getFullYear();
+  const isToday = date.getDay() === new Date().getDay();
+  const formattedDate = isToday
+    ? i18n.t('Today')
+    : `${daysOfWeek[date.getDay()]} ${day} ${month} ${year}`;
 
-  const intervals = [
-    {
-      turningPoint: SECONDS_PER_YEAR,
-      label: i18n.t('year'),
-      pluralLabel: i18n.t('years'),
-    },
-    {
-      turningPoint: SECONDS_PER_MONTH,
-      label: i18n.t('month'),
-      pluralLabel: i18n.t('months'),
-    },
-    {
-      turningPoint: SECONDS_PER_DAY,
-      label: i18n.t('day'),
-      pluralLabel: i18n.t('days'),
-    },
-    {
-      turningPoint: SECONDS_PER_HOUR,
-      label: i18n.t('hour'),
-      pluralLabel: i18n.t('hours'),
-    },
-    {
-      turningPoint: SECONDS_PER_MINUTE,
-      label: i18n.t('minute'),
-      pluralLabel: i18n.t('minutes'),
-    },
-  ];
-
-  const sortedIntervals = intervals.sort(
-    (a, b) => b.turningPoint - a.turningPoint
-  );
-
-  for (const interval of sortedIntervals) {
-    const { turningPoint, label, pluralLabel } = interval;
-    const intervalCount = Math.floor(seconds / turningPoint);
-    if (intervalCount > 1) {
-      return `${intervalCount} ${pluralLabel}`;
-    }
-    if (intervalCount === 1) {
-      return `${intervalCount} ${label}`;
-    }
-  }
-
-  if (seconds > 1) {
-    return `${seconds} ${i18n.t('seconds')}`;
-  }
-
-  return `${seconds} ${i18n.t('second')}`;
+  return `${formattedDate}, ${new Date(millisecond).toLocaleTimeString()}`;
 }
 
 export function getSwapDate(pendingSwap: PendingSwap) {
-  return pendingSwap.finishTime
-    ? i18n.t({
-        id: '{time} ago',
-        values: { time: timeSince(parseInt(pendingSwap.finishTime)) },
-      })
-    : i18n.t({
-        id: '{time} ago',
-        values: { time: timeSince(parseInt(pendingSwap.creationTime)) },
-      });
+  const time = pendingSwap.finishTime
+    ? timeSince(parseInt(pendingSwap.finishTime))
+    : timeSince(parseInt(pendingSwap.creationTime));
+  return time;
 }

--- a/widget/ui/src/components/PriceImpact/PriceImpact.tsx
+++ b/widget/ui/src/components/PriceImpact/PriceImpact.tsx
@@ -2,12 +2,20 @@ import type { PriceImpactProps } from './PriceImpact.types';
 
 import React from 'react';
 
-import { Typography } from '..';
+import { Tooltip, Typography } from '..';
 
 import { Container, OutputUsdValue } from './PriceImpact.styles';
 
 export function PriceImpact(props: PriceImpactProps) {
-  const { size, outputUsdValue, percentageChange, warningLevel, error } = props;
+  const {
+    size,
+    outputUsdValue,
+    realOutputUsdValue,
+    percentageChange,
+    warningLevel,
+    error,
+    tooltipProps,
+  } = props;
 
   let percentageChangeColor = '$neutral600';
   if (!outputUsdValue || warningLevel === 'low') {
@@ -19,12 +27,22 @@ export function PriceImpact(props: PriceImpactProps) {
   return (
     <Container>
       {outputUsdValue && (
-        <OutputUsdValue
-          size={size === 'small' ? 'small' : 'medium'}
-          variant="body"
-          color="$neutral600">
-          {`~$${outputUsdValue}`}
-        </OutputUsdValue>
+        <Tooltip
+          content={realOutputUsdValue}
+          container={tooltipProps?.container}
+          open={
+            !realOutputUsdValue || realOutputUsdValue === '0'
+              ? false
+              : undefined
+          }
+          side={tooltipProps?.side}>
+          <OutputUsdValue
+            size={size === 'small' ? 'small' : 'medium'}
+            variant="body"
+            color="$neutral600">
+            {`~$${outputUsdValue}`}
+          </OutputUsdValue>
+        </Tooltip>
       )}
       {((outputUsdValue && percentageChange) || !outputUsdValue) && (
         <Typography

--- a/widget/ui/src/components/PriceImpact/PriceImpact.types.ts
+++ b/widget/ui/src/components/PriceImpact/PriceImpact.types.ts
@@ -1,9 +1,16 @@
+import type { PropTypes as TooltipPropTypes } from '../Tooltip/Tooltip.types';
+
 export type PriceImpactWarningLevel = 'low' | 'high' | undefined;
 
 export type PriceImpactProps = {
   size: 'small' | 'large';
   outputUsdValue?: string;
+  realOutputUsdValue?: string;
   error?: string;
   percentageChange?: string | null;
   warningLevel?: PriceImpactWarningLevel;
+  tooltipProps?: {
+    container?: TooltipPropTypes['container'];
+    side?: TooltipPropTypes['side'];
+  };
 };

--- a/widget/ui/src/components/StepDetails/StepDetails.tsx
+++ b/widget/ui/src/components/StepDetails/StepDetails.tsx
@@ -7,6 +7,7 @@ import { ChainToken } from '../../components/ChainToken/ChainToken';
 import { NextIcon } from '../../icons';
 import { Image } from '../common';
 import { Divider } from '../Divider';
+import { Tooltip } from '../Tooltip';
 import { Typography } from '../Typography';
 
 import {
@@ -23,10 +24,17 @@ import {
 
 const StepDetailsComponent = forwardRef<HTMLDivElement, StepDetailsProps>(
   (props, parentRef) => {
-    const { step, hasSeparator, type, state, isFocused, tabIndex } = props;
+    const {
+      step,
+      hasSeparator,
+      type,
+      state,
+      isFocused,
+      tabIndex,
+      tooltipContainer,
+    } = props;
     const containerRef = useRef<HTMLDivElement>(null);
     const isCompleted = state === 'completed' || state === 'error';
-
     useEffect(() => {
       const parentElement = (parentRef as React.RefObject<HTMLDivElement>)
         ?.current;
@@ -73,12 +81,16 @@ const StepDetailsComponent = forwardRef<HTMLDivElement, StepDetailsProps>(
                 tokenImage={step.from.token.image}
                 size="small"
               />
-              <Typography
-                ml={4}
-                mr={4}
-                size="small"
-                color="$neutral700"
-                variant="body">{`${step.from.price.value} ${step.from.token.displayName}`}</Typography>
+              <Tooltip
+                content={step.from.price.realValue}
+                container={tooltipContainer}>
+                <Typography
+                  ml={4}
+                  mr={4}
+                  size="small"
+                  color="$neutral700"
+                  variant="body">{`${step.from.price.value} ${step.from.token.displayName}`}</Typography>
+              </Tooltip>
               <NextIcon color="gray" />
               <Divider size={4} direction="horizontal" />
               <ChainToken
@@ -86,13 +98,17 @@ const StepDetailsComponent = forwardRef<HTMLDivElement, StepDetailsProps>(
                 tokenImage={step.to.token.image}
                 size="small"
               />
-              <Typography
-                ml={4}
-                size="small"
-                color="$neutral700"
-                variant="body">{`${isCompleted ? '' : '~'}${
-                step.to.price.value
-              } ${step.to.token.displayName}`}</Typography>
+              <Tooltip
+                content={step.to.price.realValue}
+                container={tooltipContainer}>
+                <Typography
+                  ml={4}
+                  size="small"
+                  color="$neutral700"
+                  variant="body">{`${isCompleted ? '' : '~'}${
+                  step.to.price.value
+                } ${step.to.token.displayName}`}</Typography>
+              </Tooltip>
             </div>
             <Alerts pb={hasSeparator && type === 'quote-details'}>
               {step.alerts}

--- a/widget/ui/src/components/StepDetails/StepDetails.types.ts
+++ b/widget/ui/src/components/StepDetails/StepDetails.types.ts
@@ -22,4 +22,5 @@ export type StepDetailsProps = {
   state?: 'default' | 'in-progress' | 'completed' | 'warning' | 'error';
   isFocused?: boolean;
   tabIndex?: number;
+  tooltipContainer?: HTMLElement;
 };

--- a/widget/ui/src/components/SwapListItem/SwapListItem.tsx
+++ b/widget/ui/src/components/SwapListItem/SwapListItem.tsx
@@ -40,6 +40,7 @@ export function SwapListItem(props: PropsWithChildren<PropTypes>) {
     onlyShowTime,
     status,
     swapTokenData,
+    tooltipContainer,
   } = props;
   return (
     <Main onClick={onClick.bind(null, requestId)}>
@@ -57,7 +58,11 @@ export function SwapListItem(props: PropsWithChildren<PropTypes>) {
             {getStatus(status)}
           </Typography>
         </Header>
-        <SwapToken data={swapTokenData} status={status} />
+        <SwapToken
+          data={swapTokenData}
+          status={status}
+          tooltipContainer={tooltipContainer}
+        />
       </Container>
     </Main>
   );

--- a/widget/ui/src/components/SwapListItem/SwapListItem.types.ts
+++ b/widget/ui/src/components/SwapListItem/SwapListItem.types.ts
@@ -7,6 +7,7 @@ export interface SwapListItemProps {
   onClick: (requestId: string) => void;
   swapTokenData: SwapTokenData;
   onlyShowTime?: boolean;
+  tooltipContainer?: HTMLElement;
 }
 
 export interface LoadingProps {
@@ -42,6 +43,6 @@ export interface SwapTokenData {
       image: string;
     };
     amount: string;
-    estimatedAmount?: string;
+    realAmount: string;
   };
 }

--- a/widget/ui/src/components/SwapListItem/SwapToken.tsx
+++ b/widget/ui/src/components/SwapListItem/SwapToken.tsx
@@ -7,6 +7,7 @@ import { NextIcon } from '../../icons';
 import { ChainToken } from '../ChainToken';
 import { Divider } from '../Divider';
 import { Skeleton } from '../Skeleton';
+import { Tooltip } from '../Tooltip';
 import { Typography } from '../Typography';
 
 import {
@@ -72,14 +73,16 @@ export function SwapToken(props: PropTypes) {
         blockchain: fromBlockchain,
       },
       to: {
-        estimatedAmount,
         token: toToken,
         amount: toAmount,
         blockchain: toBlockchain,
+        realAmount,
       },
     },
     status,
+    tooltipContainer,
   } = props;
+
   return (
     <TokenContainer>
       <Images>
@@ -125,9 +128,11 @@ export function SwapToken(props: PropTypes) {
               {fromToken.displayName}
             </Typography>
             {!!fromAmount && (
-              <Typography size="small" variant="body" color="neutral700">
-                {fromAmount}
-              </Typography>
+              <Tooltip content={fromAmount} container={tooltipContainer}>
+                <Typography size="small" variant="body" color="neutral700">
+                  {fromAmount}
+                </Typography>
+              </Tooltip>
             )}
           </TokenInfo>
           <Icon>
@@ -137,10 +142,11 @@ export function SwapToken(props: PropTypes) {
             <Typography size="medium" variant="title">
               {toToken.displayName}
             </Typography>
-
-            <Typography size="small" variant="body" color="neutral700">
-              {toAmount || estimatedAmount}
-            </Typography>
+            <Tooltip content={realAmount} container={tooltipContainer}>
+              <Typography size="small" variant="body" color="neutral700">
+                {toAmount}
+              </Typography>
+            </Tooltip>
           </TokenInfo>
         </Layout>
       )}

--- a/widget/ui/src/components/SwapListItem/SwapToken.types.ts
+++ b/widget/ui/src/components/SwapListItem/SwapToken.types.ts
@@ -3,6 +3,7 @@ import type { LoadingProps, Status, SwapTokenData } from './SwapListItem.types';
 export interface SwapTokenProps {
   data: SwapTokenData;
   status: Status;
+  tooltipContainer?: HTMLElement;
 }
 
 export type PropTypes = SwapTokenProps | LoadingProps;

--- a/widget/ui/src/components/SwapListItem/mock.ts
+++ b/widget/ui/src/components/SwapListItem/mock.ts
@@ -315,5 +315,6 @@ export const swapTokenData: SwapTokenData = {
       image: 'https://api.rango.exchange/swappers/osmosis.png',
     },
     amount: '0.7',
+    realAmount: '0.7',
   },
 };

--- a/widget/ui/src/components/TokenAmount/TokenAmount.tsx
+++ b/widget/ui/src/components/TokenAmount/TokenAmount.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { ChainToken } from '../ChainToken';
 import { PriceImpact } from '../PriceImpact/PriceImpact';
+import { Tooltip } from '../Tooltip';
 import { Typography } from '../Typography';
 
 import {
@@ -27,37 +28,52 @@ export function TokenAmount(props: PropTypes) {
               {props.label}
             </Typography>
           )}
-          <div title={`${props.price.value} ${props.token.displayName}`}>
-            <Typography
-              ml={4}
-              size="medium"
-              variant="title"
-              style={{ fontWeight: 600 }}>
-              {props.price.value}
-            </Typography>
-            <Typography
-              ml={8}
-              size="medium"
-              variant="title"
-              style={{ fontWeight: 400 }}>
-              {props.token.displayName}
-            </Typography>
+          <div>
+            <Tooltip
+              content={props.price.realValue}
+              open={!props.price.realValue ? false : undefined}
+              container={props.tooltipContainer}>
+              <Typography
+                ml={4}
+                size="medium"
+                variant="title"
+                style={{ fontWeight: 600 }}>
+                {props.price.value}
+              </Typography>
+              <Typography
+                ml={8}
+                size="medium"
+                variant="title"
+                style={{ fontWeight: 400 }}>
+                {props.token.displayName}
+              </Typography>
+            </Tooltip>
           </div>
         </div>
       </div>
       {props.price.usdValue && props.price.usdValue !== '0' && (
         <div className={usdValueStyles()}>
-          {props.type === 'input' && (
-            <Typography mr={4} size="small" variant="body" color="$neutral700">
-              {`~$${props.price.usdValue}`}
-            </Typography>
-          )}
+          <Tooltip
+            content={props.price.realUsdValue}
+            container={props.tooltipContainer}>
+            {props.type === 'input' && (
+              <Typography
+                mr={4}
+                size="small"
+                variant="body"
+                color="$neutral700">
+                {`~$${props.price.usdValue}`}
+              </Typography>
+            )}
+          </Tooltip>
           {props.type === 'output' && (
             <PriceImpact
               size="small"
+              tooltipProps={{ container: props.tooltipContainer, side: 'top' }}
               outputUsdValue={props.price.usdValue}
               percentageChange={props.percentageChange}
               warningLevel={props.warningLevel}
+              realOutputUsdValue={props.price.realUsdValue}
             />
           )}
         </div>

--- a/widget/ui/src/components/TokenAmount/TokenAmount.types.ts
+++ b/widget/ui/src/components/TokenAmount/TokenAmount.types.ts
@@ -6,6 +6,7 @@ type BaseProps = Pick<SwapInputProps, 'token' | 'price'> & {
   direction?: 'vertical' | 'horizontal';
   centerAlign?: boolean;
   label?: string;
+  tooltipContainer?: HTMLElement;
 };
 
 type InputAmountProps = { type: 'input' };

--- a/widget/ui/src/components/Tooltip/Tooltip.tsx
+++ b/widget/ui/src/components/Tooltip/Tooltip.tsx
@@ -19,11 +19,12 @@ export function Tooltip(props: PropsWithChildren<PropTypes>) {
     container,
     open,
     side = 'top',
+    style,
   } = props;
   return (
     <RadixTooltip.Provider delayDuration={0}>
       <RadixTooltip.Root open={open}>
-        <RadixTooltip.Trigger asChild>
+        <RadixTooltip.Trigger asChild style={style}>
           <TriggerContent>{children}</TriggerContent>
         </RadixTooltip.Trigger>
         <RadixTooltip.Portal container={container}>

--- a/widget/ui/src/components/Tooltip/Tooltip.types.ts
+++ b/widget/ui/src/components/Tooltip/Tooltip.types.ts
@@ -1,4 +1,5 @@
 import type * as RadixTooltip from '@radix-ui/react-tooltip';
+import type { CSSProperties } from '@stitches/react';
 import type { ComponentProps, ReactNode } from 'react';
 
 type RadixTooltipContentProps = ComponentProps<typeof RadixTooltip.Content>;
@@ -10,4 +11,5 @@ export interface PropTypes {
   sideOffset?: RadixTooltipContentProps['sideOffset'];
   container?: HTMLElement;
   open?: boolean;
+  style?: CSSProperties;
 }

--- a/widget/ui/src/containers/SwapInput/SwapInput.tsx
+++ b/widget/ui/src/containers/SwapInput/SwapInput.tsx
@@ -3,7 +3,13 @@ import type { SwapInputProps } from './SwapInput.types';
 import { i18n } from '@lingui/core';
 import React from 'react';
 
-import { Divider, PriceImpact, Skeleton, Typography } from '../../components';
+import {
+  Divider,
+  PriceImpact,
+  Skeleton,
+  Tooltip,
+  Typography,
+} from '../../components';
 
 import {
   amountStyles,
@@ -77,36 +83,61 @@ export function SwapInput(props: SwapInputProps) {
             </>
           ) : (
             <>
-              <InputAmount
-                disabled={props.disabled || props.mode === 'To'}
-                style={{ padding: 0 }}
-                value={props.price.value}
-                type={'onInputChange' in props ? 'number' : 'text'}
-                size="large"
-                placeholder="0"
-                variant="ghost"
-                min={0}
-                {...('onInputChange' in props && {
-                  onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
-                    props.onInputChange(event.target.value),
-                })}
-              />
+              <Tooltip
+                content={props.price.realValue}
+                container={props.tooltipContainer}
+                open={
+                  !props.price.realValue || props.price.realValue === '0'
+                    ? false
+                    : undefined
+                }>
+                <InputAmount
+                  disabled={props.disabled || props.mode === 'To'}
+                  style={{ padding: 0 }}
+                  value={props.price.value}
+                  type={'onInputChange' in props ? 'number' : 'text'}
+                  size="large"
+                  placeholder="0"
+                  variant="ghost"
+                  min={0}
+                  {...('onInputChange' in props && {
+                    onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+                      props.onInputChange(event.target.value),
+                  })}
+                />
+              </Tooltip>
               {'percentageChange' in props ? (
                 <PriceImpact
                   size="large"
+                  tooltipProps={{
+                    container: props.tooltipContainer,
+                    side: 'bottom',
+                  }}
                   outputUsdValue={props.price.usdValue}
+                  realOutputUsdValue={props.price.realUsdValue}
                   error={props.price.error}
                   percentageChange={props.percentageChange}
                   warningLevel={props.warningLevel}
                 />
               ) : (
-                <ValueTypography hasWarning={!!props.price.error}>
-                  <UsdPrice variant="body" size="medium">
-                    {props.price.usdValue
-                      ? `~$${props.price.usdValue}`
-                      : props.price.error}
-                  </UsdPrice>
-                </ValueTypography>
+                <Tooltip
+                  content={props.price.realUsdValue}
+                  container={props.tooltipContainer}
+                  open={
+                    !props.price.realUsdValue ||
+                    props.price.realUsdValue === '0'
+                      ? false
+                      : undefined
+                  }
+                  side="bottom">
+                  <ValueTypography hasWarning={!!props.price.error}>
+                    <UsdPrice variant="body" size="medium">
+                      {props.price.usdValue
+                        ? `~$${props.price.usdValue}`
+                        : props.price.error}
+                    </UsdPrice>
+                  </ValueTypography>
+                </Tooltip>
               )}
             </>
           )}

--- a/widget/ui/src/containers/SwapInput/SwapInput.types.ts
+++ b/widget/ui/src/containers/SwapInput/SwapInput.types.ts
@@ -12,6 +12,8 @@ export type BaseProps = {
   price: {
     value: string;
     usdValue?: string;
+    realValue?: string;
+    realUsdValue?: string;
     error?: string;
   };
   loading?: boolean;
@@ -20,6 +22,7 @@ export type BaseProps = {
   label: string;
   sharpBottomStyle?: boolean;
   onClickToken: () => void;
+  tooltipContainer?: HTMLElement;
 };
 
 type FromProps = {


### PR DESCRIPTION
# Summary

in small amounts, since we round numbers, it shows 0.0000 for example for USD and amount. that's why we need a tooltip for that. Also, we should have fixed dates on the swap details page.

Fixes # (issue)


# How did you test this change?

- [x] all usd and amount should have tooltip.
- [x] the dates in swap details should work well.
- [x] all measures of a specific token should have a similar amount in all pages.


# Checklist:

- [x] I have performed a self-review of my code
