### PR TITLE
chore(ci): skip workflow on crowdin commit

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -45,7 +45,7 @@ jobs:
           translation: translations/%two_letters_code%.po
           project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
           token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-          commit_message: 'chore(translation): update translations'
+          commit_message: 'chore(translation): update translations [skip ci]'
 
           localization_branch_name: l10n_crowdin_translations
           create_pull_request: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
       - main
     tags:
       - '!*'
-  pull_request_target:
+  pull_request:
     types:
       - closed
     branches:


### PR DESCRIPTION
# Summary

After rebasing crowding branch, it causes run publish workflow recursively.
