### PR TITLE
hotfix: fix starknet signer problem

### DIFF
--- a/signers/signer-starknet/src/signer.ts
+++ b/signers/signer-starknet/src/signer.ts
@@ -2,8 +2,10 @@ import type { GenericSigner, StarknetTransaction } from 'rango-types';
 
 import { SignerError, SignerErrorCode } from 'rango-types';
 
-// TODO - replace with real type
-// tslint:disable-next-line: no-any
+/*
+ * TODO - replace with real type
+ * tslint:disable-next-line: no-any
+ */
 type StarknetExternalProvider = any;
 
 export class DefaultStarknetSigner
@@ -21,6 +23,7 @@ export class DefaultStarknetSigner
 
   async signAndSendTx(tx: StarknetTransaction): Promise<{ hash: string }> {
     try {
+      await this.provider.enable();
       const { transaction_hash } = await this.provider.account.execute(
         tx.calls
       );


### PR DESCRIPTION
# Summary

We frequently faced this error: `Cannot read properties of undefined (reading 'execute')` in production when users are trying to sign starknet transactions.


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Send a transaction in starknet using argentx or braavos


# Checklist:

- [x] I have performed a self-review of my code
