### PR TITLE
fix: walletDetails request is fired twice

### DIFF
--- a/wallets/core/src/types.ts
+++ b/wallets/core/src/types.ts
@@ -66,6 +66,8 @@ export type Disconnect = (options: {
   destroyInstance: () => void;
 }) => Promise<void>;
 
+type CleanupSubscribe = () => void;
+
 export type Subscribe = (options: {
   instance: any;
   state: WalletState;
@@ -74,7 +76,7 @@ export type Subscribe = (options: {
   updateAccounts: (accounts: string[], chainId?: string) => void;
   connect: (network?: Network) => void;
   disconnect: () => void;
-}) => void;
+}) => CleanupSubscribe | void;
 
 export type SwitchNetwork = (options: {
   instance: any;

--- a/wallets/core/src/wallet.ts
+++ b/wallets/core/src/wallet.ts
@@ -40,6 +40,7 @@ class Wallet<InstanceType = any> {
   private state: State;
   private options: Options;
   private info: EventInfo;
+  private cleanupSubscribe?: (() => void) | void;
 
   constructor(options: Options, actions: WalletActions) {
     this.actions = actions;
@@ -295,7 +296,7 @@ class Wallet<InstanceType = any> {
   setProvider(value: any) {
     this.provider = value;
     if (!!value && !!this.actions.subscribe) {
-      this.actions.subscribe({
+      const cleanup = this.actions.subscribe({
         instance: value,
         state: this.state,
         meta: this.info.supportedBlockchains,
@@ -320,6 +321,9 @@ class Wallet<InstanceType = any> {
         },
         updateChainId: this.updateChainId.bind(this),
       });
+      this.cleanupSubscribe = cleanup;
+    } else if (!value && this.cleanupSubscribe) {
+      this.cleanupSubscribe();
     }
   }
 

--- a/wallets/provider-argentx/src/index.ts
+++ b/wallets/provider-argentx/src/index.ts
@@ -45,13 +45,18 @@ export const connect: Connect = async ({ instance }) => {
 };
 
 export const subscribe: Subscribe = ({ instance, state, updateAccounts }) => {
-  instance?.on('accountsChanged', (accounts: any) => {
+  const handleAccountsChanged = (accounts: any) => {
     if (state.connected) {
       if (instance) {
         updateAccounts(accounts, Networks.STARKNET);
       }
     }
-  });
+  };
+  instance?.on('accountsChanged', handleAccountsChanged);
+
+  return () => {
+    instance?.off('accountsChanged', handleAccountsChanged);
+  };
 };
 
 export const canSwitchNetworkTo: CanSwitchNetwork = () => false;

--- a/wallets/provider-bitget/src/index.ts
+++ b/wallets/provider-bitget/src/index.ts
@@ -75,7 +75,7 @@ export const subscribe: Subscribe = ({
   const ethInstance = instance.get(Networks.ETHEREUM);
   const evmBlockchainMeta = meta.filter(isEvmBlockchain);
 
-  subscribeToEvm({
+  const cleanup = subscribeToEvm({
     instance: ethInstance,
     state,
     updateChainId,
@@ -99,6 +99,12 @@ export const subscribe: Subscribe = ({
       }
     }
   });
+
+  return () => {
+    if (cleanup) {
+      cleanup();
+    }
+  };
 };
 
 export const switchNetwork: SwitchNetwork = switchNetworkForEvm;

--- a/wallets/provider-braavos/src/index.ts
+++ b/wallets/provider-braavos/src/index.ts
@@ -32,13 +32,17 @@ export const connect: Connect = async ({ instance }) => {
 };
 
 export const subscribe: Subscribe = ({ instance, state, updateAccounts }) => {
-  instance?.on('accountsChanged', (accounts: any) => {
+  const handleAccountsChanged = (accounts: any) => {
     if (state.connected) {
       if (instance) {
         updateAccounts([accounts], Networks.STARKNET);
       }
     }
-  });
+  };
+  instance?.on('accountsChanged', handleAccountsChanged);
+  return () => {
+    instance?.off('accountsChanged', handleAccountsChanged);
+  };
 };
 
 export const canSwitchNetworkTo: CanSwitchNetwork = () => false;

--- a/wallets/provider-coin98/src/index.ts
+++ b/wallets/provider-coin98/src/index.ts
@@ -52,7 +52,7 @@ export const subscribe: Subscribe = ({
   connect,
 }) => {
   const eth = chooseInstance(instance, meta, Networks.ETHEREUM);
-  eth?.on('chainChanged', (chainId: string) => {
+  const handleChainChanged = (chainId: string) => {
     const network = getBlockChainNameFromId(chainId, meta) || Networks.Unknown;
     const targetInstance = chooseInstance(instance, meta, network);
     targetInstance
@@ -76,7 +76,12 @@ export const subscribe: Subscribe = ({
      */
     updateChainId(chainId);
     connect(network);
-  });
+  };
+  eth?.on('chainChanged', handleChainChanged);
+
+  return () => {
+    eth?.off('chainChanged', handleChainChanged);
+  };
 };
 
 export const switchNetwork: SwitchNetwork = async (options) => {

--- a/wallets/provider-coinbase/src/index.ts
+++ b/wallets/provider-coinbase/src/index.ts
@@ -69,7 +69,7 @@ export const subscribe: Subscribe = (options) => {
     Networks.SOLANA
   );
   const { connect, updateAccounts, state, updateChainId, meta } = options;
-  ethInstance?.on('accountsChanged', (addresses: string[]) => {
+  const handleEvmAccountsChanged = (addresses: string[]) => {
     const eth_chainId = meta
       .filter(isEvmBlockchain)
       .find((blockchain) => blockchain.name === Networks.ETHEREUM)?.chainId;
@@ -79,9 +79,9 @@ export const subscribe: Subscribe = (options) => {
       }
       updateAccounts(addresses);
     }
-  });
+  };
 
-  solanaInstance?.on('accountChanged', async (publicKey: string) => {
+  const handleSolanaAccountChanged = async (publicKey: string) => {
     if (state.network != Networks.SOLANA) {
       updateChainId(meta.filter(isSolanaBlockchain)[0].chainId);
     }
@@ -92,7 +92,16 @@ export const subscribe: Subscribe = (options) => {
     } else {
       connect(network);
     }
-  });
+  };
+  ethInstance?.on('accountsChanged', handleEvmAccountsChanged);
+
+  solanaInstance?.on('accountChanged', handleSolanaAccountChanged);
+
+  return () => {
+    ethInstance?.off('accountsChanged', handleEvmAccountsChanged);
+
+    solanaInstance?.off('accountChanged', handleSolanaAccountChanged);
+  };
 };
 export const switchNetwork: SwitchNetwork = switchNetworkForEvm;
 

--- a/wallets/provider-cosmostation/src/index.ts
+++ b/wallets/provider-cosmostation/src/index.ts
@@ -86,7 +86,7 @@ export const subscribe: Subscribe = ({
   const ethInstance = instance.get(Networks.ETHEREUM);
   const EvmBlockchainMeta = meta.filter(isEvmBlockchain);
 
-  subscribeToEvm({
+  const cleanupEvm = subscribeToEvm({
     instance: ethInstance,
     state,
     updateChainId,
@@ -96,10 +96,22 @@ export const subscribe: Subscribe = ({
     disconnect,
   });
 
-  window.cosmostation.cosmos.on('accountChanged', () => {
+  const handleCosmosAccountChanged = () => {
     disconnect();
     connect();
-  });
+  };
+
+  window.cosmostation.cosmos.on('accountChanged', handleCosmosAccountChanged);
+
+  return () => {
+    if (cleanupEvm) {
+      cleanupEvm();
+    }
+    window.cosmostation.cosmos.off(
+      'accountChanged',
+      handleCosmosAccountChanged
+    );
+  };
 };
 
 export const suggest: Suggest = async (options) => {

--- a/wallets/provider-frontier/src/index.ts
+++ b/wallets/provider-frontier/src/index.ts
@@ -64,7 +64,7 @@ export const subscribe: Subscribe = (options) => {
     Networks.SOLANA
   );
   const { connect, updateAccounts, state, updateChainId, meta } = options;
-  ethInstance?.on('accountsChanged', (addresses: string[]) => {
+  const handleEvmAccountsChanged = (addresses: string[]) => {
     const eth_chainId = meta
       .filter(isEvmBlockchain)
       .find((blockchain) => blockchain.name === Networks.ETHEREUM)?.chainId;
@@ -74,9 +74,9 @@ export const subscribe: Subscribe = (options) => {
       }
       updateAccounts(addresses);
     }
-  });
+  };
 
-  solanaInstance?.on('accountChanged', async (publicKey: string) => {
+  const handleSolanaAccountsChanged = async (publicKey: string) => {
     if (state.network != Networks.SOLANA) {
       updateChainId(meta.filter(isSolanaBlockchain)[0].chainId);
     }
@@ -87,7 +87,16 @@ export const subscribe: Subscribe = (options) => {
     } else {
       connect(network);
     }
-  });
+  };
+  ethInstance?.on('accountsChanged', handleEvmAccountsChanged);
+
+  solanaInstance?.on('accountChanged', handleSolanaAccountsChanged);
+
+  return () => {
+    ethInstance?.off('accountsChanged', handleEvmAccountsChanged);
+
+    solanaInstance?.off('accountChanged', handleSolanaAccountsChanged);
+  };
 };
 export const switchNetwork: SwitchNetwork = async (options) => {
   const instance = chooseInstance(

--- a/wallets/provider-keplr/src/index.ts
+++ b/wallets/provider-keplr/src/index.ts
@@ -35,10 +35,14 @@ export const connect: Connect = async ({ instance, network, meta }) => {
 };
 
 export const subscribe: Subscribe = ({ connect, disconnect }) => {
-  window.addEventListener('keplr_keystorechange', () => {
+  const handleAccountsChanged = () => {
     disconnect();
     connect();
-  });
+  };
+  window.addEventListener('keplr_keystorechange', handleAccountsChanged);
+  return () => {
+    window.removeEventListener('keplr_keystorechange', handleAccountsChanged);
+  };
 };
 
 export const suggest: Suggest = suggestCosmosChain;

--- a/wallets/provider-leap-cosmos/src/index.ts
+++ b/wallets/provider-leap-cosmos/src/index.ts
@@ -58,10 +58,14 @@ export const connect: Connect = async ({ instance, network, meta }) => {
 };
 
 export const subscribe: Subscribe = ({ connect, disconnect }) => {
-  window.addEventListener('leap_keystorechange', () => {
+  const handleAccountsChanged = () => {
     disconnect();
     connect();
-  });
+  };
+  window.addEventListener('leap_keystorechange', handleAccountsChanged);
+  return () => {
+    window.removeEventListener('leap_keystorechange', handleAccountsChanged);
+  };
 };
 
 export const suggest: Suggest = async (options) => {

--- a/wallets/provider-okx/src/index.ts
+++ b/wallets/provider-okx/src/index.ts
@@ -54,8 +54,7 @@ export const connect: Connect = async ({ instance, meta }) => {
 
 export const subscribe: Subscribe = ({ instance, updateAccounts, meta }) => {
   const ethInstance = chooseInstance(instance, meta, Networks.ETHEREUM);
-
-  ethInstance?.on('accountsChanged', async (addresses: string[]) => {
+  const handleEvmAccountsChanged = async (addresses: string[]) => {
     const eth_chainId = meta
       .filter(isEvmBlockchain)
       .find((blockchain) => blockchain.name === Networks.ETHEREUM)?.chainId;
@@ -63,7 +62,12 @@ export const subscribe: Subscribe = ({ instance, updateAccounts, meta }) => {
     updateAccounts(addresses, eth_chainId);
     const [{ accounts, chainId }] = await getSolanaAccounts(instance);
     updateAccounts(accounts, chainId);
-  });
+  };
+  ethInstance?.on('accountsChanged', handleEvmAccountsChanged);
+
+  return () => {
+    ethInstance?.off('accountsChanged', handleEvmAccountsChanged);
+  };
 };
 
 export const switchNetwork: SwitchNetwork = async (options) => {

--- a/wallets/provider-phantom/src/index.ts
+++ b/wallets/provider-phantom/src/index.ts
@@ -27,7 +27,7 @@ export const getInstance = phantom_instance;
 export const connect: Connect = getSolanaAccounts;
 
 export const subscribe: Subscribe = ({ instance, updateAccounts, connect }) => {
-  instance?.on('accountChanged', async (publicKey: string) => {
+  const handleAccountsChanged = async (publicKey: string) => {
     const network = Networks.SOLANA;
     if (publicKey) {
       const account = publicKey.toString();
@@ -35,7 +35,12 @@ export const subscribe: Subscribe = ({ instance, updateAccounts, connect }) => {
     } else {
       connect(network);
     }
-  });
+  };
+  instance?.on('accountChanged', handleAccountsChanged);
+
+  return () => {
+    instance?.off('accountChanged', handleAccountsChanged);
+  };
 };
 
 export const canSwitchNetworkTo: CanSwitchNetwork = () => false;

--- a/wallets/provider-safe/src/index.ts
+++ b/wallets/provider-safe/src/index.ts
@@ -53,7 +53,7 @@ export const subscribe: Subscribe = ({
 }) => {
   const evmBlockchainMeta = meta.filter(isEvmBlockchain);
 
-  subscribeToEvm({
+  const cleanup = subscribeToEvm({
     instance,
     state,
     updateChainId,
@@ -62,6 +62,11 @@ export const subscribe: Subscribe = ({
     connect,
     disconnect,
   });
+  return () => {
+    if (cleanup) {
+      cleanup();
+    }
+  };
 };
 
 export const switchNetwork: SwitchNetwork = switchNetworkForEvm;

--- a/wallets/provider-safepal/src/index.ts
+++ b/wallets/provider-safepal/src/index.ts
@@ -47,6 +47,7 @@ export const connect: Connect = async ({ instance, meta }) => {
 };
 
 export const subscribe: Subscribe = (options) => {
+  let cleanup: ReturnType<Subscribe>;
   const ethInstance = chooseInstance(
     options.instance,
     options.meta,
@@ -54,8 +55,14 @@ export const subscribe: Subscribe = (options) => {
   );
 
   if (ethInstance) {
-    subscribeToEvm({ ...options, instance: ethInstance });
+    cleanup = subscribeToEvm({ ...options, instance: ethInstance });
   }
+
+  return () => {
+    if (cleanup) {
+      cleanup();
+    }
+  };
 };
 
 export const switchNetwork: SwitchNetwork = switchNetworkForEvm;

--- a/wallets/provider-station/src/index.ts
+++ b/wallets/provider-station/src/index.ts
@@ -14,6 +14,8 @@ import signer from './signer';
 
 const WALLET = WalletTypes.STATION;
 const STATION_WALLET_ID = 'station';
+const INTERVAL_TIMEOUT = 3_000;
+const MAX_TRY_COUNT = 3;
 
 export const config = {
   type: WALLET,
@@ -30,11 +32,11 @@ async function waitInterval(instance: any) {
       } else {
         count++;
       }
-      if (count > 3) {
+      if (count > MAX_TRY_COUNT) {
         resolve(state);
         clearInterval(interval);
       }
-    }, 3000);
+    }, INTERVAL_TIMEOUT);
   });
 }
 

--- a/wallets/provider-xdefi/src/index.ts
+++ b/wallets/provider-xdefi/src/index.ts
@@ -59,8 +59,7 @@ export const subscribe: Subscribe = ({
   updateChainId,
   connect,
 }) => {
-  const eth = chooseInstance(instance, meta, Networks.ETHEREUM);
-  eth?.on('chainChanged', (chainId: string) => {
+  const handleChainChanged = (chainId: string) => {
     const network = getBlockChainNameFromId(chainId, meta) || Networks.Unknown;
     /*
      *TODO:
@@ -77,7 +76,13 @@ export const subscribe: Subscribe = ({
      */
     updateChainId(chainId);
     connect(network);
-  });
+  };
+  const eth = chooseInstance(instance, meta, Networks.ETHEREUM);
+  eth?.on('chainChanged', handleChainChanged);
+
+  return () => {
+    eth?.off('chainChanged', handleChainChanged);
+  };
 };
 
 export const switchNetwork: SwitchNetwork = switchNetworkForEvm;

--- a/wallets/react/src/types.ts
+++ b/wallets/react/src/types.ts
@@ -86,6 +86,9 @@ export type Disconnect = (options: {
   instance: any;
   destroyInstance: () => void;
 }) => Promise<void>;
+
+type CleanupSubscribe = () => void;
+
 export type Subscribe = (options: {
   instance: any;
   state: WalletState;
@@ -94,7 +97,7 @@ export type Subscribe = (options: {
   updateAccounts: (accounts: string[], chainId?: string) => void;
   connect: (network?: Network) => void;
   disconnect: () => void;
-}) => void;
+}) => CleanupSubscribe | void;
 
 export type SwitchNetwork = (options: {
   instance: any;

--- a/wallets/shared/src/providers.ts
+++ b/wallets/shared/src/providers.ts
@@ -35,7 +35,7 @@ export const subscribeToEvm: Subscribe = ({
   updateChainId,
   updateAccounts,
 }) => {
-  instance?.on('accountsChanged', (addresses: string[]) => {
+  const handleAccountsChanged = (addresses: string[]) => {
     /*
      * TODO: after enabling autoconnect, we can consider this condition
      * to be removed.
@@ -46,11 +46,22 @@ export const subscribeToEvm: Subscribe = ({
     if (state.connected) {
       updateAccounts(addresses);
     }
-  });
+  };
 
-  instance?.on('chainChanged', (chainId: string) => {
+  const handleChainChanged = (chainId: string) => {
     updateChainId(chainId);
-  });
+  };
+
+  instance?.on('accountsChanged', handleAccountsChanged);
+
+  instance?.on('chainChanged', handleChainChanged);
+
+  const cleanup = () => {
+    instance?.off('chainChanged', handleAccountsChanged);
+    instance?.off('accountsChanged', handleChainChanged);
+  };
+
+  return cleanup;
 };
 
 export const canEagerlyConnectToEvm: CanEagerConnect = async ({ instance }) => {

--- a/wallets/shared/src/rango.ts
+++ b/wallets/shared/src/rango.ts
@@ -237,6 +237,8 @@ export type Disconnect = (options: {
   destroyInstance: () => void;
 }) => Promise<void>;
 
+type CleanupSubscribe = () => void;
+
 export type Subscribe = (options: {
   instance: any;
   state: WalletState;
@@ -245,7 +247,7 @@ export type Subscribe = (options: {
   updateAccounts: (accounts: string[], chainId?: string) => void;
   connect: (network?: Network) => void;
   disconnect: () => void;
-}) => void;
+}) => CleanupSubscribe | void;
 
 export type CanEagerConnect = (options: {
   instance: any;

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -3,6 +3,7 @@ import type {
   PropTypes,
   WidgetContextInterface,
 } from './Wallets.types';
+import type { Wallet } from '../../types/wallets';
 import type { ProvidersOptions } from '../../utils/providers';
 import type { EventHandler } from '@rango-dev/wallets-react';
 import type { Network } from '@rango-dev/wallets-shared';
@@ -10,7 +11,7 @@ import type { PropsWithChildren } from 'react';
 
 import { Events, Provider } from '@rango-dev/wallets-react';
 import { isEvmBlockchain } from 'rango-sdk';
-import React, { createContext, useEffect, useRef } from 'react';
+import React, { createContext, useEffect, useRef, useState } from 'react';
 
 import { useSyncStoresWithConfig } from '../../hooks/useSyncStoresWithConfig';
 import { useWalletProviders } from '../../hooks/useWalletProviders';
@@ -34,6 +35,7 @@ function Main(props: PropsWithChildren<PropTypes>) {
   const walletOptions: ProvidersOptions = {
     walletConnectProjectId: props.config?.walletConnectProjectId,
   };
+  const [accounts, setAccounts] = useState<Wallet[]>([]);
   const { providers } = useWalletProviders(props.config.wallets, walletOptions);
   const { connectWallet, disconnectWallet } = useWalletsStore();
   const onConnectWalletHandler = useRef<OnConnectHandler>();
@@ -66,7 +68,7 @@ function Main(props: PropsWithChildren<PropTypes>) {
           supportedChainNames,
           meta.isContractWallet
         );
-        connectWallet(data, tokens);
+        setAccounts(data);
       } else {
         disconnectWallet(type);
       }
@@ -99,6 +101,13 @@ function Main(props: PropsWithChildren<PropTypes>) {
       props.onUpdateState(type, event, value, state, meta);
     }
   };
+
+  useEffect(() => {
+    if (accounts.length) {
+      connectWallet(accounts, tokens);
+    }
+  }, [accounts, tokens]);
+
   return (
     <WidgetContext.Provider
       // eslint-disable-next-line react/jsx-no-constructed-context-values


### PR DESCRIPTION
# Summary

This pull request resolves the issue where the 'accountChanged' event fires twice in wallets like Metamask when we change the accounts, causing duplicate server requests for walletDetails.

To reproduce (for example in https://widget.rango.exchange/) by switching MetaMask accounts, observe multiple server requests for balance and account information.
[Screencast](https://github.com/rango-exchange/rango-client/assets/123297941/ce9dc26f-cd9b-4b8d-82f9-b91d6582b611)


Fixes # (issue)


# How did you test this change?

I added cleanup functions in both wallets/core and providers. I tested all wallets. For those without "off" events, I returned `void` during cleanup. The testing procedure ensured that changing the account triggers a single server request.




# Checklist:

- [x] I have performed a self-review of my code
