### PR TITLE
feat: for long routes, we should show a shorter version and hide the rest in a button.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.validate": [
     "javascript",

--- a/widget/embedded/src/components/Quote/Quote.styles.ts
+++ b/widget/embedded/src/components/Quote/Quote.styles.ts
@@ -114,6 +114,15 @@ export const summaryStyles = css({
   cursor: 'default',
 });
 
+export const rowStyles = css({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'center',
+  alignItems: 'center',
+  '.blockchainImage': {
+    marginLeft: '-$8',
+  },
+});
 export const basicInfoStyles = css({
   paddingTop: '$10',
   display: 'flex',
@@ -127,7 +136,7 @@ export const basicInfoStyles = css({
   },
 });
 
-export const Chains = styled(Collapsible.Trigger, {
+export const Trigger = styled(Collapsible.Trigger, {
   display: 'flex',
   width: '100%',
   justifyContent: 'space-between',
@@ -171,17 +180,27 @@ export const Chains = styled(Collapsible.Trigger, {
       },
     },
   },
-  '& div:nth-child(1)': { display: 'flex' },
+  '.blockchains_section': {
+    display: 'none',
+  },
+  '@xs': {
+    '.blockchains_section': {
+      display: 'block',
+    },
+  },
 });
 
-export const ChainImageContainer = styled('div', {
+export const ImageContainer = styled('div', {
   width: '18px',
   height: '18px',
   borderRadius: '100%',
-  border: '1.5px transparent solid',
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
+  border: '1.5px transparent solid',
+  img: {
+    borderRadius: '100%',
+  },
   variants: {
     state: {
       error: {
@@ -251,4 +270,24 @@ export const BasicInfoOutput = styled(Typography, {
 export const ContainerInfoOutput = styled('div', {
   display: 'flex',
   flexWrap: 'wrap',
+});
+
+export const MoreStep = styled('div', {
+  width: '18px',
+  height: '18px',
+  borderRadius: '100%',
+  backgroundColor: '$background',
+  cursor: 'default',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  border: '1.5px transparent solid',
+  variants: {
+    state: {
+      error: {
+        borderColor: '$error500',
+      },
+      warning: { borderColor: '$warning500' },
+    },
+  },
 });

--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -5,10 +5,7 @@ import type { SwapResult } from 'rango-sdk';
 import { i18n } from '@lingui/core';
 import {
   Alert,
-  ChevronDownIcon,
-  ChevronRightIcon,
   Divider,
-  Image,
   InfoIcon,
   QuoteCost,
   StepDetails,
@@ -52,20 +49,18 @@ import { getTotalFeeInUsd } from '../../utils/swap';
 import {
   BasicInfoOutput,
   basicInfoStyles,
-  ChainImageContainer,
-  Chains,
   ContainerInfoOutput,
   Content,
   EXPANDABLE_QUOTE_TRANSITION_DURATION,
   FrameIcon,
   HorizontalSeparator,
-  IconContainer,
   QuoteContainer,
   stepsDetailsStyles,
   SummaryContainer,
   summaryStyles,
 } from './Quote.styles';
 import { QuoteSummary } from './QuoteSummary';
+import { QuoteTrigger } from './QuoteTrigger ';
 
 export function Quote(props: QuoteProps) {
   const {
@@ -374,59 +369,13 @@ export function Quote(props: QuoteProps) {
           recommended={recommended}
           open={expanded}
           onOpenChange={setExpanded}>
-          <Chains
-            ref={(ref) => (quoteRef.current = ref)}
+          <QuoteTrigger
+            quoteRef={quoteRef}
             recommended={recommended}
-            onClick={() => setExpanded((prevState) => !prevState)}>
-            <div>
-              {steps.map((step, index) => {
-                const key = `item-${index}`;
-                const arrow = (
-                  <IconContainer>
-                    <ChevronRightIcon
-                      size={12}
-                      color="black"
-                      {...(step.state && {
-                        color: step.state === 'error' ? 'error' : 'warning',
-                      })}
-                    />
-                  </IconContainer>
-                );
-                return (
-                  <React.Fragment key={key}>
-                    <Tooltip
-                      container={tooltipContainer}
-                      side="bottom"
-                      sideOffset={4}
-                      content={step.from.chain.displayName}>
-                      <ChainImageContainer
-                        state={step.state || steps[index - 1]?.state}>
-                        <Image src={step.from.chain.image} size={16} />
-                      </ChainImageContainer>
-                    </Tooltip>
-                    {index === numberOfSteps - 1 && (
-                      <>
-                        {arrow}
-                        <Tooltip
-                          container={tooltipContainer}
-                          side="bottom"
-                          sideOffset={4}
-                          content={step.to.chain.displayName}>
-                          <ChainImageContainer state={step.state}>
-                            <Image src={step.to.chain.image} size={16} />
-                          </ChainImageContainer>
-                        </Tooltip>
-                      </>
-                    )}
-                    {index !== numberOfSteps - 1 && <>{arrow}</>}
-                  </React.Fragment>
-                );
-              })}
-            </div>
-            <IconContainer orientation={expanded ? 'up' : 'down'}>
-              <ChevronDownIcon size={12} color="black" />
-            </IconContainer>
-          </Chains>
+            setExpanded={setExpanded}
+            expanded={expanded}
+            steps={steps}
+          />
           <Content open={expanded}>
             <HorizontalSeparator />
             <div className={stepsDetailsStyles()}>

--- a/widget/embedded/src/components/Quote/Quote.types.ts
+++ b/widget/embedded/src/components/Quote/Quote.types.ts
@@ -1,4 +1,5 @@
 import type { QuoteError, QuoteWarning } from '../../types';
+import type { Step } from '@rango-dev/ui';
 import type { BestRouteResponse } from 'rango-sdk';
 import type { ReactNode } from 'react';
 
@@ -12,4 +13,20 @@ export type QuoteProps = {
   input: { value: string; usdValue: string };
   output: { value: string; usdValue?: string };
   expanded?: boolean;
+};
+
+export type QuoteTriggerProps = {
+  quoteRef: React.MutableRefObject<HTMLButtonElement | null>;
+  recommended: boolean;
+  setExpanded: React.Dispatch<React.SetStateAction<boolean | undefined>>;
+  steps: Step[];
+  expanded?: boolean;
+};
+
+export type QuoteTriggerImagesProps = {
+  content: ReactNode;
+  state?: 'error' | 'warning' | undefined;
+  src: string;
+  open?: boolean;
+  className?: string;
 };

--- a/widget/embedded/src/components/Quote/QuoteTrigger .tsx
+++ b/widget/embedded/src/components/Quote/QuoteTrigger .tsx
@@ -1,0 +1,215 @@
+import type { QuoteTriggerImagesProps, QuoteTriggerProps } from './Quote.types';
+
+import { i18n } from '@lingui/core';
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  Divider,
+  Image,
+  Tooltip,
+  Typography,
+} from '@rango-dev/ui';
+import React, { useEffect, useState } from 'react';
+
+import { getContainer } from '../../utils/common';
+import { getUniqueBlockchains } from '../../utils/quote';
+
+import {
+  IconContainer,
+  ImageContainer,
+  MoreStep,
+  rowStyles,
+  Trigger,
+} from './Quote.styles';
+
+const MAX_STEPS = 4;
+const MAX_BLOCKCHAINS = 6;
+const MIN_WIDTH_WINDOW = 375;
+
+const ImageComponent = (props: QuoteTriggerImagesProps) => {
+  const tooltipContainer = getContainer();
+  const { content, src, className, open, state } = props;
+  return (
+    <Tooltip
+      container={tooltipContainer}
+      side="bottom"
+      sideOffset={4}
+      open={open}
+      content={content}>
+      <ImageContainer className={className} state={state}>
+        <Image src={src} size={16} />
+      </ImageContainer>
+    </Tooltip>
+  );
+};
+
+export function QuoteTrigger(props: QuoteTriggerProps) {
+  const { quoteRef, recommended, setExpanded, steps, expanded } = props;
+  const tooltipContainer = getContainer();
+  const numberOfSteps = steps.length;
+  const blockchains = getUniqueBlockchains(steps);
+  const [isMobile, setIsMobile] = useState(false);
+
+  //choose the screen size
+  const handleResize = () => {
+    if (window.innerWidth < MIN_WIDTH_WINDOW) {
+      setIsMobile(true);
+    } else {
+      setIsMobile(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('resize', handleResize);
+  });
+
+  return (
+    <Trigger
+      ref={(ref) => (quoteRef.current = ref)}
+      recommended={recommended}
+      onClick={() => setExpanded((prevState) => !prevState)}>
+      <div className={rowStyles()}>
+        <Typography variant="body" size="xsmall">
+          {i18n.t('Via:')}
+        </Typography>
+        <Divider direction="horizontal" size={4} />
+        {steps.map((step, index) => {
+          const key = `item-${index}`;
+          const arrow = (
+            <IconContainer>
+              <ChevronRightIcon size={12} color="black" />
+            </IconContainer>
+          );
+
+          return isMobile ? (
+            <>
+              <ImageComponent
+                content={step.swapper.displayName}
+                src={step.swapper.image}
+                state={step.state}
+              />
+              {index !== numberOfSteps - 1 && <>{arrow}</>}
+            </>
+          ) : (
+            <React.Fragment key={key}>
+              {numberOfSteps <= MAX_STEPS ||
+              (numberOfSteps > MAX_STEPS && index < MAX_STEPS - 1) ? (
+                <>
+                  <ImageComponent
+                    content={step.swapper.displayName}
+                    src={step.swapper.image}
+                    state={step.state}
+                  />
+                  {index !== numberOfSteps - 1 && <>{arrow}</>}
+                </>
+              ) : (
+                index === MAX_STEPS - 1 && (
+                  <Tooltip
+                    container={tooltipContainer}
+                    side="bottom"
+                    align="right"
+                    sideOffset={4}
+                    content={
+                      <div className={rowStyles()}>
+                        {arrow}
+                        {steps.map((step, i) => {
+                          const key = `image-${i}`;
+                          return (
+                            i >= index && (
+                              <React.Fragment key={key}>
+                                <ImageComponent
+                                  content={step.swapper.displayName}
+                                  src={step.swapper.image}
+                                  state={step.state}
+                                  open={false}
+                                />
+                                {i !== numberOfSteps - 1 && <>{arrow}</>}
+                              </React.Fragment>
+                            )
+                          );
+                        })}
+                      </div>
+                    }>
+                    <MoreStep
+                      state={
+                        steps.find(
+                          (step, i) =>
+                            i >= index &&
+                            (step.state === 'error' || step.state === 'warning')
+                        )?.state
+                      }>
+                      <Typography size="xsmall" variant="body">
+                        +{numberOfSteps - index}
+                      </Typography>
+                    </MoreStep>
+                  </Tooltip>
+                )
+              )}
+            </React.Fragment>
+          );
+        })}
+      </div>
+      <div className={rowStyles()}>
+        <div className="blockchains_section">
+          <div className={rowStyles()}>
+            <Typography variant="body" size="xsmall">
+              {i18n.t('Chains:')}
+            </Typography>
+            <Divider direction="horizontal" size={4} />
+            {blockchains.map((blockchain, index) => (
+              <>
+                {blockchains.length <= MAX_BLOCKCHAINS ||
+                (blockchains.length > MAX_BLOCKCHAINS &&
+                  index < MAX_BLOCKCHAINS - 1) ? (
+                  <ImageComponent
+                    key={blockchain.displayName}
+                    content={''}
+                    src={blockchain.image}
+                    open={false}
+                    className={index !== 0 ? 'blockchainImage' : ''}
+                  />
+                ) : (
+                  index === MAX_BLOCKCHAINS - 1 && (
+                    <Tooltip
+                      container={tooltipContainer}
+                      side="bottom"
+                      align="right"
+                      sideOffset={4}
+                      content={
+                        <div className={rowStyles()}>
+                          {blockchains.map(
+                            (chain, i) =>
+                              i >= index && (
+                                <ImageComponent
+                                  key={chain.displayName}
+                                  content={''}
+                                  src={chain.image}
+                                  open={false}
+                                  className={i > index ? 'blockchainImage' : ''}
+                                />
+                              )
+                          )}
+                        </div>
+                      }>
+                      <MoreStep className={'blockchainImage'}>
+                        <Typography size="xsmall" variant="body">
+                          +{blockchains.length - index}
+                        </Typography>
+                      </MoreStep>
+                    </Tooltip>
+                  )
+                )}
+              </>
+            ))}
+
+            <Divider direction="horizontal" size={32} />
+          </div>
+        </div>
+
+        <IconContainer orientation={expanded ? 'up' : 'down'}>
+          <ChevronDownIcon size={12} color="black" />
+        </IconContainer>
+      </div>
+    </Trigger>
+  );
+}

--- a/widget/embedded/src/utils/quote.ts
+++ b/widget/embedded/src/utils/quote.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 import type { QuoteError, QuoteWarning, Wallet } from '../types';
-import type { PriceImpactWarningLevel } from '@rango-dev/ui';
+import type { PriceImpactWarningLevel, Step } from '@rango-dev/ui';
 import type {
   SimulationAssetAndAmount,
   SimulationValidationStatus,
@@ -336,3 +336,20 @@ export function getPriceImpact(
 
   return percentageChange && percentageChange < 0 ? percentageChange : null;
 }
+
+export const getUniqueBlockchains = (steps: Step[]) => {
+  const set = new Set();
+  const result: { displayName: string; image: string }[] = [];
+  steps.forEach((step) => {
+    if (!set.has(step.from.chain.displayName)) {
+      set.add(step.from.chain.displayName);
+      result.push(step.from.chain);
+    }
+    if (!set.has(step.to.chain.displayName)) {
+      set.add(step.to.chain.displayName);
+      result.push(step.to.chain);
+    }
+  });
+
+  return result;
+};

--- a/widget/ui/src/components/Tooltip/Tooltip.styles.ts
+++ b/widget/ui/src/components/Tooltip/Tooltip.styles.ts
@@ -5,6 +5,13 @@ import { Typography } from '../Typography';
 
 export const TooltipContent = styled(RadixTooltip.Content, {
   zIndex: '999999',
+  variants: {
+    align: {
+      right: {
+        position: 'absolute',
+      },
+    },
+  },
 });
 
 export const TooltipTypography = styled(Typography, {

--- a/widget/ui/src/components/Tooltip/Tooltip.tsx
+++ b/widget/ui/src/components/Tooltip/Tooltip.tsx
@@ -20,6 +20,7 @@ export function Tooltip(props: PropsWithChildren<PropTypes>) {
     open,
     side = 'top',
     style,
+    align,
   } = props;
   return (
     <RadixTooltip.Provider delayDuration={0}>
@@ -28,7 +29,7 @@ export function Tooltip(props: PropsWithChildren<PropTypes>) {
           <TriggerContent>{children}</TriggerContent>
         </RadixTooltip.Trigger>
         <RadixTooltip.Portal container={container}>
-          <TooltipContent side={side} sideOffset={sideOffset}>
+          <TooltipContent align={align} side={side} sideOffset={sideOffset}>
             <TooltipTypography variant="label" size="medium" color={color}>
               {content}
             </TooltipTypography>

--- a/widget/ui/src/components/Tooltip/Tooltip.types.ts
+++ b/widget/ui/src/components/Tooltip/Tooltip.types.ts
@@ -1,8 +1,11 @@
+import type { TooltipContent } from './Tooltip.styles';
 import type * as RadixTooltip from '@radix-ui/react-tooltip';
-import type { CSSProperties } from '@stitches/react';
+import type * as Stitches from '@stitches/react';
 import type { ComponentProps, ReactNode } from 'react';
 
 type RadixTooltipContentProps = ComponentProps<typeof RadixTooltip.Content>;
+type BaseProps = Stitches.VariantProps<typeof TooltipContent>;
+type BaseAlign = Exclude<BaseProps['align'], object>;
 
 export interface PropTypes {
   content: ReactNode;
@@ -11,5 +14,6 @@ export interface PropTypes {
   sideOffset?: RadixTooltipContentProps['sideOffset'];
   container?: HTMLElement;
   open?: boolean;
-  style?: CSSProperties;
+  style?: Stitches.CSSProperties;
+  align?: BaseAlign;
 }

--- a/widget/ui/src/theme.ts
+++ b/widget/ui/src/theme.ts
@@ -168,6 +168,7 @@ export const theme = {
   transitions: {},
 };
 const media = {
+  xs: '(min-width: 375px)',
   sm: '(min-width: 640px)',
   md: '(min-width: 768px)',
   lg: '(min-width: 1024px)',


### PR DESCRIPTION
# Summary

For long routes, we should show a shorter version and hide the rest in a button.

# How did you test this change?

- [x] Test in different routes

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.