### PR TITLE
fix: add animations and some improvements to playground

### DIFF
--- a/widget/playground/src/App.tsx
+++ b/widget/playground/src/App.tsx
@@ -2,6 +2,7 @@ import { Widget, WidgetProvider } from '@rango-dev/widget-embedded';
 import React, { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
+import { PLAYGROUND_CONTAINER_ID } from './constants';
 import { ConfigContainer } from './containers/configContainer';
 import { useTheme } from './hooks/useTheme';
 import { useConfigStore } from './store/config';
@@ -19,7 +20,7 @@ export function App() {
   }, []);
 
   return (
-    <div className={activeStyle}>
+    <div id={PLAYGROUND_CONTAINER_ID} className={activeStyle}>
       <WidgetProvider config={overridedConfig}>
         <ConfigContainer>
           <Routes>

--- a/widget/playground/src/components/ExportConfigModal/CodeBlock.styles.tsx
+++ b/widget/playground/src/components/ExportConfigModal/CodeBlock.styles.tsx
@@ -1,4 +1,4 @@
-import { Button, styled } from '@rango-dev/ui';
+import { Button, keyframes, styled } from '@rango-dev/ui';
 
 export const CopyCodeBlock = styled('div', {
   position: 'absolute',
@@ -17,4 +17,97 @@ export const CodeBlockContainer = styled('div', {
   borderRadius: '$sm',
   height: '507px',
   width: '100%',
+});
+
+const copyIconFadeIn = keyframes({
+  '0%': {
+    opacity: 0,
+  },
+  '100%': {
+    opacity: 1,
+  },
+});
+
+const copyIconFadeOut = keyframes({
+  '0%': {
+    opacity: 1,
+  },
+  '100%': {
+    opacity: 0,
+  },
+});
+
+export const CopyCodeBlockButtonIcon = styled('span', {
+  variants: {
+    visible: {
+      true: {
+        animation: `${copyIconFadeIn} .5s ease-in-out`,
+        opacity: 1,
+      },
+      false: {
+        animation: `${copyIconFadeOut} .5s ease-in-out`,
+        opacity: 0,
+      },
+    },
+  },
+});
+
+const doneIconFadeIn = keyframes({
+  '0%': {
+    transform: 'translateY(12px)',
+    opacity: 0,
+  },
+  '100%': {
+    transform: 'translateY(0)',
+    opacity: 1,
+  },
+});
+
+export const CopyCodeBlockButtonDoneIcon = styled('span', {
+  position: 'absolute',
+  top: '12px',
+  left: '12px',
+  transform: 'translateY(0)',
+  variants: {
+    visible: {
+      true: {
+        animation: `${doneIconFadeIn} .5s ease-in-out`,
+        transform: 'translateY(0)',
+        opacity: 1,
+      },
+      false: {
+        opacity: 0,
+      },
+    },
+  },
+});
+
+const SuccessfulAlertContainerTransform = keyframes({
+  '0%': {
+    transform: 'translateY(24px) translateX(-50%)',
+    opacity: 0,
+  },
+  '100%': {
+    transform: 'translateY(0) translateX(-50%)',
+    opacity: 1,
+  },
+});
+
+export const SuccessfulAlertContainer = styled('div', {
+  display: 'inline',
+  position: 'fixed',
+  bottom: '$12',
+  left: '50%',
+  variants: {
+    visible: {
+      true: {
+        animation: `${SuccessfulAlertContainerTransform} .5s ease-in-out`,
+        transform: 'translateY(0) translateX(-50%)',
+        opacity: 1,
+      },
+      false: {
+        opacity: 0,
+      },
+    },
+  },
 });

--- a/widget/playground/src/components/ExportConfigModal/CodeBlock.tsx
+++ b/widget/playground/src/components/ExportConfigModal/CodeBlock.tsx
@@ -1,7 +1,13 @@
 import type { CodeBlockProps } from './CodeBlock.types';
 
-import { CopyIcon, Tooltip, useCopyToClipboard } from '@rango-dev/ui';
-import React, { useState } from 'react';
+import {
+  Alert,
+  CopyIcon,
+  DoneIcon,
+  Tooltip,
+  useCopyToClipboard,
+} from '@rango-dev/ui';
+import React from 'react';
 import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import {
   javascript,
@@ -12,6 +18,9 @@ import {
   CodeBlockContainer,
   CopyCodeBlock,
   CopyCodeBlockButton,
+  CopyCodeBlockButtonDoneIcon,
+  CopyCodeBlockButtonIcon,
+  SuccessfulAlertContainer,
 } from './CodeBlock.styles';
 
 const RESET_INTERVAL = 2_000;
@@ -20,36 +29,42 @@ SyntaxHighlighter.registerLanguage('javascript', javascript);
 SyntaxHighlighter.registerLanguage('jsx', jsx);
 
 export function CodeBlock(props: CodeBlockProps) {
-  const { language, theme, children } = props;
+  const { language, theme, children, selectedType } = props;
 
-  const [, handleCopy] = useCopyToClipboard(RESET_INTERVAL);
-  const [open, setOpen] = useState<boolean>(false);
+  const [isCopied, handleCopy] = useCopyToClipboard(RESET_INTERVAL);
+
   return (
-    <Tooltip side="bottom" open={open} content={<span> Code Copied! </span>}>
-      <CodeBlockContainer>
-        <CopyCodeBlock>
-          <Tooltip content="Copy to clipboard" side="top">
-            <CopyCodeBlockButton
-              type="primary"
-              onClick={() => {
-                handleCopy(children);
-                setOpen(true);
-                setInterval(() => {
-                  setOpen(false);
-                }, RESET_INTERVAL);
-              }}>
+    <CodeBlockContainer>
+      <CopyCodeBlock>
+        <Tooltip content="Copy to clipboard" side="top">
+          <CopyCodeBlockButton
+            type="primary"
+            onClick={() => {
+              handleCopy(children);
+            }}>
+            <CopyCodeBlockButtonDoneIcon visible={isCopied}>
+              <DoneIcon size={24} />
+            </CopyCodeBlockButtonDoneIcon>
+            <CopyCodeBlockButtonIcon visible={!isCopied}>
               <CopyIcon size={24} />
-            </CopyCodeBlockButton>
-          </Tooltip>
-        </CopyCodeBlock>
-        <SyntaxHighlighter
-          showLineNumbers
-          language={language}
-          customStyle={{ height: '100%', borderRadius: '15px' }}
-          style={theme}>
-          {children}
-        </SyntaxHighlighter>
-      </CodeBlockContainer>
-    </Tooltip>
+            </CopyCodeBlockButtonIcon>
+          </CopyCodeBlockButton>
+        </Tooltip>
+      </CopyCodeBlock>
+      <SyntaxHighlighter
+        showLineNumbers
+        language={language}
+        customStyle={{ height: '100%', borderRadius: '15px' }}
+        style={theme}>
+        {children}
+      </SyntaxHighlighter>
+
+      <SuccessfulAlertContainer visible={isCopied}>
+        <Alert
+          type="success"
+          title={`${selectedType || ''} Code copied successfully`}
+        />
+      </SuccessfulAlertContainer>
+    </CodeBlockContainer>
   );
 }

--- a/widget/playground/src/components/ExportConfigModal/CodeBlock.types.tsx
+++ b/widget/playground/src/components/ExportConfigModal/CodeBlock.types.tsx
@@ -1,6 +1,7 @@
-import type { Language } from './ExportConfigModal.types';
+import type { ExportType, Language } from './ExportConfigModal.types';
 
 export interface CodeBlockProps {
+  selectedType: ExportType;
   language: Language;
   theme: any;
   children: string;

--- a/widget/playground/src/components/ExportConfigModal/ExportConfigModal.tsx
+++ b/widget/playground/src/components/ExportConfigModal/ExportConfigModal.tsx
@@ -19,6 +19,7 @@ import {
   prism,
 } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
+import { PLAYGROUND_CONTAINER_ID } from '../../constants';
 import { useTheme } from '../../hooks/useTheme';
 import { initialConfig, useConfigStore } from '../../store/config';
 import { filterConfig, formatConfig } from '../../utils/export';
@@ -56,6 +57,9 @@ export function ExportConfigModal(props: ExportConfigModalProps) {
 
   return (
     <Modal
+      container={
+        document.getElementById(PLAYGROUND_CONTAINER_ID) as HTMLElement
+      }
       containerStyle={{
         maxWidth: '1109px',
         width: '90%',
@@ -163,6 +167,7 @@ export function ExportConfigModal(props: ExportConfigModalProps) {
       </ButtonsContainer>
       <Divider size={10} />
       <CodeBlock
+        selectedType={selected}
         language={typesOfCodeBlocks[selected].language}
         theme={syntaxHighlighterTheme}>
         {typesOfCodeBlocks[selected].generateCode(formatedConfig)}

--- a/widget/playground/src/components/MultiSelect/MultiSelect.styles.ts
+++ b/widget/playground/src/components/MultiSelect/MultiSelect.styles.ts
@@ -15,17 +15,26 @@ export const Select = styled('div', {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    cursor: 'pointer',
   },
   '& .chips': {
     display: 'flex',
     flexWrap: 'wrap',
     gap: '$5',
   },
-  '&:hover': {
-    borderColor: '$info300',
-    '& svg': {
-      color: '$secondary500',
+
+  variants: {
+    disabled: {
+      false: {
+        '&:hover': {
+          borderColor: '$info300',
+          '& svg': {
+            color: '$secondary500',
+          },
+        },
+        '& .field': {
+          cursor: 'pointer',
+        },
+      },
     },
   },
 });

--- a/widget/playground/src/components/MultiSelect/MultiSelect.tsx
+++ b/widget/playground/src/components/MultiSelect/MultiSelect.tsx
@@ -32,12 +32,17 @@ const Chip = (props: MultiSelectChipProps) => {
 
 export function MultiSelect(props: MuliSelectPropTypes) {
   const [showNextModal, setShowNextModal] = useState(false);
-  const { label, type, value, list } = props;
+  const { label, type, value, list, disabled } = props;
   const valueAll = !value;
   const noneSelected = !valueAll && !value.length;
   const hasValue = !valueAll;
   const showMore = hasValue && value.length > MAX_CHIPS;
   const onBack = () => setShowNextModal(false);
+  const onOpenNextModal = () => {
+    if (!disabled) {
+      setShowNextModal(true);
+    }
+  };
 
   return (
     <>
@@ -49,8 +54,8 @@ export function MultiSelect(props: MuliSelectPropTypes) {
         </Typography>
       </Label>
       <Divider size={4} />
-      <Select>
-        <div className="field" onClick={() => setShowNextModal(true)}>
+      <Select disabled={!!disabled}>
+        <div className="field" onClick={onOpenNextModal}>
           <div className="chips">
             {valueAll && <Chip label={`All ${type}`} />}
             {noneSelected && <Chip label="None Selected" />}

--- a/widget/playground/src/components/MultiSelect/MultiSelect.types.ts
+++ b/widget/playground/src/components/MultiSelect/MultiSelect.types.ts
@@ -22,6 +22,7 @@ export type MuliSelectPropTypes = (TokensListProps | CommonListProps) & {
   value?: string[];
   label: string;
   icon: React.ReactNode;
+  disabled?: boolean;
 };
 
 export interface MultiSelectChipProps {

--- a/widget/playground/src/components/Slider/Slider.tsx
+++ b/widget/playground/src/components/Slider/Slider.tsx
@@ -27,7 +27,7 @@ function Slider(props: PropTypes) {
     const sliderEl = document.querySelector(`#${id}`) as HTMLInputElement;
     const sliderValue = parseInt(sliderEl.value);
     const mainValue = sliderValue * (MAX_VALUE / (max as number));
-    sliderEl.style.background = `linear-gradient(to right, #5BABFF ${mainValue}%, #F2F2F2 ${mainValue}%)`;
+    sliderEl.style.background = `linear-gradient(to right, #5BABFF ${mainValue}%, #C8E2FF ${mainValue}%)`;
   };
 
   useEffect(() => {

--- a/widget/playground/src/constants/index.ts
+++ b/widget/playground/src/constants/index.ts
@@ -9,3 +9,5 @@ export enum SIDE_TABS_IDS {
 }
 
 export const NOT_FOUND = -1;
+
+export const PLAYGROUND_CONTAINER_ID = 'playgroundContainerId';

--- a/widget/playground/src/containers/DefaultChainAndToken/DefaultChainAndToken.tsx
+++ b/widget/playground/src/containers/DefaultChainAndToken/DefaultChainAndToken.tsx
@@ -82,6 +82,7 @@ export function DefaultChainAndToken({ type }: { type: Type }) {
         title="Default Blockchain"
         hasLogo={true}
         placeholder="Chain"
+        disabled={!blockchains?.length}
       />
       <Divider size={10} />
       <Tooltip

--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Liquidities.tsx
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Liquidities.tsx
@@ -106,6 +106,7 @@ export function LiquiditiesSection() {
         onChange={(items) =>
           handleChange(allDexsNames, allBridgeNames, items, selectedBridges)
         }
+        disabled={!swappers?.length}
       />
       <Divider size={10} />
       <MultiSelect
@@ -125,6 +126,7 @@ export function LiquiditiesSection() {
         onChange={(items) =>
           handleChange(allBridgeNames, allDexsNames, items, selectedDexs)
         }
+        disabled={!swappers?.length}
       />
       <Divider size={4} />
       <Checkbox

--- a/widget/playground/src/containers/StyleLayout/StyleLayout.styles.ts
+++ b/widget/playground/src/containers/StyleLayout/StyleLayout.styles.ts
@@ -61,7 +61,7 @@ export const BackdropTab = styled('div', {
   position: 'absolute',
   borderRadius: '$md',
   inset: 0,
-  transition: 'transform 0.5s cubic-bezier(0, 0, 0.86, 1.2)',
+  transition: 'transform 0.2s cubic-bezier(0, 0, 0.86, 1.2)',
 });
 
 export const PresetContent = styled('div', {

--- a/widget/playground/src/containers/SupportedBlockchains/SupportedBlockchains.tsx
+++ b/widget/playground/src/containers/SupportedBlockchains/SupportedBlockchains.tsx
@@ -64,6 +64,7 @@ export function SupportedBlockchains({ type }: { type: Type }) {
       }
       list={allBlockchains}
       onChange={handleBlockchainChange}
+      disabled={!blockchains?.length}
     />
   );
 }

--- a/widget/playground/src/containers/SupportedTokens/SupportedTokens.tsx
+++ b/widget/playground/src/containers/SupportedTokens/SupportedTokens.tsx
@@ -82,6 +82,7 @@ export function SupportedTokens({ type }: { type: Type }) {
           onChangeTokens(selectedTokens, type);
           onChangeToken(undefined, type);
         }}
+        disabled={!blockchains?.length || !tokens.length}
       />
     </>
   );


### PR DESCRIPTION
# Summary

Add animations and some improvements to Playground

# Checklist:

- [x] Disable buttons when meta hasn't been loaded (Supported Blockchain, Supported Tokens, and check all the places that has a dependency to meta.)
- [x] Add an animation for Copy button on export modal
- [x] Update slider animation and design
- [x] Reduce animation duration for switch tabs
- [x] Apply theme colors to modal (e.g. export modal) when use presets





