### PR TITLE
fix: fix widget-iframe styles

### DIFF
--- a/widget/app/public/index.css
+++ b/widget/app/public/index.css
@@ -7,17 +7,12 @@ html {
 body {
   padding: 0;
   margin: 0;
-  background-color: #eee;
+  background-color: transparent;
 }
 
 #app {
   height: 100vh;
-}
-
-#swap-container {
   display: flex;
-  align-items: center;
   justify-content: center;
-  height: 100%;
-  width: 100%;
+  align-items: baseline;
 }

--- a/widget/app/src/App.tsx
+++ b/widget/app/src/App.tsx
@@ -43,10 +43,8 @@ export function App() {
   }
 
   return (
-    <div>
-      <Routes>
-        <Route path="/*" element={<Widget config={configRef.current} />} />
-      </Routes>
-    </div>
+    <Routes>
+      <Route path="/*" element={<Widget config={configRef.current} />} />
+    </Routes>
   );
 }

--- a/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
@@ -18,6 +18,7 @@ import {
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { RANGO_SWAP_BOX_ID } from '../../constants';
 import { getQuoteErrorMessage } from '../../constants/errors';
 import { getQuoteUpdateWarningMessage } from '../../constants/warnings';
 import { useAppStore } from '../../store/AppStore';
@@ -238,7 +239,9 @@ export function ConfirmWalletsModal(props: PropTypes) {
     }
   }, [showCustomDestination]);
 
-  const modalContainer = document.querySelector('#swap-box') as HTMLDivElement;
+  const modalContainer = document.getElementById(
+    RANGO_SWAP_BOX_ID
+  ) as HTMLDivElement;
 
   const navigate = useNavigate();
   return (

--- a/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
@@ -18,6 +18,7 @@ import {
 import React, { useEffect, useState } from 'react';
 
 import { useWallets } from '../..';
+import { RANGO_SWAP_BOX_ID } from '../../constants';
 import { useWalletList } from '../../hooks/useWalletList';
 import {
   TIME_TO_CLOSE_MODAL,
@@ -107,7 +108,9 @@ export function WalletList(props: PropTypes) {
     });
   }, [JSON.stringify(list)]);
 
-  const modalContainer = document.querySelector('#swap-box') as HTMLDivElement;
+  const modalContainer = document.getElementById(
+    RANGO_SWAP_BOX_ID
+  ) as HTMLDivElement;
 
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout> | null = null;

--- a/widget/embedded/src/components/Layout/Layout.styles.ts
+++ b/widget/embedded/src/components/Layout/Layout.styles.ts
@@ -7,7 +7,7 @@ export const Container = styled('div', {
   borderRadius: '$primary',
   overflow: 'hidden !important',
   boxShadow: '15px 15px 15px 0px rgba(0, 0, 0, 0.05)',
-  width: '95vw',
+  width: '100vw',
   minWidth: '300px',
   maxWidth: '390px',
   maxHeight: '700px',
@@ -20,10 +20,10 @@ export const Container = styled('div', {
   variants: {
     fixedHeight: {
       true: {
-        height: '95vh',
+        height: '100vh',
       },
       false: {
-        height: 'auto',
+        height: 'auto !important',
       },
     },
   },

--- a/widget/embedded/src/components/Layout/Layout.tsx
+++ b/widget/embedded/src/components/Layout/Layout.tsx
@@ -4,7 +4,9 @@ import type { PropsWithChildren } from 'react';
 import { BottomLogo, Divider, Header } from '@rango-dev/ui';
 import React from 'react';
 
+import { RANGO_SWAP_BOX_ID } from '../../constants';
 import { useNavigateBack } from '../../hooks/useNavigateBack';
+import { useTheme } from '../../hooks/useTheme';
 import { useAppStore } from '../../store/AppStore';
 import { useUiStore } from '../../store/ui';
 import { useWalletsStore } from '../../store/wallets';
@@ -25,8 +27,9 @@ function LayoutComponent(props: PropsWithChildren<PropTypes>, ref: Ref) {
   } = props;
   const connectedWallets = useWalletsStore.use.connectedWallets();
   const {
-    config: { features },
+    config: { features, theme },
   } = useAppStore();
+  const { activeTheme } = useTheme(theme || {});
 
   const isConnectWalletHidden = isFeatureHidden(
     'connectWalletButton',
@@ -47,7 +50,11 @@ function LayoutComponent(props: PropsWithChildren<PropTypes>, ref: Ref) {
     typeof header.hasBackButton === 'undefined' || header.hasBackButton;
 
   return (
-    <Container ref={ref} fixedHeight={fixedHeight} id="swap-box">
+    <Container
+      ref={ref}
+      fixedHeight={fixedHeight}
+      id={RANGO_SWAP_BOX_ID}
+      className={activeTheme()}>
       <Header
         prefix={<>{showBackButton && <BackButton onClick={navigateBack} />}</>}
         title={header.title}

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx
@@ -12,6 +12,8 @@ import {
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { RANGO_SWAP_BOX_ID } from '../../constants';
+
 export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
   const {
     open,
@@ -31,7 +33,7 @@ export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
     <Modal
       open={open}
       onClose={onClose}
-      container={document.getElementById('swap-box') || document.body}>
+      container={document.getElementById(RANGO_SWAP_BOX_ID) || document.body}>
       {status === 'success' ? (
         <MessageBox type="success" title={i18n.t('Swap Successful')}>
           <TokenAmount

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.tsx
@@ -4,6 +4,8 @@ import { Modal } from '@rango-dev/ui';
 import { PendingSwapNetworkStatus } from 'rango-types';
 import React from 'react';
 
+import { RANGO_SWAP_BOX_ID } from '../../constants';
+
 import { CancelContent } from './SwapDetailsModal.Cancel';
 import { DeleteContent } from './SwapDetailsModal.Delete';
 import { modalNetworkValues } from './SwapDetailsModal.helpers';
@@ -22,7 +24,7 @@ export function SwapDetailsModal(props: ModalPropTypes) {
     <Modal
       open={!!state}
       onClose={onClose}
-      container={document.getElementById('swap-box') || document.body}>
+      container={document.getElementById(RANGO_SWAP_BOX_ID) || document.body}>
       {showWalletStateContent && (
         <WalletStateContent
           type={modalNetworkValues[state].type}

--- a/widget/embedded/src/components/WalletModal/WalletModal.tsx
+++ b/widget/embedded/src/components/WalletModal/WalletModal.tsx
@@ -3,6 +3,8 @@ import type { PropTypes } from './WalletModal.types';
 import { Divider, Modal } from '@rango-dev/ui';
 import React from 'react';
 
+import { RANGO_SWAP_BOX_ID } from '../../constants';
+
 import { ModalContent } from './WalletModalContent';
 
 export function WalletModal(props: PropTypes) {
@@ -12,7 +14,7 @@ export function WalletModal(props: PropTypes) {
     <Modal
       open={open}
       onClose={onClose}
-      container={document.getElementById('swap-box') || document.body}>
+      container={document.getElementById(RANGO_SWAP_BOX_ID) || document.body}>
       <ModalContent {...otherProps} />
       <Divider direction="vertical" size={32} />
     </Modal>

--- a/widget/embedded/src/constants/index.ts
+++ b/widget/embedded/src/constants/index.ts
@@ -1,2 +1,3 @@
 export const RANGO_PUBLIC_API_KEY = 'c6381a79-2817-4602-83bf-6a641a409e32';
 export const DEFAULT_BASE_URL = 'https://api.rango.exchange';
+export const RANGO_SWAP_BOX_ID = 'rango-swap-box';

--- a/widget/embedded/src/containers/App/App.styles.ts
+++ b/widget/embedded/src/containers/App/App.styles.ts
@@ -1,7 +1,6 @@
 import { styled } from '@rango-dev/ui';
 
 export const MainContainer = styled('div', {
-  width: '100%',
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
@@ -9,10 +8,10 @@ export const MainContainer = styled('div', {
   boxSizing: 'border-box',
   '& *, *::before, *::after': {
     boxSizing: 'inherit',
-    listStyleType: 'none',
   },
   '& *:focus-visible': {
     outlineColor: '$info500',
     transition: 'none',
   },
+  '& ul, ol, li': { listStyleType: 'none' },
 });

--- a/widget/embedded/src/utils/common.ts
+++ b/widget/embedded/src/utils/common.ts
@@ -1,3 +1,5 @@
+import { RANGO_SWAP_BOX_ID } from '../constants';
+
 export function removeDuplicateFrom<T>(array: T[]): T[] {
   return Array.from(new Set(array));
 }
@@ -31,4 +33,4 @@ export function containsText(text: string, searchText: string): boolean {
 }
 
 export const getContainer = () =>
-  document.getElementById('swap-box') as HTMLElement;
+  document.getElementById(RANGO_SWAP_BOX_ID) as HTMLElement;

--- a/widget/iframe/src/main.ts
+++ b/widget/iframe/src/main.ts
@@ -1,11 +1,23 @@
-import { WidgetConfig } from '@rango-dev/widget-embedded';
+import type { WidgetConfig } from '@rango-dev/widget-embedded';
+
 import { commonStyles } from './styles';
 
 // Actual app that will be loaded inside the iframe.
 const WIDGET_URL = 'https://widget.rango.exchange/';
 const DEFAULT_CONTAINER_ID = 'rango-widget-container';
+const RANGO_WIDGET_IFRAME_ID = 'rango-widget-iframe';
 
 export class RangoWidget {
+  public init(configuration?: WidgetConfig, rootId?: string): void {
+    const container = this.getContainer(rootId || DEFAULT_CONTAINER_ID);
+    const widget = this.createWidget(configuration);
+
+    container.appendChild(widget);
+
+    widget.onload = () => {
+      widget.style.display = 'block';
+    };
+  }
   /**
    * Encode configuration object into a string that can be passed as url param.
    */
@@ -14,7 +26,8 @@ export class RangoWidget {
       // Take # out of the url parameters
       if (typeof value === 'string' && value[0] === '#') {
         return value.replace('#', '$');
-      } else return value;
+      }
+      return value;
     });
     return configParams;
   }
@@ -46,27 +59,16 @@ export class RangoWidget {
     const url = `${WIDGET_URL}?config=${configs}`;
 
     const widget = document.createElement('iframe');
+    widget.setAttribute('id', RANGO_WIDGET_IFRAME_ID);
     widget.src = url;
+    widget.style.backgroundColor = 'transparent';
+    widget.style.width = commonStyles.width;
+    widget.style.height = commonStyles.height;
     widget.style.maxWidth = commonStyles.maxWidth;
-    widget.style.minWidth = commonStyles.minWidth;
-    widget.width = commonStyles.width;
-    widget.height = commonStyles.height;
+    widget.style.maxHeight = commonStyles.maxHeight;
     widget.style.overflow = commonStyles.overflow;
     widget.style.border = 'none';
-    widget.style.display = 'none';
 
     return widget;
-  }
-
-  public init(configuration?: WidgetConfig, rootId?: string): void {
-    const container = this.getContainer(rootId || DEFAULT_CONTAINER_ID);
-    const widget = this.createWidget(configuration);
-
-    container.style.width = '100%';
-    container.appendChild(widget);
-
-    widget.onload = () => {
-      widget.style.display = 'block';
-    };
   }
 }

--- a/widget/iframe/src/styles.ts
+++ b/widget/iframe/src/styles.ts
@@ -1,7 +1,7 @@
 export const commonStyles = {
-  maxWidth: '512px',
-  height: '720px',
-  width: '100%',
-  minWidth: '415px',
+  width: '100vw',
+  maxWidth: '390px',
+  height: '100vh',
+  maxHeight: '700px',
   overflow: 'hidden',
 };

--- a/widget/iframe/tsconfig.json
+++ b/widget/iframe/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
+  "extends": "../../tsconfig.lib.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist",
+    "lib": ["dom", "esnext"],
+    // match output dir to input dir. e.g. dist/index instead of dist/src/index
+    "rootDir": "./src"
+  }
+}


### PR DESCRIPTION
# Summary

After updating the widget to version 2, the i-frame version of the widget no longer functions correctly. Its styles need adjustment, and the dimensions of the i-frame must be updated, along with refining several styles.

Fixes # (issue)

The dimensions of the i-frame should change based on the widget layout dimensions. The background of the widget-app should be removed, and the widget should cover the entire i-frame.

# How did you test this change?

First, we need to serve the widget-app in one place. You can use the 'serve' package for ease of use:

```
serve --cors -p 3002
```

In the main.ts file, we modify the source address of the i-frame from the widget-i-frame package to the address where the widget-app is served. We then build the widget-i-frame package.

We place the code exported from the playground for the i-frame into the HTML file where we want to test it. Instead of using "https://api.rango.exchange/widget/iframe.bundle.min.js", we use the file that we built ourselves.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation

