### PR TITLE
fix: remove cleanup for subscribe in phantom

### DIFF
--- a/wallets/provider-phantom/src/index.ts
+++ b/wallets/provider-phantom/src/index.ts
@@ -37,10 +37,6 @@ export const subscribe: Subscribe = ({ instance, updateAccounts, connect }) => {
     }
   };
   instance?.on('accountChanged', handleAccountsChanged);
-
-  return () => {
-    instance?.off('accountChanged', handleAccountsChanged);
-  };
 };
 
 export const canSwitchNetworkTo: CanSwitchNetwork = () => false;


### PR DESCRIPTION
# Summary

There is an issue in switching accounts in phantom. This PR tries to fix it temporarily.
