### PR TITLE
fix: address some minor bugs in swapHistory & wallet page loading

### DIFF
--- a/widget/embedded/src/components/Slippage/Slippage.tsx
+++ b/widget/embedded/src/components/Slippage/Slippage.tsx
@@ -72,12 +72,12 @@ export function Slippage() {
           value={customSlippage || ''}
           color="dark"
           onChange={(event) => {
-            const parsedValue = parseFloat(event.target.value);
-            if (
-              !parsedValue ||
-              (parsedValue >= MIN_SLIPPGAE && parsedValue <= MAX_SLIPPAGE)
-            ) {
+            const value = event.target.value;
+            const parsedValue = parseFloat(value);
+            if (parsedValue >= MIN_SLIPPGAE && parsedValue <= MAX_SLIPPAGE) {
               setCustomSlippage(parsedValue);
+            } else {
+              setCustomSlippage(null);
             }
           }}
           suffix={

--- a/widget/embedded/src/components/SwapsGroup/SwapsGroup.tsx
+++ b/widget/embedded/src/components/SwapsGroup/SwapsGroup.tsx
@@ -4,6 +4,10 @@ import { i18n } from '@lingui/core';
 import { Divider, SwapListItem, Typography } from '@rango-dev/ui';
 import React from 'react';
 
+import {
+  TOKEN_AMOUNT_MAX_DECIMALS,
+  TOKEN_AMOUNT_MIN_DECIMALS,
+} from '../../constants/routing';
 import { getContainer } from '../../utils/common';
 import { formatTooltipNumbers, numberToString } from '../../utils/numbers';
 
@@ -96,7 +100,12 @@ export function SwapsGroup(props: PropTypes) {
                             blockchain: {
                               image: firstStep.fromBlockchainLogo || '',
                             },
-                            amount: swap.inputAmount,
+                            amount: numberToString(
+                              swap.inputAmount,
+                              TOKEN_AMOUNT_MIN_DECIMALS,
+                              TOKEN_AMOUNT_MAX_DECIMALS
+                            ),
+                            realAmount: formatTooltipNumbers(swap.inputAmount),
                           },
                           to: {
                             token: {
@@ -109,7 +118,9 @@ export function SwapsGroup(props: PropTypes) {
                             amount: numberToString(
                               lastStep.outputAmount ||
                                 lastStep.expectedOutputAmountHumanReadable ||
-                                ''
+                                '',
+                              TOKEN_AMOUNT_MIN_DECIMALS,
+                              TOKEN_AMOUNT_MAX_DECIMALS
                             ),
                             realAmount: formatTooltipNumbers(
                               lastStep.outputAmount ||

--- a/widget/ui/src/components/SwapListItem/SwapListItem.types.ts
+++ b/widget/ui/src/components/SwapListItem/SwapListItem.types.ts
@@ -32,6 +32,7 @@ export interface SwapTokenData {
       image: string;
     };
     amount: string;
+    realAmount: string;
   };
 
   to: {

--- a/widget/ui/src/components/SwapListItem/SwapToken.tsx
+++ b/widget/ui/src/components/SwapListItem/SwapToken.tsx
@@ -71,12 +71,13 @@ export function SwapToken(props: PropTypes) {
         token: fromToken,
         amount: fromAmount,
         blockchain: fromBlockchain,
+        realAmount: fromRealAmount,
       },
       to: {
         token: toToken,
         amount: toAmount,
         blockchain: toBlockchain,
-        realAmount,
+        realAmount: toRealAmount,
       },
     },
     status,
@@ -128,7 +129,7 @@ export function SwapToken(props: PropTypes) {
               {fromToken.displayName}
             </Typography>
             {!!fromAmount && (
-              <Tooltip content={fromAmount} container={tooltipContainer}>
+              <Tooltip content={fromRealAmount} container={tooltipContainer}>
                 <Typography size="small" variant="body" color="neutral700">
                   {fromAmount}
                 </Typography>
@@ -142,7 +143,7 @@ export function SwapToken(props: PropTypes) {
             <Typography size="medium" variant="title">
               {toToken.displayName}
             </Typography>
-            <Tooltip content={realAmount} container={tooltipContainer}>
+            <Tooltip content={toRealAmount} container={tooltipContainer}>
               <Typography size="small" variant="body" color="neutral700">
                 {toAmount}
               </Typography>

--- a/widget/ui/src/components/Wallet/Wallet.styles.ts
+++ b/widget/ui/src/components/Wallet/Wallet.styles.ts
@@ -72,5 +72,5 @@ export const LoadingButton = styled('div', {
   backgroundColor: '$neutral100',
   alignItems: 'center',
   justifyContent: 'center',
-  width: 110,
+  width: 100,
 });


### PR DESCRIPTION
# Summary

Some minor bugs should be resolved.

Fixes # (issue)


# How did you test this change?

- [x] Wallets page loading should have a three-column layout
- [x] The amounts in the swap history page are too precise (should be rounded).
- [x] when custom slippage is empty, slippage property in best route gets NaN.


# Checklist:

- [x] I have performed a self-review of my code
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
