### PR TITLE
feat: add default injected wallet

### DIFF
--- a/wallets/provider-all/package.json
+++ b/wallets/provider-all/package.json
@@ -29,6 +29,7 @@
     "@rango-dev/provider-coin98": "^0.26.0",
     "@rango-dev/provider-coinbase": "^0.25.0",
     "@rango-dev/provider-cosmostation": "^0.25.0",
+    "@rango-dev/provider-default": "^0.22.0",
     "@rango-dev/provider-enkrypt": "^0.25.0",
     "@rango-dev/provider-exodus": "^0.25.0",
     "@rango-dev/provider-frontier": "^0.25.0",

--- a/wallets/provider-all/src/index.ts
+++ b/wallets/provider-all/src/index.ts
@@ -6,6 +6,7 @@ import * as clover from '@rango-dev/provider-clover';
 import * as coin98 from '@rango-dev/provider-coin98';
 import * as coinbase from '@rango-dev/provider-coinbase';
 import * as cosmostation from '@rango-dev/provider-cosmostation';
+import * as defaultInjected from '@rango-dev/provider-default';
 import * as enkrypt from '@rango-dev/provider-enkrypt';
 import * as exodus from '@rango-dev/provider-exodus';
 import * as frontier from '@rango-dev/provider-frontier';
@@ -32,6 +33,7 @@ export const allProviders = (enviroments?: Enviroments) => {
 
   return [
     safe,
+    defaultInjected,
     metamask,
     walletconnect2,
     keplr,

--- a/wallets/provider-default/package.json
+++ b/wallets/provider-default/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@rango-dev/provider-default",
+  "version": "0.22.0",
+  "license": "MIT",
+  "type": "module",
+  "source": "./src/index.ts",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-default",
+    "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
+    "clean": "rimraf dist",
+    "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",
+    "lint": "eslint \"**/*.{ts,tsx}\" --ignore-path ../../.eslintignore"
+  },
+  "dependencies": {
+    "@rango-dev/signer-evm": "^0.25.0",
+    "@rango-dev/wallets-shared": "^0.25.0",
+    "rango-types": "^0.1.57"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/wallets/provider-default/readme.md
+++ b/wallets/provider-default/readme.md
@@ -1,0 +1,1 @@
+# @rango-dev/provider-default

--- a/wallets/provider-default/src/helpers.ts
+++ b/wallets/provider-default/src/helpers.ts
@@ -1,0 +1,4 @@
+export function defaultInjected() {
+  const { ethereum } = window;
+  return ethereum ?? null;
+}

--- a/wallets/provider-default/src/index.ts
+++ b/wallets/provider-default/src/index.ts
@@ -1,0 +1,69 @@
+import type {
+  CanEagerConnect,
+  CanSwitchNetwork,
+  Connect,
+  Subscribe,
+  SwitchNetwork,
+  WalletInfo,
+} from '@rango-dev/wallets-shared';
+import type { BlockchainMeta, SignerFactory } from 'rango-types';
+
+import {
+  canEagerlyConnectToEvm,
+  canSwitchNetworkToEvm,
+  getEvmAccounts,
+  subscribeToEvm,
+  switchNetworkForEvm,
+  WalletTypes,
+} from '@rango-dev/wallets-shared';
+import { evmBlockchains } from 'rango-types';
+
+import { defaultInjected } from './helpers';
+import signer from './signer';
+
+const WALLET = WalletTypes.DEFAULT;
+
+export const config = {
+  type: WALLET,
+};
+
+export const getInstance = defaultInjected;
+export const connect: Connect = async ({ instance }) => {
+  /*
+   * Note: We need to get `chainId` here, because for the first time
+   * after opening the browser, wallet is locked, and don't give us accounts and chainId
+   * on `check` phase, so `network` will be null. For this case we need to get chainId
+   * whenever we are requesting accounts.
+   */
+  const { accounts, chainId } = await getEvmAccounts(instance);
+
+  return {
+    accounts,
+    chainId,
+  };
+};
+
+export const subscribe: Subscribe = subscribeToEvm;
+
+export const switchNetwork: SwitchNetwork = switchNetworkForEvm;
+
+export const canSwitchNetworkTo: CanSwitchNetwork = canSwitchNetworkToEvm;
+
+export const getSigners: (provider: any) => SignerFactory = signer;
+
+export const canEagerConnect: CanEagerConnect = canEagerlyConnectToEvm;
+
+export const getWalletInfo: (allBlockChains: BlockchainMeta[]) => WalletInfo = (
+  allBlockChains
+) => {
+  const evms = evmBlockchains(allBlockChains);
+  return {
+    name: 'Default',
+    img: 'https://raw.githubusercontent.com/rango-exchange/assets/main/wallets/default/icon.svg',
+    installLink: {
+      DEFAULT: 'https://metamask.io/download/',
+    },
+    color: '#dac7ae',
+    supportedChains: evms,
+  };
+};

--- a/wallets/provider-default/src/signer.ts
+++ b/wallets/provider-default/src/signer.ts
@@ -1,0 +1,10 @@
+import type { SignerFactory } from 'rango-types';
+
+import { DefaultEvmSigner } from '@rango-dev/signer-evm';
+import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
+
+export default function getSigners(provider: any): SignerFactory {
+  const signers = new DefaultSignerFactory();
+  signers.registerSigner(TxType.EVM, new DefaultEvmSigner(provider));
+  return signers;
+}

--- a/wallets/provider-default/tsconfig.json
+++ b/wallets/provider-default/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
+  "extends": "../../tsconfig.lib.json",
+  "include": ["src", "types", "../../global-wallets-env.d.ts"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./src",
+    "lib": ["dom", "esnext"]
+    // match output dir to input dir. e.g. dist/index instead of dist/src/index
+  }
+}

--- a/wallets/shared/src/rango.ts
+++ b/wallets/shared/src/rango.ts
@@ -49,6 +49,7 @@ export type WalletType = string;
 export type Network = string;
 
 export enum WalletTypes {
+  DEFAULT = 'default',
   META_MASK = 'metamask',
   WALLET_CONNECT_2 = 'wallet-connect-2',
   TRUST_WALLET = 'trust-wallet',


### PR DESCRIPTION
# Summary

Many dApps show a default injected wallet, so users could connect to that even their wallet is not supported by the dApp explicitly (as almost all wallets implemented same api)


# How did you test this change?

- [x] You could install an evm wallet which is not supported by Rango and disable other user wallet. You should see a default wallet and could connect to it without problem.


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
