### PR TITLE
fix: fix publish workflow status issue

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,4 +18,3 @@ jobs:
         run: node ./scripts/check-conventional-commits/command.mjs
         env:
           REF: ${{ github.ref }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,6 @@ jobs:
         run: yarn run deploy
         env:
           REF: ${{ github.ref }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
           GH_TOKEN: ${{ github.token }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -26,4 +25,4 @@ jobs:
           VERCEL_PROJECT_Q: ${{ secrets.VERCEL_PROJECT_Q }}
           VERCEL_PROJECT_WALLET_ADAPTER: ${{ secrets.VERCEL_PROJECT_WALLET_ADAPTER }}
           VERCEL_PROJECT_WIDGET_CONFIG: ${{ secrets.VERCEL_PROJECT_WIDGET_CONFIG }}
-          VERCEL_PROJECT_WIDGET_APP: ${{ secrets.VERCEL_PROJECT_WIDGET_APP }}  
+          VERCEL_PROJECT_WIDGET_APP: ${{ secrets.VERCEL_PROJECT_WIDGET_APP }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,7 @@ name: Publish
 on:
   push:
     branches:
-      - main
-  pull_request:
-    types:
-      - closed
-    branches:
+      - 'main'
       - 'next'
 
 jobs:
@@ -14,9 +10,9 @@ jobs:
     if: ${{ github.ref == 'refs/heads/next' }}
     uses: ./.github/workflows/crowdin.yml
     secrets:
-      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }} 
-      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }} 
-      PAT: ${{ secrets.PAT }} 
+      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      PAT: ${{ secrets.PAT }}
 
   publish:
     if: ${{ always() }}
@@ -33,19 +29,17 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }} 
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build, Version & Publish packages
         run: yarn run publish
         env:
           REF: ${{ github.ref }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
           GH_TOKEN: ${{ github.token }}
 
-      - name: Creating PR on next 
+      - name: Creating PR on next
         if: ${{ github.ref == 'refs/heads/main' }}
         run: yarn run post-release-prod
         env:
           REF: ${{ github.ref }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
           GH_TOKEN: ${{ github.token }}

--- a/docs/release.md
+++ b/docs/release.md
@@ -45,14 +45,16 @@ All the apps published by `prerelase` workflow will be published under the Verce
 
 ### Next (Staging)
 
-A publish only will be triggered when a **Pull Request** has been merged. If you try to commit directly into the `next` branch it wouldn't be triggered.
+A publish will be triggered when a **Pull Request** has been merged.
 
 First it tries to extracting translations (if any) and push them onto Crowdin, then releasing libraries will be started.
 _Note 1_: Syncing translations (first workflow) is an optional step which means if it fails we will do the publish anyway.
 
 ### Production
 
-For releasing production, you need to run `yarn release-prod` it will checkout to `next` branch and pull the latest changes then it tries to merge the `next` into `main`.
+For releasing production, you need to run `yarn release-prod` it will checkout to `next` branch and pull the latest changes then it tries to merge the `next` into `main` by `--no-ff` strategy, To make sure that a new commit is made And previous commits that may have `[skips ci]` Do not prevent workflow from triggering.
+
+
 _Note 1_: Make sure you are having permission for `push` on `main`.
 
 In production, we don't run localization workflow (crowdin) since we assume our `/translation` folder is in sync with Crowdin. if you think there is new translation, you can run `crowdin` workflow manually and then try to release.

--- a/scripts/common/git.mjs
+++ b/scripts/common/git.mjs
@@ -157,13 +157,10 @@ export async function publishCommitAndTags(pkgs) {
   let body = `Affected packages: ${tags.join(',')}`;
 
   /* 
-    When we are pushing a publish commit into main, it triggers a redundant workflow run,
+    When we are pushing a publish commit into main or next, it triggers a redundant workflow run,
     To avoid this, by adding a [skip ci] the workflow run will be skipped.
-    We don't need it on `next` since the next workflow is running on `pullrequest.closed` event.
   */
-  if (channel === 'prod') {
-    body += '\n[skip ci]';
-  }
+  body += '\n[skip ci]';
 
   // Making a publish commit
   await execa('git', ['commit', '-m', message, '-m', body]).catch((error) => {
@@ -244,8 +241,10 @@ export async function checkout(branch) {
   return output;
 }
 
-export async function merge(branch) {
-  const output = await execa('git', ['merge', branch])
+
+export async function merge(branch, mergeOptions) {
+  const { mergeStrategy = '' } = mergeOptions;
+  const output = await execa('git', ['merge', mergeStrategy, branch])
     .then(({ stdout }) => stdout)
     .catch((error) => {
       throw new GitError(`git merge failed. \n ${error.stderr}`);
@@ -253,6 +252,7 @@ export async function merge(branch) {
 
   return output;
 }
+
 
 export async function getLastCommitId() {
   const commitId = await execa('git', ['log', '--format=%s', '-n', 1])

--- a/scripts/common/github.mjs
+++ b/scripts/common/github.mjs
@@ -129,7 +129,6 @@ export function checkEnvironments() {
   const envs = {
     NPM_TOKEN: !!process.env.NPM_TOKEN,
     REF: !!process.env.REF,
-    BASE_REF: process.env.BASE_REF,
     GH_TOKEN: !!process.env.GH_TOKEN,
     VERCEL_ORG_ID: !!process.env.VERCEL_ORG_ID,
     VERCEL_TOKEN: !!process.env.VERCEL_TOKEN,

--- a/scripts/release/command.mjs
+++ b/scripts/release/command.mjs
@@ -7,7 +7,7 @@ async function run() {
 
   // Get latest changes from `next`
   const pullNextOutput = await pull();
-  console.log(`Result for: checkout\n`, pullNextOutput);
+  console.log(`Result for: pull\n`, pullNextOutput);
 
   // Checkout to `main`
   const checkoutOutput = await checkout('main');
@@ -18,7 +18,7 @@ async function run() {
   console.log(`Result for: pull\n`, pullOutput);
 
   // Merge `next` into `main`
-  const mergeOutput = await merge('next');
+  const mergeOutput = await merge('next',{ mergeStrategy: '--no-ff' });
   console.log(`Result for: merge\n`, mergeOutput);
 
   // Push merged commits to `main`


### PR DESCRIPTION
# Summary
I changed the triggering of the publishing workflow.
And now both Branch **Main** and  **Next** will be triggered on **push** any commit. It is also will be triggered when a Pull Request has been merged.

**[skip ci]** is added for release commits that do not trigger the workflow on **next** or **prod** publish again.

For releasing production,  it tries to merge the **next** into **main** by **--no-ff** strategy, To make sure that a new commit is made And previous commits that may have `[skips ci]` Do not prevent workflow from triggering.

Fixes # (issue)

- Fix close PR issue: Workflow should not be run when closing the PR. Now by putting the trigger on the **push**, this problem is solved.
- Fix the workflow status of each commit: When the PR trigger was on **pull_request**, The status of commit workflows was not detected. Now by putting the trigger on the **push**, this problem is solved.

# How did you test this change?

Testing scenarios:

- Making a pull request on **next** then merge the PR, it should publishing **next** versions correctly. 
- After merging PR into next, You can run yarn release-prod it should trigger the production Github Actions and publish production.


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
