### PR TITLE
fix: reset the quote when the source token matches the destination token

### DIFF
--- a/widget/embedded/src/components/HeaderButtons/HeaderButtons.types.ts
+++ b/widget/embedded/src/components/HeaderButtons/HeaderButtons.types.ts
@@ -8,5 +8,4 @@ export interface HomeButtonsPropTypes {
   onClickRefresh?: () => void;
   onClickHistory?: () => void;
   onClickSettings?: () => void;
-  onClickNotifications?: () => void;
 }

--- a/widget/embedded/src/components/HeaderButtons/HomeButtons.tsx
+++ b/widget/embedded/src/components/HeaderButtons/HomeButtons.tsx
@@ -20,13 +20,7 @@ import { HeaderButton } from './HeaderButtons.styles';
 import { UnreadNotificationsBadge } from './UnreadNotificationsBadge';
 
 export function HomeButtons(props: HomeButtonsPropTypes) {
-  const {
-    layoutRef,
-    onClickRefresh,
-    onClickHistory,
-    onClickSettings,
-    onClickNotifications,
-  } = props;
+  const { layoutRef, onClickRefresh, onClickHistory, onClickSettings } = props;
 
   const {
     config: { features },
@@ -50,25 +44,24 @@ export function HomeButtons(props: HomeButtonsPropTypes) {
       </Tooltip>
 
       {!isNotificationsHidden && (
-        <Tooltip
+        <Popover
+          align="center"
+          collisionBoundary={layoutRef}
+          collisionPadding={{ right: 20, left: 20 }}
           container={getContainer()}
-          side="top"
-          content={i18n.t('Notifications')}>
-          <Popover
-            align="center"
-            collisionBoundary={layoutRef}
-            collisionPadding={{ right: 20, left: 20 }}
-            container={getContainer()}
-            content={<NotificationContent />}>
-            <HeaderButton
-              size="small"
-              variant="ghost"
-              onClick={onClickNotifications}>
-              <NotificationsIcon size={18} color="black" />
-              <UnreadNotificationsBadge />
-            </HeaderButton>
-          </Popover>
-        </Tooltip>
+          content={<NotificationContent />}>
+          <div>
+            <Tooltip
+              container={getContainer()}
+              side="top"
+              content={i18n.t('Notifications')}>
+              <HeaderButton size="small" variant="ghost">
+                <NotificationsIcon size={18} color="black" />
+                <UnreadNotificationsBadge />
+              </HeaderButton>
+            </Tooltip>
+          </div>
+        </Popover>
       )}
       <Tooltip
         container={getContainer()}

--- a/widget/embedded/src/hooks/useSwapInput.ts
+++ b/widget/embedded/src/hooks/useSwapInput.ts
@@ -48,6 +48,7 @@ export function useSwapInput(): UseSwapInput {
     toToken,
     inputAmount,
     inputUsdValue,
+    quote,
     resetQuote,
     setQuote,
   } = useQuoteStore();
@@ -63,9 +64,9 @@ export function useSwapInput(): UseSwapInput {
   const [error, setError] = useState<QuoteError | null>(null);
   const [warning, setWarning] = useState<QuoteWarning | null>(null);
   const userSlippage = customSlippage ?? slippage;
-  const hasTokensValue = !fromToken || !toToken;
+  const tokensValueInvalid = !fromToken || !toToken;
   const shouldSkipRequest =
-    hasTokensValue ||
+    tokensValueInvalid ||
     tokensAreEqual(fromToken, toToken) ||
     !isPositiveNumber(inputAmount);
 
@@ -153,6 +154,9 @@ export function useSwapInput(): UseSwapInput {
       return;
     }
     if (shouldSkipRequest) {
+      if (quote) {
+        resetQuote();
+      }
       return;
     }
     resetQuote();


### PR DESCRIPTION
# Summary

On the home page, if we have a quote and set the source and destination tokens to be the same, it disrupts the state, and the user can navigate to the "confirm-swap" page. Additionally, on the home page, when hovering over the "notifications" button and clicking on it, as long as the notification popover is open, the notification tooltip is visible.

Fixes # (issue)

Resetting the quote state when tokens are identical.
Removing the popover component from within the notification tooltip.

# Checklist:

- [x] I have performed a self-review of my code
