### PR TITLE
feat: add dynamicHeight to iframe

### DIFF
--- a/widget/embedded/src/components/Layout/Layout.styles.ts
+++ b/widget/embedded/src/components/Layout/Layout.styles.ts
@@ -6,7 +6,7 @@ export const Container = styled('div', {
   display: 'flex',
   flexDirection: 'column',
   borderRadius: '$primary',
-  width: '100vh',
+  width: '100vw',
   minWidth: '300px',
   maxWidth: '390px',
   boxShadow: '15px 15px 15px 0px rgba(0, 0, 0, 0.05)',

--- a/widget/embedded/src/constants/searchParams.ts
+++ b/widget/embedded/src/constants/searchParams.ts
@@ -5,4 +5,6 @@ export enum SearchParams {
   TO_TOKEN = 'toToken',
   FROM_AMOUNT = 'fromAmount',
   AUTO_CONNECT = 'autoConnect',
+  // iframe environments
+  CLIENT_URL = 'clientUrl',
 }

--- a/widget/embedded/src/hooks/useIframe/index.ts
+++ b/widget/embedded/src/hooks/useIframe/index.ts
@@ -1,0 +1,1 @@
+export { useIframe } from './useIframe';

--- a/widget/embedded/src/hooks/useIframe/useIframe.helpers.ts
+++ b/widget/embedded/src/hooks/useIframe/useIframe.helpers.ts
@@ -1,0 +1,3 @@
+export function isAppLoadedIntoIframe() {
+  return window.self !== window.top;
+}

--- a/widget/embedded/src/hooks/useIframe/useIframe.ts
+++ b/widget/embedded/src/hooks/useIframe/useIframe.ts
@@ -1,0 +1,55 @@
+import type { Messages } from './useIframe.types';
+
+import { useRef } from 'react';
+
+import { useAppStore } from '../../store/AppStore';
+
+import { isAppLoadedIntoIframe } from './useIframe.helpers';
+
+interface UseIframe {
+  send: (message: Messages) => void;
+  connectHeightObserver: (element: HTMLElement) => void;
+  disconnectHeightObserver: () => void;
+}
+
+function useIframe(): UseIframe {
+  const heightObserver = useRef<ResizeObserver | null>(null);
+  const { iframe } = useAppStore();
+  const isMessagePassingAvailable = isAppLoadedIntoIframe() && iframe.clientUrl;
+
+  const send = (message: Messages) => {
+    if (isMessagePassingAvailable) {
+      window.top?.postMessage(message, iframe.clientUrl!);
+    }
+  };
+
+  const connectHeightObserver = (element: HTMLElement) => {
+    heightObserver.current = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        send({
+          type: 'widget_height',
+          data: {
+            height: entry.contentRect.height,
+          },
+        });
+      }
+    });
+
+    heightObserver.current.observe(element);
+  };
+
+  const disconnectHeightObserver = () => {
+    if (heightObserver.current) {
+      heightObserver.current.disconnect();
+      heightObserver.current = null;
+    }
+  };
+
+  return {
+    send,
+    connectHeightObserver,
+    disconnectHeightObserver,
+  };
+}
+
+export { useIframe };

--- a/widget/embedded/src/hooks/useIframe/useIframe.types.ts
+++ b/widget/embedded/src/hooks/useIframe/useIframe.types.ts
@@ -1,0 +1,13 @@
+type Message<T, D> = {
+  type: T;
+  data: D;
+};
+type WidgetHeightMessage = Message<
+  'widget_height',
+  {
+    height: number;
+  }
+>;
+
+// Add new types of messages to this union.
+export type Messages = WidgetHeightMessage;

--- a/widget/embedded/src/hooks/useSyncUrlAndStore/useSyncUrlAndStore.ts
+++ b/widget/embedded/src/hooks/useSyncUrlAndStore/useSyncUrlAndStore.ts
@@ -33,6 +33,7 @@ export function useSyncUrlAndStore() {
   const blockchains = useAppStore().blockchains();
   const tokens = useAppStore().tokens();
   const isInRouterContext = useInRouterContext();
+  const { updateIframe } = useAppStore();
 
   const getUrlSearchParams = () => {
     const fromAmount = searchParams.get(SearchParams.FROM_AMOUNT);
@@ -41,6 +42,7 @@ export function useSyncUrlAndStore() {
     const toBlockchain = searchParams.get(SearchParams.TO_BLOCKCHAIN);
     const toToken = searchParams.get(SearchParams.TO_TOKEN);
     const autoConnect = searchParams.get(SearchParams.AUTO_CONNECT);
+    const clientUrl = searchParams.get(SearchParams.CLIENT_URL);
 
     return {
       fromAmount,
@@ -49,6 +51,7 @@ export function useSyncUrlAndStore() {
       toBlockchain,
       toToken,
       autoConnect,
+      clientUrl,
     };
   };
 
@@ -64,7 +67,7 @@ export function useSyncUrlAndStore() {
   };
 
   useEffect(() => {
-    const { autoConnect } = getUrlSearchParams();
+    const { autoConnect, clientUrl } = getUrlSearchParams();
     if (isInRouterContext && fetchMetaStatus === 'success') {
       updateUrlSearchParams({
         [SearchParams.FROM_BLOCKCHAIN]: fromBlockchain?.name,
@@ -73,6 +76,7 @@ export function useSyncUrlAndStore() {
         [SearchParams.TO_TOKEN]: tokenToSearchParam(toToken),
         [SearchParams.FROM_AMOUNT]: inputAmount,
         [SearchParams.AUTO_CONNECT]: autoConnect ?? undefined,
+        [SearchParams.CLIENT_URL]: clientUrl ?? undefined,
       });
     }
   }, [
@@ -132,4 +136,10 @@ export function useSyncUrlAndStore() {
       }
     }
   }, [fetchMetaStatus]);
+
+  // We run this only once, because if the app is embedded into an iframe, the data in url for iframe will not change.
+  useEffect(() => {
+    const { clientUrl } = getUrlSearchParams();
+    updateIframe('clientUrl', clientUrl || undefined);
+  }, []);
 }

--- a/widget/embedded/src/store/slices/config.ts
+++ b/widget/embedded/src/store/slices/config.ts
@@ -9,10 +9,25 @@ export const DEFAULT_CONFIG: WidgetConfig = {
   customDestination: true,
 };
 
-export type ConfigSlice = {
-  config: WidgetConfig;
+interface IframeConfigs {
+  clientUrl?: string;
+}
 
+const DEFAULT_IFRAME_CONFIGS: IframeConfigs = {
+  clientUrl: undefined,
+};
+
+export type ConfigSlice = {
+  // What user can set directly.
+  config: WidgetConfig;
   updateConfig: (config: WidgetConfig) => void;
+
+  // What we are setting based on enviroments.
+  iframe: { clientUrl?: string };
+  updateIframe: <K extends keyof IframeConfigs>(
+    name: K,
+    value: IframeConfigs[K]
+  ) => void;
 };
 
 export const createConfigSlice: StateCreatorWithInitialData<
@@ -22,6 +37,7 @@ export const createConfigSlice: StateCreatorWithInitialData<
 > = (initialData, set, get) => {
   return {
     config: { ...DEFAULT_CONFIG, ...initialData },
+    iframe: DEFAULT_IFRAME_CONFIGS,
 
     // Actions
     updateConfig: (nextConfig: WidgetConfig) => {
@@ -31,6 +47,17 @@ export const createConfigSlice: StateCreatorWithInitialData<
         config: {
           ...currentConfig,
           ...nextConfig,
+        },
+      });
+    },
+
+    updateIframe: (name, value) => {
+      const currentIframeConfig = get().iframe;
+
+      set({
+        iframe: {
+          ...currentIframeConfig,
+          [name]: value,
         },
       });
     },

--- a/widget/iframe/src/main.ts
+++ b/widget/iframe/src/main.ts
@@ -1,23 +1,119 @@
 import type { WidgetConfig } from '@rango-dev/widget-embedded';
 
-import { commonStyles } from './styles';
+import {
+  applyCommonStyles,
+  applyDefaultStyles,
+  applyDynamicHeightStyles,
+} from './styles';
+import { canParse } from './utils';
 
 // Actual app that will be loaded inside the iframe.
 const WIDGET_URL = 'https://widget.rango.exchange/';
 const DEFAULT_CONTAINER_ID = 'rango-widget-container';
 const RANGO_WIDGET_IFRAME_ID = 'rango-widget-iframe';
 
+interface Options {
+  rootId?: string;
+  clientUrl?: string;
+  widgetUrl?: string;
+}
+
+interface Features {
+  dynamicHeight: boolean;
+}
+
+/**
+ * TODO: we should add a new path to our build process to be able to use some internal types.
+ * esm supports for `exports` in package json which will be useful for this use case.
+ * The bellow type should come from `widget/embedded/src/hooks/useIframe/useIframe.types.ts`.
+ */
+type Messages = any;
+
 export class RangoWidget {
-  public init(configuration?: WidgetConfig, rootId?: string): void {
-    const container = this.getContainer(rootId || DEFAULT_CONTAINER_ID);
-    const widget = this.createWidget(configuration);
+  private widget: HTMLIFrameElement | null = null;
+  private features: Features = {
+    dynamicHeight: false,
+  };
+  private options?: Options;
 
-    container.appendChild(widget);
+  public init(configuration?: WidgetConfig, options?: string | Options) {
+    /**
+     * It was only an string for setting rootId previously, so for backward compatibility we should keep the string yet.
+     * Here, we are parsing the value and convert it to an object.
+     */
+    this.parseOptions(options);
 
-    widget.onload = () => {
-      widget.style.display = 'block';
+    if (!!this.options?.widgetUrl && !canParse(this.options.widgetUrl)) {
+      throw new Error('You need to pass a valid `widgetUrl`.');
+    }
+
+    if (!!this.options?.clientUrl && !canParse(this.options.clientUrl)) {
+      throw new Error('You need to pass a valid `clientUrl`.');
+    }
+
+    // Create widget
+    this.createWidget(configuration);
+    if (!this.widget) {
+      throw new Error("Widget element hasn't been created yet.");
+    }
+
+    // Append the widget to target container
+    const rootId = this.options?.rootId || DEFAULT_CONTAINER_ID;
+    const container = this.getContainer(rootId);
+    container.appendChild(this.widget);
+
+    // Listening to events
+    this.widget.onload = () => {
+      this.widget!.style.display = 'block';
+    };
+
+    if (!!this.options?.clientUrl) {
+      this.listenToMessages();
+    }
+
+    return this.builder();
+  }
+
+  /**
+   *
+   * Activating feature
+   * This script can have different features that needs to be activated by user explicitly.
+   *
+   * @param feature
+   * @returns
+   */
+  public activate(feature: keyof Features) {
+    if (!this.widget) {
+      throw new Error(
+        "It seems you didn't call `init`. Please first setup iframe using `init` then try to activate a feature."
+      );
+    }
+    if (!this.options?.clientUrl) {
+      throw new Error(
+        "You need to pass `clientUrl` in your init's options to be able to use iframe features."
+      );
+    }
+    if (!(feature in this.features)) {
+      throw new Error(`${feature} is not a valid feature.`);
+    }
+
+    this.features[feature] = true;
+
+    return this.builder();
+  }
+
+  /**
+   * We can call some specific methods like a chain by using this pattern.
+   * It will be like: rango().activate('a').activate('b')
+   */
+  private builder(): {
+    activate: RangoWidget['activate'];
+  } {
+    return {
+      activate: this.activate.bind(this),
     };
   }
+
   /**
    * Encode configuration object into a string that can be passed as url param.
    */
@@ -50,25 +146,59 @@ export class RangoWidget {
   /**
    * Creating an iframe node with desired attributes to load the widget.
    */
-  private createWidget(configuration?: WidgetConfig): HTMLIFrameElement {
+  private createWidget(configuration?: WidgetConfig) {
     if (!configuration) {
       throw new Error('Make sure you are passing configurations.');
     }
 
     const configs = this.encode(configuration);
-    const url = `${WIDGET_URL}?config=${configs}`;
-
+    const baseUrl = this.options?.widgetUrl || WIDGET_URL;
+    let url = `${baseUrl}?config=${configs}`;
     const widget = document.createElement('iframe');
     widget.setAttribute('id', RANGO_WIDGET_IFRAME_ID);
-    widget.src = url;
-    widget.style.backgroundColor = 'transparent';
-    widget.style.width = commonStyles.width;
-    widget.style.height = commonStyles.height;
-    widget.style.maxWidth = commonStyles.maxWidth;
-    widget.style.maxHeight = commonStyles.maxHeight;
-    widget.style.overflow = commonStyles.overflow;
-    widget.style.border = 'none';
 
-    return widget;
+    if (this.options?.clientUrl) {
+      url += `&clientUrl=${encodeURI(this.options.clientUrl)}`;
+      applyDynamicHeightStyles(widget);
+    } else {
+      applyCommonStyles(widget);
+      applyDefaultStyles(widget);
+    }
+    widget.src = url;
+    this.widget = widget;
+  }
+
+  /**
+   * Listening to messages and react to events sent by widget.
+   */
+  private listenToMessages() {
+    window.addEventListener('message', (e) => {
+      if (this.features.dynamicHeight && e.data.type === 'widget_height') {
+        this.onWidgetHeightChange(e.data);
+      }
+    });
+  }
+
+  private onWidgetHeightChange(message: Messages) {
+    if (!this.widget) {
+      return;
+    }
+    this.widget.style.height = message.data.height;
+  }
+
+  /**
+   * This is for backward compatibility. Previously we only got `rootId` as option and second parameter of `init`.
+   */
+  private parseOptions(options?: string | Options) {
+    let opts: Options | undefined = undefined;
+    if (typeof options === 'string') {
+      opts = {
+        rootId: options,
+      };
+    } else if (typeof options !== 'undefined') {
+      opts = options;
+    }
+
+    this.options = opts;
   }
 }

--- a/widget/iframe/src/styles.ts
+++ b/widget/iframe/src/styles.ts
@@ -1,7 +1,18 @@
-export const commonStyles = {
-  width: '100vw',
-  maxWidth: '390px',
-  height: '100vh',
-  maxHeight: '700px',
-  overflow: 'hidden',
-};
+export function applyCommonStyles(element: HTMLIFrameElement) {
+  element.style.width = '100vw';
+  element.style.maxWidth = '390px';
+  element.style.overflow = 'hidden';
+  element.style.backgroundColor = 'transparent';
+  element.style.border = 'none';
+}
+
+export function applyDefaultStyles(element: HTMLIFrameElement) {
+  applyCommonStyles(element);
+  element.style.height = '100vh';
+  element.style.maxHeight = '700px';
+}
+export function applyDynamicHeightStyles(element: HTMLIFrameElement) {
+  applyCommonStyles(element);
+  // This is an initial value when widget hasn't been loaded completely.
+  element.style.height = '390px';
+}

--- a/widget/iframe/src/utils.ts
+++ b/widget/iframe/src/utils.ts
@@ -1,0 +1,11 @@
+// URL.canParse hasn't good support yet, so using a polyfill if it's not available.
+export function canParse(url: string) {
+  if ('canParse' in window.URL) {
+    return URL.canParse(url);
+  }
+  try {
+    return !!new URL(url);
+  } catch (error) {
+    return false;
+  }
+}


### PR DESCRIPTION
# Summary

We've a new feature for iframes to be able to get the swap box/widget height. There are some solutions to solve this:

1. Adding a new config to detect iframe
2. Using message passing to set some inital values (widget url is need to send messages between origins)
3. Using query param to set the initial value

The first one will pollute our public API for widget, so this is last thing I wanted. I tried the second approach but it has some issues regarding we couldn't detect when dom is ready in embedded page in iframe. I chose the last one, I added a `clientUrl` to be set from our iframe script, it will be used to send message between origins.

I also introduced a new standard way for our message passing. Another change is adding a feature management to our iframe script so user can activate them only if they need. 

Fixes RF-1192
Draft PR: https://github.com/rango-exchange/rango-client/pull/510 


# How did you test this change?

You first need to `cd widget/iframe && yarn build ` then copy the `index.js` inside `/dist`.

There is another PR here: https://github.com/rango-exchange/widget-examples/pull/3

You can copy the `index.js` into `/iframe` in `widget-example` then script `src` path to point to your local js file instead of production build.



# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.

