### PR TITLE
chore(ci): rebase pr for crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -57,6 +57,6 @@ jobs:
 
       - name: Enable auto-merge for the PR
         if: steps.crowdin-download.outputs.pull_request_url
-        run: gh pr --repo $GITHUB_REPOSITORY merge ${{ steps.crowdin-download.outputs.pull_request_url }} --admin --merge
+        run: gh pr --repo $GITHUB_REPOSITORY merge ${{ steps.crowdin-download.outputs.pull_request_url }} --admin --rebase
         env:
           GITHUB_TOKEN: ${{secrets.PAT}}


### PR DESCRIPTION
# Summary

Crowding is failing because it should be `rebase`d.