### PR TITLE
!WIP feat: add crowdin to release prod workflow

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -51,7 +51,7 @@ jobs:
           create_pull_request: true
           pull_request_title: '🤖chore(translation): update translations'
           pull_request_body: 'New Crowdin pull request with translations'
-          pull_request_base_branch_name: 'next'
+          pull_request_base_branch_name: ${{ github.ref == 'refs/heads/main' && 'main' || 'next' }}
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   localization:
-    if: ${{ github.ref == 'refs/heads/next' }}
     uses: ./.github/workflows/crowdin.yml
     secrets:
       CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}


### PR DESCRIPTION
# Summary

The condition that caused the crowdin job to run only on Next brnach has been removed. And now the Crowdin job is always running, both for Next and for Production.

In Crowdin's workflow, the branch is assigned to **pull_request_base_branch_name** from **gitHub.ref**.
So that the PR related to each branch is made and then it becomes merge.

Fixes # (issue)


# How did you test this change?

Testing scenarios:

Making a pull request on next then merge the PR, it should pull crowdin change and create pr to next branch.
After merging PR into next, You can run yarn release-prod it should pull crowdin change and create pr to main branch.


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
