### PR TITLE
chore: fix linter for monorepo root files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,6 @@
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module",
-    // "project": ["tsconfig.base.json"]
     "project": true
   },
   "rules": {

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,0 +1,14 @@
+import micromatch from 'micromatch';
+
+const eslintIgnoredFiles = ['**/global-wallets-env.d.ts'];
+
+export default {
+  '*.{ts,tsx}': (files) => {
+    const match = micromatch.not(files, eslintIgnoredFiles);
+    return `eslint --fix --quiet ${match.join(' ')}`;
+  },
+
+  '*.{ts,tsx,json}': (files) => {
+    return `prettier --write ${files.join(' ')}`;
+  },
+};

--- a/package.json
+++ b/package.json
@@ -101,13 +101,5 @@
   },
   "resolutions": {
     "react-refresh": "0.9.0"
-  },
-  "lint-staged": {
-    "*.{ts,tsx}": [
-      "eslint --fix --quiet"
-    ],
-    "*.{ts,tsx,json}": [
-      "prettier --write"
-    ]
   }
 }


### PR DESCRIPTION
# Summary

Typescript parser needs to point a `tsconfig`, by passing `project: true` it uses nearest `tsconifg.json` but the problem is we don't have any `tsconfig.json` in root. I fixed it by ignoring root files using `projectFolderIgnoreList` option.

More datails: 
https://typescript-eslint.io/packages/parser/#project

Fixes RNG-1221


# How did you test this change?

Try to change some files in root and then run the linter on the file using:

```
npx eslint global-wallets-env.d.ts --ignore-path ./.eslintignore
```

And also do some changes that breaks our eslint rules then add them to your git's stage then run following command:
```
npx lint-staged  
```

