### PR TITLE
fix: correct token data type in storybook

### DIFF
--- a/widget/ui/src/components/SwapListItem/mock.ts
+++ b/widget/ui/src/components/SwapListItem/mock.ts
@@ -305,6 +305,7 @@ export const swapTokenData: SwapTokenData = {
       image: 'https://api.rango.exchange/swappers/osmosis.png',
     },
     amount: '1.1',
+    realAmount: '1.1',
   },
   to: {
     token: {


### PR DESCRIPTION
# Summary

There was a bug in ui build related to the swap token data type.


