### PR TITLE
feat: add transition for tabs

### DIFF
--- a/widget/playground/src/components/ExportConfigModal/ExportConfigModal.styles.tsx
+++ b/widget/playground/src/components/ExportConfigModal/ExportConfigModal.styles.tsx
@@ -19,6 +19,7 @@ export const ButtonsContainer = styled('div', {
   justifyItems: 'center',
   alignItems: 'center',
   backgroundColor: '$neutral300',
+  position: 'relative',
 });
 
 export const ModalFlex = styled('div', {
@@ -47,15 +48,27 @@ export const StyledButton = styled(Button, {
     },
     type: {
       secondary: {
+        zIndex: 10,
+        transition: 'color 0.8s linear',
         color: '$background',
-        backgroundColor: '$secondary500',
+        backgroundColor: 'transparent',
         '&:hover, &:focus': {
           color: '$background',
-          backgroundColor: '$secondary500',
+          backgroundColor: 'transparent',
         },
       },
     },
   },
+});
+
+export const BackdropTab = styled('div', {
+  width: '362px',
+  height: '$40',
+  backgroundColor: '$secondary500',
+  position: 'absolute',
+  borderRadius: '$xm',
+  inset: 0,
+  transition: 'transform 0.5s ease-in-out',
 });
 
 export const LinkContainer = styled('div', {

--- a/widget/playground/src/components/ExportConfigModal/ExportConfigModal.tsx
+++ b/widget/playground/src/components/ExportConfigModal/ExportConfigModal.tsx
@@ -25,6 +25,7 @@ import { filterConfig, formatConfig } from '../../utils/export';
 import { CodeBlock } from './CodeBlock';
 import {
   APIKeyInputContainer,
+  BackdropTab,
   ButtonsContainer,
   ExternalLinkIconContainer,
   Head,
@@ -37,11 +38,14 @@ import {
 } from './ExportConfigModal.styles';
 import { typesOfCodeBlocks } from './ExportConfigModal.types';
 
+const TAB_WIDTH = 333;
+
 export function ExportConfigModal(props: ExportConfigModalProps) {
   const { open, onClose, config } = props;
 
   const { activeTheme } = useTheme();
   const [selected, setSelected] = useState<ExportType>('embedded');
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const syntaxHighlighterTheme = activeTheme === 'dark' ? dark : prism;
   const { filteredConfigForExport } = filterConfig(config, initialConfig);
   const formatedConfig = formatConfig(filteredConfigForExport);
@@ -126,14 +130,23 @@ export function ExportConfigModal(props: ExportConfigModalProps) {
             <Fragment key={key}>
               <StyledButton
                 size="medium"
-                variant="contained"
+                disableRipple={true}
                 type={selected === type ? 'secondary' : undefined}
-                onClick={() => setSelected(type as ExportType)}>
+                variant={selected !== type ? 'contained' : undefined}
+                onClick={() => {
+                  setSelectedIndex(index);
+                  setSelected(type as ExportType);
+                }}>
                 {type}
               </StyledButton>
             </Fragment>
           );
         })}
+        <BackdropTab
+          css={{
+            transform: `translateX(${TAB_WIDTH * selectedIndex}px)`,
+          }}
+        />
       </ButtonsContainer>
       <Divider size={12} />
       <CodeBlock

--- a/widget/playground/src/components/SideNavigation/SideNavigation.Tabs.tsx
+++ b/widget/playground/src/components/SideNavigation/SideNavigation.Tabs.tsx
@@ -1,29 +1,44 @@
 import type { TabPropTypes } from './SideNavigation.types';
+import type { SIDE_TABS_IDS } from '../../constants';
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Indicator, Tab, TabsContainer } from './SideNavigation.styles';
 
+const TAB_HEIGHT = 95;
 const Tabs = (props: TabPropTypes) => {
   const { variant = 'vertical', tabs, onChange, activeLayout } = props;
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const handleTabClick = (tabId: SIDE_TABS_IDS, index: number) => {
+    onChange(tabId);
+    setActiveIndex(index);
+  };
 
   return (
     <TabsContainer>
       {variant === 'vertical' &&
-        tabs.map((tab) => {
+        tabs.map((tab, index) => {
           const isActive = activeLayout === tab.id;
           const disabled = tab.disabled;
           return (
             <Tab
               key={tab.title}
               disabled={disabled}
-              active={isActive}
-              onClick={!disabled ? () => onChange(tab.id) : undefined}>
+              onClick={
+                !disabled && !isActive
+                  ? () => handleTabClick(tab.id, index)
+                  : undefined
+              }>
               {tab.content}
-              {isActive && <Indicator />}
             </Tab>
           );
         })}
+      <Indicator
+        css={{
+          transform: `translateY(${activeIndex * TAB_HEIGHT}px)`,
+        }}
+      />
     </TabsContainer>
     // TODO: check horizontal tab
   );

--- a/widget/playground/src/components/SideNavigation/SideNavigation.styles.ts
+++ b/widget/playground/src/components/SideNavigation/SideNavigation.styles.ts
@@ -40,11 +40,6 @@ export const Tab = styled(Flex, {
         },
       },
     },
-    active: {
-      true: {
-        position: 'relative',
-      },
-    },
   },
   '&:hover': {
     backgroundColor: '$neutral200',
@@ -54,15 +49,17 @@ export const Tab = styled(Flex, {
 export const Indicator = styled('div', {
   width: '7px',
   height: '64px',
-  borderRadius: '20px 0 0 20px',
+  borderRadius: '0 20px 20px 0',
   backgroundColor: '$secondary500',
   position: 'absolute',
-  transform: 'rotate(180deg)',
+  transition: 'transform 0.4s ease-in-out',
   left: 0,
+  top: 20,
 });
 
 export const TabsContainer = styled(Flex, {
   flexDirection: 'column',
+  position: 'relative',
   width: '100%',
 });
 

--- a/widget/playground/src/containers/StyleLayout/StyleLayout.Themes.tsx
+++ b/widget/playground/src/containers/StyleLayout/StyleLayout.Themes.tsx
@@ -1,12 +1,12 @@
-import type { Mode } from '../../store/config';
-
 import { ColorsIcon, Divider, Typography } from '@rango-dev/ui';
 import React, { useState } from 'react';
 
 import { TABS } from '../../constants';
+import { type Mode } from '../../store/config';
 
 import { Preset } from './StyleLayout.Preset';
 import {
+  BackdropTab,
   Field,
   FieldTitle,
   GeneralContainer,
@@ -14,28 +14,37 @@ import {
   Tabs,
 } from './StyleLayout.styles';
 
+const TAB_WIDTH = 80;
 export function Themes() {
   const [tab, setTab] = useState<Mode>('auto');
-
+  const currentTabIndex = TABS.findIndex((mode) => mode.id === tab);
   const onChangeMode = (mode: Mode) => {
     setTab(mode);
   };
+
   return (
     <>
       <GeneralContainer>
         <Field>
           <Tabs>
-            {TABS.map((item) => (
+            {TABS.map((item, index) => (
               <Tab
                 fullWidth
                 key={item.id}
+                disableRipple={true}
                 type="secondary"
                 onClick={() => onChangeMode(item.id)}
                 size="small"
-                variant={item.id === tab ? 'contained' : 'default'}>
+                isActive={index === currentTabIndex}
+                variant="default">
                 {item.title}
               </Tab>
             ))}
+            <BackdropTab
+              css={{
+                transform: `translateX(${TAB_WIDTH * currentTabIndex}px)`,
+              }}
+            />
           </Tabs>
           <Divider size={16} />
 

--- a/widget/playground/src/containers/StyleLayout/StyleLayout.styles.ts
+++ b/widget/playground/src/containers/StyleLayout/StyleLayout.styles.ts
@@ -1,4 +1,4 @@
-import { Button, Collapsible, styled } from '@rango-dev/ui';
+import { Button, Collapsible, darkTheme, styled } from '@rango-dev/ui';
 
 export const Layout = styled('div', {
   borderRadius: '20px',
@@ -34,15 +34,46 @@ export const Tabs = styled('div', {
   display: 'flex',
   border: '3px solid $neutral100',
   flexDirection: 'row',
+  position: 'relative',
 });
 
 export const Tab = styled(Button, {
   color: '$neutral700',
   backgroundColor: 'transparent',
-  '&:hover': {
-    backgroundColor: '$info100',
-    color: '$secondary500',
+  zIndex: 10,
+  variants: {
+    isActive: {
+      true: {
+        transition: 'color 0.8s linear',
+        $$color: '$colors$background',
+        [`.${darkTheme} &`]: {
+          color: '$colors$foreground',
+        },
+        color: '$$color',
+      },
+      false: {
+        '&:hover': {
+          backgroundColor: '$info100',
+          color: '$secondary500',
+          [`.${darkTheme} &`]: {
+            backgroundColor: 'transparent',
+            color: '$neutral700',
+          },
+        },
+      },
+    },
   },
+});
+
+export const BackdropTab = styled('div', {
+  width: '80px',
+  height: '$28',
+  padding: '$4',
+  backgroundColor: '$secondary500',
+  position: 'absolute',
+  borderRadius: '$md',
+  inset: 0,
+  transition: 'transform 0.5s cubic-bezier(0, 0, 0.86, 1.2)',
 });
 
 export const PresetContent = styled('div', {

--- a/widget/ui/src/components/Button/Button.tsx
+++ b/widget/ui/src/components/Button/Button.tsx
@@ -16,8 +16,11 @@ function ButtonComponent(props: PropsWithChildren<PropTypes>, ref?: Ref) {
     prefix,
     suffix,
     onClick,
+    disableRipple,
     ...otherProps
   } = props;
+
+  const shouldShowRipple = !disabled && !loading && !disableRipple;
 
   return (
     <ButtonBase
@@ -38,7 +41,7 @@ function ButtonComponent(props: PropsWithChildren<PropTypes>, ref?: Ref) {
           {suffix}
         </>
       )}
-      {!disabled && !loading && <Ripple />}
+      {shouldShowRipple && <Ripple />}
     </ButtonBase>
   );
 }

--- a/widget/ui/src/components/Button/Button.types.tsx
+++ b/widget/ui/src/components/Button/Button.types.tsx
@@ -24,4 +24,5 @@ export type PropTypes = ButtonElement & {
   prefix?: React.ReactNode;
   suffix?: React.ReactNode;
   fullWidth?: boolean;
+  disableRipple?: boolean;
 };


### PR DESCRIPTION
# Summary

Implemented a smooth transition for tab-switching for both the LeftNavigation Tabs indicator and the background of the themes tab. 

# How did you test this change?
Switching tabs in LeftNavigation and themes should have a smooth transition.


# Checklist:

- [x] I have performed a self-review of my code
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
