### PR TITLE
fix: address apiKey config bug in iframe

### DIFF
--- a/widget/app/src/App.tsx
+++ b/widget/app/src/App.tsx
@@ -14,32 +14,33 @@ export function App() {
 
   let config: WidgetConfig | undefined = undefined;
 
-  if (!!configParam) {
-    try {
-      config = JSON.parse(configParam, (_, value) => {
-        if (typeof value === 'string' && value[0] === '$') {
-          return value.replace('$', '#');
-        }
-        return value;
-      });
-    } catch (error) {
-      console.error('Widget config param is invalid!');
+  if (!configRef.current) {
+    if (!!configParam) {
+      try {
+        config = JSON.parse(configParam, (_, value) => {
+          if (typeof value === 'string' && value[0] === '$') {
+            return value.replace('$', '#');
+          }
+          return value;
+        });
+      } catch (error) {
+        console.error('Widget config param is invalid!');
+      }
+    } else {
+      /*
+       *TODO:
+       *The assumption here is this object won't be created on iframe so we are on dev mode.
+       *We should consider a more proper way.
+       */
+
+      config = {
+        apiKey: '',
+        walletConnectProjectId: WC_PROJECT_ID,
+      };
     }
-  } else {
-    /*
-     *TODO:
-     *The assumption here is this object won't be created on `iframe` so we are on dev mode.
-     *We should consider a more proper way.
-     */
-
-    config = {
-      apiKey: '',
-      walletConnectProjectId: WC_PROJECT_ID,
-    };
-  }
-
-  if (!!config) {
-    configRef.current = config;
+    if (!!config) {
+      configRef.current = config;
+    }
   }
 
   return (

--- a/widget/embedded/src/containers/WidgetProvider/WidgetProvider.tsx
+++ b/widget/embedded/src/containers/WidgetProvider/WidgetProvider.tsx
@@ -17,7 +17,8 @@ export function WidgetProvider(props: PropsWithChildren<PropTypes>) {
       API_KEY: config?.apiKey || RANGO_PUBLIC_API_KEY,
       BASE_URL: config?.apiUrl || DEFAULT_BASE_URL,
     });
-  }, [config]);
+  }, [config.apiKey, config.apiUrl]);
+
   return (
     <WidgetWallets config={config} onUpdateState={onUpdateState}>
       <QueueManager apiKey={config.apiKey}>


### PR DESCRIPTION
# Summary

This pull request addresses the issue where setting the apiKey in an iframe resulted in the creation of a transaction with the default apiKey instead of the apiKey provided in the configuration.


Fixes # (issue)


# How did you test this change?
I tested this change using the provided template [here](https://docs.rango.exchange/widget-integration/quick-start#iframe-version). The `WIDGET_URL` was set to 3000, and the widget was run on port 3000. During testing, I monitored network requests to confirm that the correct apiKey was being sent from the configuration to the iframe.


# Checklist:

- [x] I have performed a self-review of my code
