### PR TITLE
fix: persist language in store

### DIFF
--- a/widget/embedded/src/containers/App/App.tsx
+++ b/widget/embedded/src/containers/App/App.tsx
@@ -20,7 +20,7 @@ export function Main() {
 
   const { config } = useAppStore();
   const { activeTheme } = useTheme(config?.theme || {});
-  const { activeLanguage, changeLanguage } = useLanguage();
+  const { activeLanguage } = useLanguage();
   const [lastConnectedWalletWithNetwork, setLastConnectedWalletWithNetwork] =
     useState<string>('');
   const [disconnectedWallet, setDisconnectedWallet] = useState<WalletType>();
@@ -30,9 +30,6 @@ export function Main() {
     void useNotificationStore.persist.rehydrate();
     widgetContext.onConnectWallet(setLastConnectedWalletWithNetwork);
   }, []);
-  useEffect(() => {
-    changeLanguage(config?.language);
-  }, [config?.language]);
 
   return (
     <I18nManager language={activeLanguage}>

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
@@ -3,6 +3,7 @@ import type { WidgetInfoContextInterface } from './WidgetInfo.types';
 import { useManager } from '@rango-dev/queue-manager-react';
 import React, { createContext, useContext } from 'react';
 
+import { useLanguage } from '../../hooks/useLanguage';
 import { useAppStore } from '../../store/AppStore';
 import { useQuoteStore } from '../../store/quote';
 import { useWalletsStore } from '../../store/wallets';
@@ -26,6 +27,7 @@ export function WidgetInfo(props: React.PropsWithChildren) {
   const tokens = useAppStore().tokens();
   const swappers = useAppStore().swappers();
   const loadingStatus = useAppStore().fetchStatus;
+  const resetLanguage = useLanguage().resetLanguage;
 
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   const value = {
@@ -42,6 +44,7 @@ export function WidgetInfo(props: React.PropsWithChildren) {
       swappers,
       loadingStatus,
     },
+    resetLanguage,
   };
 
   return (

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.types.ts
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.types.ts
@@ -18,4 +18,5 @@ export interface WidgetInfoContextInterface {
     swappers: SwapperMeta[];
     loadingStatus: FetchStatus;
   };
+  resetLanguage: () => void;
 }

--- a/widget/embedded/src/hooks/useLanguage.ts
+++ b/widget/embedded/src/hooks/useLanguage.ts
@@ -9,18 +9,20 @@ interface UseLanguage {
   languages: LanguageItem[];
   defaultLanguage: Language;
   activeLanguage: Language;
-  changeLanguage: (language?: Language) => void;
+  changeLanguage: (language?: Language | null) => void;
+  resetLanguage: () => void;
 }
 
 export function useLanguage(): UseLanguage {
-  const { setLanguage, language } = useAppStore();
+  const { setLanguage, language, config } = useAppStore();
   const languages = LANGUAGES;
-  const defaultLanguage = DEFAULT_LANGUAGE;
+  const defaultLanguage = config?.language || DEFAULT_LANGUAGE;
 
   return {
-    activeLanguage: language,
+    activeLanguage: language || defaultLanguage,
     languages,
     defaultLanguage,
     changeLanguage: (language) => setLanguage(language || DEFAULT_LANGUAGE),
+    resetLanguage: () => setLanguage(null),
   };
 }

--- a/widget/embedded/src/store/slices/settings.ts
+++ b/widget/embedded/src/store/slices/settings.ts
@@ -15,7 +15,7 @@ export type ThemeMode = 'auto' | 'dark' | 'light';
 
 export interface SettingsSlice {
   theme: ThemeMode;
-  language: Language;
+  language: Language | null;
   disabledLiquiditySources: string[];
   /** Keeping a history of blockchains that user has selected (in Swap process) */
   preferredBlockchains: string[];
@@ -31,7 +31,7 @@ export interface SettingsSlice {
   toggleInfiniteApprove: () => void;
   toggleLiquiditySource: (name: string) => void;
   setTheme: (theme: ThemeMode) => void;
-  setLanguage: (language: Language) => void;
+  setLanguage: (language: Language | null) => void;
   toggleAllLiquiditySources: (
     swappers: SwapperMeta[],
     shouldReset?: boolean
@@ -53,7 +53,7 @@ export const createSettingsSlice: StateCreator<
 > = (set, get) => ({
   disabledLiquiditySources: [],
   theme: 'auto',
-  language: DEFAULT_LANGUAGE,
+  language: null,
   preferredBlockchains: [],
   slippage: DEFAULT_SLIPPAGE,
   customSlippage: null,

--- a/widget/playground/src/containers/StyleLayout/StyleLayout.General.tsx
+++ b/widget/playground/src/containers/StyleLayout/StyleLayout.General.tsx
@@ -7,6 +7,7 @@ import {
   LanguageIcon,
   Typography,
 } from '@rango-dev/ui';
+import { useWidget } from '@rango-dev/widget-embedded';
 import React, { useCallback, useState } from 'react';
 
 import { ItemPicker } from '../../components/ItemPicker';
@@ -37,6 +38,8 @@ export function General() {
   const fontFamily =
     useConfigStore.use.config().theme?.fontFamily || FONTS[0].value;
   const language = useConfigStore.use.config().language || LANGUAGES[0].value;
+  const { resetLanguage } = useWidget();
+
   const handleFontChange = (value: string) => {
     if (value) {
       onChangeTheme({
@@ -49,6 +52,7 @@ export function General() {
   const handleLanguageChange = (value: string) => {
     if (value) {
       onChangeLanguage(value);
+      resetLanguage();
     }
     onBack();
   };


### PR DESCRIPTION
# Summary

When navigating to a new route, the language restores to the default state (En).
this issue was fixed by persistent language in the store.

# Checklist:

- [x] I have performed a self-review of my code