### PR TITLE
fix: fix connecting wallet issue

### DIFF
--- a/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
@@ -59,23 +59,24 @@ export function WalletList(props: PropTypes) {
     useState<'in-progress' | 'completed' | 'rejected' | null>(null);
   const { suggestAndConnect } = useWallets();
   let modalTimerId: ReturnType<typeof setTimeout> | null = null;
-  const { list, error, handleClick } = useWalletList({
-    config,
-    chain,
-    onBeforeConnect: (type) => {
-      modalTimerId = setTimeout(() => {
-        setOpenWalletStateModal(type);
-      }, TIME_TO_IGNORE_MODAL);
-    },
-    onConnect: () => {
-      if (modalTimerId) {
-        clearTimeout(modalTimerId);
-      }
-      setTimeout(() => {
-        setOpenWalletStateModal('');
-      }, TIME_TO_CLOSE_MODAL);
-    },
-  });
+  const { list, error, handleClick, disconnectConnectingWallets } =
+    useWalletList({
+      config,
+      chain,
+      onBeforeConnect: (type) => {
+        modalTimerId = setTimeout(() => {
+          setOpenWalletStateModal(type);
+        }, TIME_TO_IGNORE_MODAL);
+      },
+      onConnect: () => {
+        if (modalTimerId) {
+          clearTimeout(modalTimerId);
+        }
+        setTimeout(() => {
+          setOpenWalletStateModal('');
+        }, TIME_TO_CLOSE_MODAL);
+      },
+    });
   const [sortedList, setSortedList] = useState<WalletInfo[]>(list);
   const numberOfSupportedWallets = list.length;
   const shouldShowMoreWallets = limit && numberOfSupportedWallets - limit > 0;
@@ -132,6 +133,11 @@ export function WalletList(props: PropTypes) {
       }
     };
   }, [addingExperimentalChainStatus]);
+
+  const handleCloseWalletModal = () => {
+    disconnectConnectingWallets();
+    setOpenWalletStateModal('');
+  };
 
   return (
     <>
@@ -193,7 +199,7 @@ export function WalletList(props: PropTypes) {
           <>
             <WalletModal
               open={openWalletStateModal === wallet.type}
-              onClose={() => setOpenWalletStateModal('')}
+              onClose={handleCloseWalletModal}
               image={wallet.image}
               state={wallet.state}
               error={error}

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.WalletState.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.WalletState.tsx
@@ -1,8 +1,8 @@
 import type { WalletStateContentProps } from './SwapDetailsModal.types';
 
-import { MessageBox, Wallet } from '@rango-dev/ui';
+import { MessageBox, Wallet, WalletState } from '@rango-dev/ui';
 import { useWallets } from '@rango-dev/wallets-react';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import { getContainer } from '../../utils/common';
 import { mapStatusToWalletState } from '../../utils/wallets';
@@ -18,14 +18,40 @@ export const WalletStateContent = (props: WalletStateContentProps) => {
     showWalletButton,
     walletButtonDisabled,
   } = props;
-  const { connect, getWalletInfo, state } = useWallets();
+  const { connect, getWalletInfo, state, disconnect } = useWallets();
   const walletType = currentStepWallet?.walletType;
   const walletState = walletType
     ? mapStatusToWalletState(state(walletType))
     : null;
+  const componentWillUnmount = useRef(false);
+
   const walletInfo = walletType ? getWalletInfo(walletType) : null;
   const shouldShowWallet =
     showWalletButton && !!walletType && !!walletState && !!walletInfo;
+
+  /*
+   * The order of useEffects is crucial.
+   * 1- The first useEffect for componentWillUnmount sets its value to true
+   */
+  useEffect(() => {
+    return () => {
+      componentWillUnmount.current = true;
+    };
+  }, []);
+
+  // 2- The second useEffect checks if componentWillUnmount is true then it disconnects connecting wallet
+  useEffect(() => {
+    return () => {
+      if (
+        componentWillUnmount.current &&
+        walletType &&
+        walletState === WalletState.CONNECTING
+      ) {
+        void disconnect(walletType);
+      }
+    };
+  }, [walletState]);
+
   return (
     <>
       <MessageBox type={type} title={title} description={message} />

--- a/widget/embedded/src/hooks/useWalletList.ts
+++ b/widget/embedded/src/hooks/useWalletList.ts
@@ -9,12 +9,13 @@ import {
   type WalletType,
   WalletTypes,
 } from '@rango-dev/wallets-shared';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAppStore } from '../store/AppStore';
 import { useWalletsStore } from '../store/wallets';
 import { configWalletsToWalletName } from '../utils/providers';
 import {
+  hashWalletsState,
   isExperimentalChain,
   mapWalletTypesToWalletInfo,
   sortWalletsBasedOnConnectionState,
@@ -39,6 +40,7 @@ export function useWalletList(params: Params) {
   const { state, disconnect, getWalletInfo, connect } = useWallets();
   const { connectedWallets } = useWalletsStore();
   const blockchains = useAppStore().blockchains();
+  const componentWillUnmount = useRef(false);
 
   /** It can be what has been set by widget config or as a fallback we use all the supported wallets by our library */
   const listAvailableWalletTypes =
@@ -87,20 +89,33 @@ export function useWalletList(params: Params) {
     }
   };
 
-  const disconnectConnectingWallets = () => {
+  const disconnectConnectingWallets = useCallback(() => {
     const connectingWallets =
       wallets?.filter((wallet) => wallet.state === WalletState.CONNECTING) ||
       [];
     for (const wallet of connectingWallets) {
       void disconnect(wallet.type);
     }
-  };
+  }, [hashWalletsState(wallets)]);
 
+  /*
+   * The order of useEffects is crucial.
+   * 1- The first useEffect for componentWillUnmount sets its value to true
+   */
   useEffect(() => {
     return () => {
-      disconnectConnectingWallets();
+      componentWillUnmount.current = true;
     };
   }, []);
+
+  // 2- The second useEffect checks if componentWillUnmount is true then it disconnects connecting wallets
+  useEffect(() => {
+    return () => {
+      if (componentWillUnmount.current) {
+        disconnectConnectingWallets();
+      }
+    };
+  }, [disconnectConnectingWallets]);
 
   /*
    * Atm, we only support default injected wallet for the EVM
@@ -141,5 +156,6 @@ export function useWalletList(params: Params) {
     ),
     error,
     handleClick,
+    disconnectConnectingWallets,
   };
 }

--- a/widget/embedded/src/pages/WalletsPage.tsx
+++ b/widget/embedded/src/pages/WalletsPage.tsx
@@ -35,23 +35,29 @@ export function WalletsPage() {
   let modalTimerId: ReturnType<typeof setTimeout> | null = null;
   const isActiveTab = useUiStore.use.isActiveTab();
 
-  const { list, handleClick, error } = useWalletList({
-    config,
-    onBeforeConnect: (type) => {
-      modalTimerId = setTimeout(() => {
-        setOpenModal(true);
-        setSelectedWalletType(type);
-      }, TIME_TO_IGNORE_MODAL);
-    },
-    onConnect: () => {
-      if (modalTimerId) {
-        clearTimeout(modalTimerId);
-      }
-      setTimeout(() => {
-        setOpenModal(false);
-      }, TIME_TO_CLOSE_MODAL);
-    },
-  });
+  const { list, handleClick, error, disconnectConnectingWallets } =
+    useWalletList({
+      config,
+      onBeforeConnect: (type) => {
+        modalTimerId = setTimeout(() => {
+          setOpenModal(true);
+          setSelectedWalletType(type);
+        }, TIME_TO_IGNORE_MODAL);
+      },
+      onConnect: () => {
+        if (modalTimerId) {
+          clearTimeout(modalTimerId);
+        }
+        setTimeout(() => {
+          setOpenModal(false);
+        }, TIME_TO_CLOSE_MODAL);
+      },
+    });
+
+  const handleCloseWalletModal = () => {
+    disconnectConnectingWallets();
+    setOpenModal(false);
+  };
 
   const selectedWallet = list.find(
     (wallet) => wallet.type === selectedWalletType
@@ -87,7 +93,7 @@ export function WalletsPage() {
           })}
           <WalletModal
             open={!!openModal}
-            onClose={() => setOpenModal(false)}
+            onClose={handleCloseWalletModal}
             image={selectedWalletImage}
             state={selectedWalletState}
             error={error}

--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -551,3 +551,7 @@ export const isFetchingBalance = (
   !!connectedWallets.find(
     (wallet) => wallet.chain === blockchain && wallet.loading
   );
+
+export function hashWalletsState(walletsInfo: ModalWalletInfo[]) {
+  return walletsInfo.map((w) => w.state).join('-');
+}


### PR DESCRIPTION
# Summary

When the Wallet state is **connecting** and leaves the page or component, we disconnect all connecting statuses in the clean-up component.

And if the modal connecting wallet is closed, we disconnect the wallet again.


Fixes # (issue)

This issue has been fixed in 3 different places:

-  WalletPage
- ConfirmWalletsModal
- SwapDetail


# How did you test this change?

After clicking to connect the wallet, do not close the main window of the wallet,
so that it remains in the connecting mode.
Then you can click on the back of the browser or close the conecting modal.
After you return to the previous page, Wallet should be disconnected.


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
