### PR TITLE
feat: implement toast

### DIFF
--- a/widget/ui/.storybook/preview.tsx
+++ b/widget/ui/.storybook/preview.tsx
@@ -56,7 +56,7 @@ export const withTheme: Decorator = (StoryFn, context) => {
   switch (theme) {
     case 'side-by-side':
       return (
-        <I18nManager>
+        <I18nManager language="en">
           <ThemeBlock position="left" className={lightTheme}>
             <StoryFn />
           </ThemeBlock>
@@ -68,7 +68,7 @@ export const withTheme: Decorator = (StoryFn, context) => {
 
     default:
       return (
-        <I18nManager>
+        <I18nManager language="en">
           <ThemeBlock position="fill" className={storyTheme}>
             <StoryFn />
           </ThemeBlock>

--- a/widget/ui/src/components/Alert/Alert.styles.ts
+++ b/widget/ui/src/components/Alert/Alert.styles.ts
@@ -153,6 +153,11 @@ export const IconHighlight = styled('div', {
         backgroundColor: '$$color',
       },
     },
+    align: {
+      center: {
+        alignSelf: 'center',
+      },
+    },
   },
 });
 

--- a/widget/ui/src/components/Toast/Toast.Provider.tsx
+++ b/widget/ui/src/components/Toast/Toast.Provider.tsx
@@ -1,0 +1,87 @@
+import type {
+  ProviderContext,
+  ProviderPropTypes,
+  ToastProps,
+  ToastType,
+} from './Toast.types';
+import type { PropsWithChildren } from 'react';
+
+import React, { createContext, useContext, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { Toast } from './Toast';
+import { idGenerator } from './Toast.helpers';
+import { ToastContainer } from './Toast.styles';
+
+const ToastContext = createContext<ProviderContext | undefined>(undefined);
+
+export const ToastProvider = (props: PropsWithChildren<ProviderPropTypes>) => {
+  const generateId = useMemo(() => idGenerator(), []);
+
+  const {
+    children,
+    anchorOrigin = {
+      horizontal: 'right',
+      vertical: 'bottom',
+    },
+    container,
+    containerStyle = {},
+  } = props;
+  const [toasts, setToasts] = useState<ToastProps[]>([]);
+
+  // eslint-disable-next-line react/jsx-no-constructed-context-values
+  const api: ProviderContext = {
+    addToast(content: ToastType) {
+      setToasts((toasts) => {
+        const isToastExistById = toasts.find(
+          (toast) => toast.id === content.id
+        );
+        if (isToastExistById) {
+          console.warn(
+            'Trying to send a toast with an existing ID. Please update the toast ID or use it after the toast is hidden'
+          );
+          return toasts;
+        }
+        return [
+          ...toasts,
+          {
+            ...content,
+            id: content.id || generateId(),
+            horizontal: anchorOrigin.horizontal,
+          },
+        ];
+      });
+    },
+    removeToast(id: number | string) {
+      setToasts((toasts) => toasts.filter((t) => t.id !== id));
+    },
+  };
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      {container &&
+        createPortal(
+          <ToastContainer
+            style={containerStyle}
+            horizontal={anchorOrigin.horizontal}
+            vertical={anchorOrigin.vertical}>
+            {toasts.map((toast) => (
+              <Toast {...toast} key={toast.id} />
+            ))}
+          </ToastContainer>,
+          container
+        )}
+    </ToastContext.Provider>
+  );
+};
+
+export function useToast(): ProviderContext {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error(
+      'useToast can only be used within the ToastProvider component'
+    );
+  }
+  return context;
+}

--- a/widget/ui/src/components/Toast/Toast.helpers.ts
+++ b/widget/ui/src/components/Toast/Toast.helpers.ts
@@ -1,0 +1,7 @@
+export function idGenerator() {
+  let id = 1;
+  return () => {
+    id++;
+    return id;
+  };
+}

--- a/widget/ui/src/components/Toast/Toast.stories.tsx
+++ b/widget/ui/src/components/Toast/Toast.stories.tsx
@@ -1,0 +1,71 @@
+import type { ToastProps } from './Toast.types';
+import type { Meta } from '@storybook/react';
+
+import React from 'react';
+
+import { Button } from '../Button';
+
+import { ToastStoryContainer } from './Toast.styles';
+
+import { Toast, ToastProvider, useToast } from '.';
+
+export default {
+  title: 'Components/Toast',
+  component: Toast,
+  args: {
+    type: 'success',
+    title: 'Please change your wallet network to Polygon',
+    autoHideDuration: 5_000,
+    horizontal: 'right',
+  },
+  argTypes: {
+    type: {
+      name: 'type',
+      control: {
+        type: 'select',
+        options: ['success', 'warning', 'error', 'info', 'loading'],
+      },
+    },
+  },
+} as Meta<typeof Toast>;
+
+export const TopToasts = (props: ToastProps) => {
+  return (
+    <ToastProvider
+      container={document.body}
+      anchorOrigin={{
+        horizontal: props.horizontal,
+        vertical: 'top',
+      }}>
+      <ToastComponent {...props} />
+    </ToastProvider>
+  );
+};
+
+export const BottomToasts = (props: ToastProps) => {
+  return (
+    <ToastProvider
+      container={document.body}
+      anchorOrigin={{
+        horizontal: props.horizontal,
+        vertical: 'bottom',
+      }}>
+      <ToastComponent {...props} />
+    </ToastProvider>
+  );
+};
+
+const ToastComponent = (props: ToastProps) => {
+  const { addToast } = useToast();
+
+  return (
+    <ToastStoryContainer>
+      <Button
+        variant="contained"
+        type="success"
+        onClick={() => addToast(props)}>
+        Show Toast
+      </Button>
+    </ToastStoryContainer>
+  );
+};

--- a/widget/ui/src/components/Toast/Toast.styles.ts
+++ b/widget/ui/src/components/Toast/Toast.styles.ts
@@ -1,0 +1,113 @@
+import { darkTheme, keyframes, lightTheme, styled } from '../../theme';
+import { Typography } from '../Typography';
+
+const toastOpacity = keyframes({
+  from: { opacity: 0 },
+  to: { opacity: 1 },
+});
+
+export const ToastContentContainer = styled('div', {
+  variants: {
+    horizontal: {
+      right: {
+        right: 12,
+        animation: `${toastOpacity} .7s`,
+      },
+      left: {
+        left: 12,
+        animation: `${toastOpacity} .7s`,
+      },
+    },
+  },
+});
+
+export const ToastContainer = styled('div', {
+  position: 'absolute',
+  zIndex: 9999,
+  display: 'flex',
+  gap: '$4',
+  flexDirection: 'column',
+  variants: {
+    horizontal: {
+      right: {
+        right: 12,
+      },
+      left: {
+        left: 12,
+      },
+    },
+
+    vertical: {
+      top: {
+        top: 2,
+      },
+      bottom: {
+        bottom: 2,
+      },
+    },
+  },
+});
+
+export const AlertBox = styled('div', {
+  display: 'flex',
+  borderRadius: '$sm',
+  width: '292px',
+  minHeight: '52px',
+  backgroundColor: '$background',
+  borderRight: '1px solid',
+  [`.${darkTheme} &`]: {
+    backgroundColor: '#070917',
+  },
+  '&:hover': {
+    backgroundColor: '$info100',
+    [`.${darkTheme} &`]: {
+      backgroundColor: '#111733',
+    },
+  },
+  variants: {
+    type: {
+      error: {
+        borderRightColor: '$error500',
+      },
+      success: {
+        borderRightColor: '$success500',
+      },
+      warning: {
+        borderRightColor: '$warning500',
+      },
+      info: {
+        borderRightColor: '$info500',
+      },
+      loading: {
+        borderRightColor: '$info500',
+      },
+    },
+  },
+});
+
+export const AlertFlexContainer = styled('div', {
+  display: 'flex',
+  padding: '$10',
+  alignItems: 'center',
+});
+
+export const StyledTypography = styled(Typography, {
+  variants: {
+    hasColor: {
+      false: {
+        [`.${lightTheme} &`]: {
+          color: '$neutral700',
+        },
+        [`.${darkTheme} &`]: {
+          color: '$neutral900',
+        },
+      },
+    },
+  },
+});
+
+export const ToastStoryContainer = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+});

--- a/widget/ui/src/components/Toast/Toast.tsx
+++ b/widget/ui/src/components/Toast/Toast.tsx
@@ -1,0 +1,59 @@
+import type { ToastProps } from './Toast.types';
+
+import React, { useEffect } from 'react';
+
+import { IconHighlight } from '../Alert/Alert.styles';
+import AlertIcon from '../Alert/AlertIcon';
+import { Divider } from '../Divider';
+
+import { useToast } from './Toast.Provider';
+import {
+  AlertBox,
+  AlertFlexContainer,
+  StyledTypography,
+  ToastContentContainer,
+} from './Toast.styles';
+
+const DEFAULT_HIDE_DURATION = 3_000;
+
+export const Toast = (props: ToastProps) => {
+  const { id, horizontal, autoHideDuration = DEFAULT_HIDE_DURATION } = props;
+  const { removeToast } = useToast();
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      removeToast(id);
+    }, autoHideDuration);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [id]);
+
+  return (
+    <ToastContentContainer horizontal={horizontal}>
+      {'component' in props ? (
+        props.component
+      ) : (
+        <AlertBox
+          onClick={() => removeToast(id)}
+          type={props.type}
+          style={props.style}>
+          <AlertFlexContainer>
+            <IconHighlight type={props.type} align="center">
+              <AlertIcon type={props.type} />
+            </IconHighlight>
+            <Divider direction="horizontal" size={10} />
+            <StyledTypography
+              variant="body"
+              size="small"
+              color={props.titleColor}
+              hasColor={!!props.titleColor}
+              align="left">
+              {props.title}
+            </StyledTypography>
+          </AlertFlexContainer>
+        </AlertBox>
+      )}
+    </ToastContentContainer>
+  );
+};

--- a/widget/ui/src/components/Toast/Toast.types.ts
+++ b/widget/ui/src/components/Toast/Toast.types.ts
@@ -1,0 +1,31 @@
+import type { Type } from '../Alert/Alert.types';
+import type { CSSProperties } from '@stitches/react';
+
+export interface ProviderPropTypes {
+  container: HTMLElement;
+  anchorOrigin?: {
+    horizontal: 'left' | 'right';
+    vertical: 'bottom' | 'top';
+  };
+  containerStyle?: CSSProperties;
+}
+
+export type ToastType = { autoHideDuration?: number; id?: number | string } & (
+  | {
+      title: string;
+      type: Type;
+      titleColor?: string;
+      style?: CSSProperties;
+    }
+  | { component: React.ReactNode }
+);
+
+export type ToastProps = ToastType & {
+  id: number | string;
+  horizontal: 'left' | 'right';
+};
+
+export type ProviderContext = {
+  addToast: (content: ToastType) => void;
+  removeToast: (id: number | string) => void;
+};

--- a/widget/ui/src/components/Toast/index.ts
+++ b/widget/ui/src/components/Toast/index.ts
@@ -1,0 +1,2 @@
+export { Toast } from './Toast';
+export { ToastProvider, useToast } from './Toast.Provider';

--- a/widget/ui/src/components/index.ts
+++ b/widget/ui/src/components/index.ts
@@ -29,6 +29,7 @@ export * from './SwapListItem';
 export * from './SwapDetailsPlaceholder';
 export * from './Switch';
 export * from './TextField';
+export * from './Toast';
 export * from './TokenList';
 export * from './TokenPreview';
 export * from './Tooltip';


### PR DESCRIPTION
# Summary
- Implemented  `Toast` component.


Toast component has not been used in widget (embedded) yet, and for testing its Provider should be used somewhere in widget. but for testing in dapp, it can be tested by linking this PR with this PR: https://github.com/rango-exchange/app/pull/45.

if you don't want to test in dapp and just test in widget, first you need to wrap one of higher components in widget with `ToastProvider`  like this:
```
<ToastProvider
      anchorOrigin={{
        vertical: 'top',
        horizontal: 'right',
      }}><Layout /></ToastProvider>
```
and then use addToast function inside it:
   ```
 addToast({
          title:'Hi',
          type: 'success',
        });
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
