### PR TITLE
feat: add production release workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,3 +18,16 @@ jobs:
         run: node ./scripts/check-conventional-commits/command.mjs
         env:
           REF: ${{ github.ref }}
+
+  localization:
+    if: ${{ github.base_ref == 'main' }}
+    uses: ./.github/workflows/crowdin.yml
+    needs:
+      - check
+    secrets:
+      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      PAT: ${{ secrets.PAT }}
+    with:
+      create_pull_request: false
+      localization_branch_name: ${{github.head_ref}}

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,12 +1,16 @@
 name: Sync translations using Crowdin
+env:
+  LOCALIZATION_BRANCH_NAME: 'l10n_crowdin_translations'
 
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'to trigger the workflow manually'
+      create_pull_request:
+        description: 'It requires pull request'
         required: false
-        type: string
+        default: true
+        type: boolean
+
   workflow_call:
     secrets:
       CROWDIN_PROJECT_ID:
@@ -17,6 +21,15 @@ on:
         required: true
       PAT:
         description: 'Add a PAT to secrets.'
+        required: true
+    inputs:
+      localization_branch_name:
+        description: 'Target branch name for new commit'
+        required: false
+        type: string
+      create_pull_request:
+        description: 'It requires pull request'
+        type: boolean
         required: true
 
 jobs:
@@ -47,8 +60,8 @@ jobs:
           token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           commit_message: 'chore(translation): update translations [skip ci]'
 
-          localization_branch_name: l10n_crowdin_translations
-          create_pull_request: true
+          localization_branch_name: ${{inputs.localization_branch_name || env.LOCALIZATION_BRANCH_NAME}}
+          create_pull_request: ${{inputs.create_pull_request}}
           pull_request_title: '🤖chore(translation): update translations'
           pull_request_body: 'New Crowdin pull request with translations'
           pull_request_base_branch_name: 'next'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,9 @@
-name: Publish
+name: Release
 on:
-  push:
-    branches:
-      - 'main'
-      - 'next'
+  workflow_dispatch:
 
 jobs:
   localization:
-    if: ${{ github.ref == 'refs/heads/next' }}
     uses: ./.github/workflows/crowdin.yml
     secrets:
       CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
@@ -16,8 +12,7 @@ jobs:
     with:
       create_pull_request: true
 
-  publish:
-    if: ${{ always() }}
+  release:
     runs-on: ubuntu-latest
     needs:
       - localization
@@ -26,15 +21,14 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT }}
-      - run: git pull
 
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Build, Version & Publish packages
-        run: yarn run publish
+      - name: Release Production
+        run: yarn run release-prod
         env:
           REF: ${{ github.ref }}
           GH_TOKEN: ${{ github.token }}

--- a/docs/release.md
+++ b/docs/release.md
@@ -27,9 +27,8 @@ Libs will be published under `next` tag on npm, which means you need to use `yar
 
 #### Production relase
 
-Release should be triggered manually and then it will automatically published. You only need to run this command on you local machine to release the production:
+There is a workflow called `Production Release`, you just need to run this workflow manually and then it will automatically published.
 
-`yarn run release-prod`
 
 ### Deploy flow
 
@@ -52,11 +51,11 @@ _Note 1_: Syncing translations (first workflow) is an optional step which means 
 
 ### Production
 
-For releasing production, you need to run `yarn release-prod` it will checkout to `next` branch and pull the latest changes then it tries to merge the `next` into `main` by `--no-ff` strategy, To make sure that a new commit is made And previous commits that may have `[skips ci]` Do not prevent workflow from triggering.
+For releasing production, you need to run `Production Release` workflow, it will pull the latest translation changes on `next` branch and checkout to `next` branch and pull the latest changes then it tries to merge the `next` into `main` by `--no-ff` strategy, To make sure that a new commit is made And previous commits that may have `[skips ci]` Do not prevent workflow from triggering.
 
 
 _Note 1_: Make sure you are having permission for `push` on `main`.
 
-In production, we don't run localization workflow (crowdin) since we assume our `/translation` folder is in sync with Crowdin. if you think there is new translation, you can run `crowdin` workflow manually and then try to release.
+In production, we don't run localization workflow again (crowdin) since we assume our `/translation` folder is in sync with Crowdin. if you think there is new translation, you can run `crowdin` workflow manually and then try to release.
 
 At the end, a PR will be created to merge `main` into `next` after publishing the libraries. You need to check the PR description and make sure you are considering/doing them.

--- a/scripts/common/constants.mjs
+++ b/scripts/common/constants.mjs
@@ -1,2 +1,3 @@
 /** A fixed subject for using in publish commit. */
 export const PUBLISH_COMMIT_SUBJECT = 'chore(release): publish';
+export const NPM_ORG_NAME = '@rango-dev';

--- a/scripts/common/utils.mjs
+++ b/scripts/common/utils.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { execa } from 'execa';
 import process from 'node:process';
+import { NPM_ORG_NAME } from './constants.mjs';
 
 const root = join(printDirname(), '..', '..');
 
@@ -91,3 +92,14 @@ export function getEnvWithFallback(name) {
 export function generateTagName(pkg) {
   return `${packageNameWithoutScope(pkg.name)}@${pkg.version}`;
 }
+
+/**
+ * Opposite of `generateTagName`
+ *
+ * @param {string} pkgNameWithoutScope
+ * @returns
+ */
+export function tagNameToPkgName(pkgNameWithoutScope) {
+  return `${NPM_ORG_NAME}/${pkgNameWithoutScope}`;
+}
+

--- a/scripts/post-release/command.mjs
+++ b/scripts/post-release/command.mjs
@@ -1,17 +1,18 @@
-import { checkout, pull } from '../common/git.mjs';
-import { createPullRequest } from '../common/github.mjs';
+import { checkout, merge, pull, push } from '../common/git.mjs';
+import { checkCommitAndGetPkgs } from './tag.mjs';
 
 async function run() {
   // Make sure we are on main and having latest changes
   await checkout('main');
   await pull();
 
-  await createPullRequest({
-    title: '🤖 Post Release',
-    branch: 'main',
-    baseBranch: 'next',
-    templatePath: '.github/PUBLISH_TEMPLATE.md',
-  });
+  await checkCommitAndGetPkgs();
+
+  // Merge phase
+  await checkout('next');
+  await pull();
+  await merge('main', { mergeStrategy: '--no-ff' });
+  await push();
 }
 
 run().catch((e) => {

--- a/scripts/post-release/tag.mjs
+++ b/scripts/post-release/tag.mjs
@@ -1,0 +1,42 @@
+import { PUBLISH_COMMIT_SUBJECT } from '../common/constants.mjs';
+import { getLastCommitMessage, getLastCommitSubject } from '../common/git.mjs';
+import { tagNameToPkgName } from '../common/utils.mjs';
+
+/**
+ *
+ * @returns {Promise<pkg[]>}
+ * @typedef {Object} pkg
+ * @property {string} pkg.name
+ * @property {string} pkg.version
+ */
+export async function checkCommitAndGetPkgs() {
+  const lastCommitSubject = await getLastCommitSubject();
+  const lastCommitMessage = await getLastCommitMessage();
+
+  if (lastCommitSubject !== PUBLISH_COMMIT_SUBJECT) {
+    throw new Error('Can not proceed');
+  }
+
+  const lines = lastCommitMessage.split('\n');
+  const affectedPackagesList = lines.find((line) =>
+    line.startsWith('Affected packages:')
+  );
+
+  if (!affectedPackagesList) {
+    throw new Error("Commit message isn't valid");
+  }
+
+  const [, affectedPackages] = affectedPackagesList.split(
+    'Affected packages: '
+  );
+  const pkgs = affectedPackages.split(',').map((pkg) => {
+    const [name, version] = pkg.split('@');
+
+    return {
+      name: tagNameToPkgName(name),
+      version: version,
+    };
+  });
+
+  return pkgs;
+}


### PR DESCRIPTION
# Summary

A new workflow named **Production Release**  has been added, which takes the latest translation changes on the **next** branch and then automatically performs the production release.


# How did you test this change?

Testing scenarios:

Making a pull request on next then merge the PR, After merging PR into next, You can run yarn **production release** workflow manually, it should pull crowdin change on **next** branch and then it will automatically published.


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
