### PR TITLE
fix: correct item picker style

### DIFF
--- a/widget/playground/src/components/ItemPicker/ItemPicker.styles.ts
+++ b/widget/playground/src/components/ItemPicker/ItemPicker.styles.ts
@@ -33,6 +33,7 @@ export const InputContainer = styled('div', {
 export const Container = styled('div', {
   display: 'flex',
   flexDirection: 'column',
+  width: '100%',
 });
 
 export const Title = styled('div', {


### PR DESCRIPTION
# Summary

After modifying the styles of the tooltip component, the default token style in the playground was affected. This pull request addresses the issue and ensures consistent styling.

# Checklist:

- [x] I have performed a self-review of my code
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
