### PR TITLE
chore: remove default wallet from playground

### DIFF
--- a/widget/playground/src/utils/common.ts
+++ b/widget/playground/src/utils/common.ts
@@ -49,6 +49,7 @@ export function tokensAreEqual(tokenA?: Asset, tokenB?: Asset) {
 }
 
 export const excludedWallets = [
+  WalletTypes.DEFAULT,
   WalletTypes.STATION,
   WalletTypes.LEAP,
   WalletTypes.SAFE,


### PR DESCRIPTION
# Summary
The playground displays the Default wallet type. There is no need for it, so this PR removes it from the wallet list in playground settings.

# Checklist:

- [x] I have performed a self-review of my code
