### PR TITLE
chore: accept safe wallet messages from all domains

### DIFF
--- a/wallets/provider-safe/src/helpers.ts
+++ b/wallets/provider-safe/src/helpers.ts
@@ -3,7 +3,6 @@ import { SafeAppProvider } from '@safe-global/safe-apps-provider';
 import SafeAppsSDK, { TransactionStatus } from '@safe-global/safe-apps-sdk';
 
 const options = {
-  allowedDomains: [/gnosis-safe.io$/, /app.safe.global$/],
   debug: false,
 };
 


### PR DESCRIPTION
# Summary

The Safe wallet team is attempting to evaluate the functionality of the Rango Dapp, but the auto-connect feature is not functioning. We need to adjust the Safe wallet configuration so that it can accept messages from their domain.

Fixes # (issue)

remove "allowedDomains" from the Safe wallet options to enable the wallet to accept messages from any domain.

# How did you test this change?

Link wallet packages within the Rango Dapp and test the Rango Dapp in the Safe custom apps.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works

