### PR TITLE
fix: correct refresh icon style on firefox

### DIFF
--- a/widget/ui/src/components/RefreshProgressButton/RefreshProgressButton.styles.ts
+++ b/widget/ui/src/components/RefreshProgressButton/RefreshProgressButton.styles.ts
@@ -1,10 +1,10 @@
 import { styled } from '../../theme';
 
 export const StyledEllipse = styled('ellipse', {
-  cx: 12.5,
-  cy: 12.5,
-  rx: 7.7,
-  ry: 7.7,
+  cx: '12.5px',
+  cy: '12.5px',
+  rx: '7.7px',
+  ry: '7.7px',
   strokeLinecap: 'round',
   fill: 'none',
   strokeDasharray: 100,


### PR DESCRIPTION
# Summary

The icon refresh styles didn't appear correctly on firefox.

Fixes # (issue)


# How did you test this change?
The refresh icon should be tested on Firefox.

# Checklist:

- [x] I have performed a self-review of my code
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
