### PR TITLE
fix: change widget-iframe height based on it's content

### DIFF
--- a/widget/embedded/src/components/Layout/Layout.styles.ts
+++ b/widget/embedded/src/components/Layout/Layout.styles.ts
@@ -7,26 +7,13 @@ export const Container = styled('div', {
   borderRadius: '$primary',
   overflow: 'hidden !important',
   boxShadow: '15px 15px 15px 0px rgba(0, 0, 0, 0.05)',
-  width: '100vw',
-  minWidth: '300px',
-  maxWidth: '390px',
-  maxHeight: '700px',
+  width: '100%',
   textAlign: 'left',
   $$color: '$colors$neutral100',
   [`.${darkTheme} &`]: {
     $$color: '$colors$neutral300',
   },
   backgroundColor: '$$color',
-  variants: {
-    fixedHeight: {
-      true: {
-        height: '100vh',
-      },
-      false: {
-        height: 'auto !important',
-      },
-    },
-  },
 });
 
 export const Content = styled('div', {

--- a/widget/embedded/src/components/Layout/Layout.tsx
+++ b/widget/embedded/src/components/Layout/Layout.tsx
@@ -61,6 +61,10 @@ function LayoutComponent(props: PropsWithChildren<PropTypes>, outerRef: Ref) {
             type: 'dimensionsChanged',
             height: '700px',
           },
+          /*
+           * Due to cross-origin restrictions, it is necessary to transmit the parent URL to the iframe.
+           * We can dynamically post the parent URL to the iframe within the parent context, eliminating the need for hardcoding this value.
+           */
           'http://localhost:3000'
         );
       } else {

--- a/widget/embedded/src/components/Layout/Layout.tsx
+++ b/widget/embedded/src/components/Layout/Layout.tsx
@@ -2,7 +2,7 @@ import type { PropTypes, Ref } from './Layout.types';
 import type { PropsWithChildren } from 'react';
 
 import { BottomLogo, Divider, Header } from '@rango-dev/ui';
-import React from 'react';
+import React, { useEffect, useImperativeHandle, useRef } from 'react';
 
 import { RANGO_SWAP_BOX_ID } from '../../constants';
 import { useNavigateBack } from '../../hooks/useNavigateBack';
@@ -16,7 +16,7 @@ import { BackButton, CancelButton, WalletButton } from '../HeaderButtons';
 
 import { Container, Content, Footer } from './Layout.styles';
 
-function LayoutComponent(props: PropsWithChildren<PropTypes>, ref: Ref) {
+function LayoutComponent(props: PropsWithChildren<PropTypes>, outerRef: Ref) {
   const {
     children,
     header,
@@ -49,12 +49,35 @@ function LayoutComponent(props: PropsWithChildren<PropTypes>, ref: Ref) {
   const showBackButton =
     typeof header.hasBackButton === 'undefined' || header.hasBackButton;
 
+  const innerRef = useRef<HTMLDivElement | null>(null);
+  useImperativeHandle(outerRef, () => innerRef.current!, []);
+
+  useEffect(() => {
+    if (innerRef.current) {
+      if (fixedHeight) {
+        innerRef.current.style.height = '700px';
+        window.parent.postMessage(
+          {
+            type: 'dimensionsChanged',
+            height: '700px',
+          },
+          'http://localhost:3000'
+        );
+      } else {
+        innerRef.current.style.height = 'auto !important';
+        window.parent.postMessage(
+          {
+            type: 'dimensionsChanged',
+            height: innerRef.current.clientHeight + 'px',
+          },
+          'http://localhost:3000'
+        );
+      }
+    }
+  }, [fixedHeight]);
+
   return (
-    <Container
-      ref={ref}
-      fixedHeight={fixedHeight}
-      id={RANGO_SWAP_BOX_ID}
-      className={activeTheme()}>
+    <Container ref={innerRef} id={RANGO_SWAP_BOX_ID} className={activeTheme()}>
       <Header
         prefix={<>{showBackButton && <BackButton onClick={navigateBack} />}</>}
         title={header.title}

--- a/widget/embedded/src/containers/App/App.styles.ts
+++ b/widget/embedded/src/containers/App/App.styles.ts
@@ -1,6 +1,9 @@
 import { styled } from '@rango-dev/ui';
 
 export const MainContainer = styled('div', {
+  width: '100%',
+  minWidth: '300px',
+  maxWidth: '390px',
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',

--- a/widget/iframe/src/main.ts
+++ b/widget/iframe/src/main.ts
@@ -67,13 +67,17 @@ export class RangoWidget {
     const widget = document.createElement('iframe');
     widget.setAttribute('id', RANGO_WIDGET_IFRAME_ID);
     widget.src = url;
+    //Introduce a high-contrast color to enhance visibility when observing the height changes.
     widget.style.backgroundColor = 'red';
     widget.style.width = '100%';
     widget.style.maxWidth = commonStyles.maxWidth;
     widget.style.maxHeight = commonStyles.maxHeight;
     widget.style.overflow = commonStyles.overflow;
     widget.style.border = 'none';
-
+    /*
+     * To prevent layout shifts, we can set an initial height for the iframe.
+     *  widget.style.height = '441px';
+     */
     return widget;
   }
 }

--- a/widget/iframe/src/main.ts
+++ b/widget/iframe/src/main.ts
@@ -1,9 +1,8 @@
 import type { WidgetConfig } from '@rango-dev/widget-embedded';
 
 import { commonStyles } from './styles';
-
 // Actual app that will be loaded inside the iframe.
-const WIDGET_URL = 'https://widget.rango.exchange/';
+const WIDGET_URL = 'http://localhost:3002';
 const DEFAULT_CONTAINER_ID = 'rango-widget-container';
 const RANGO_WIDGET_IFRAME_ID = 'rango-widget-iframe';
 
@@ -11,6 +10,13 @@ export class RangoWidget {
   public init(configuration?: WidgetConfig, rootId?: string): void {
     const container = this.getContainer(rootId || DEFAULT_CONTAINER_ID);
     const widget = this.createWidget(configuration);
+
+    window.addEventListener('message', (event) => {
+      if (event.data.type === 'dimensionsChanged') {
+        console.log('new height:', event.data.height);
+        widget.style.height = event.data.height;
+      }
+    });
 
     container.appendChild(widget);
 
@@ -61,9 +67,8 @@ export class RangoWidget {
     const widget = document.createElement('iframe');
     widget.setAttribute('id', RANGO_WIDGET_IFRAME_ID);
     widget.src = url;
-    widget.style.backgroundColor = 'transparent';
-    widget.style.width = commonStyles.width;
-    widget.style.height = commonStyles.height;
+    widget.style.backgroundColor = 'red';
+    widget.style.width = '100%';
     widget.style.maxWidth = commonStyles.maxWidth;
     widget.style.maxHeight = commonStyles.maxHeight;
     widget.style.overflow = commonStyles.overflow;


### PR DESCRIPTION
# Summary

The current version of the widget calculates its height based on the viewport. However, in the iframe version of the widget, we are obliged to consider a fixed value for the iframe that represents the maximum possible height of the widget. Consequently, when the widget is loaded and is placed on the home page, an empty space is created at the bottom of the widget, disrupting the user experience. In this draft, we address this issue by using messaging between the iframe source and the hosting website, setting the iframe height to the actual height occupied by the widget.