### PR TITLE
feat: add transitionDuration prop to modal

### DIFF
--- a/widget/ui/src/components/Modal/Modal.tsx
+++ b/widget/ui/src/components/Modal/Modal.tsx
@@ -20,7 +20,7 @@ import {
 } from './Modal.styles';
 
 const CLOSED_DELAY = 600;
-const OPEN_DELAY = 300;
+const OPEN_DELAY = 10;
 
 export function Modal(props: PropsWithChildren<PropTypes>) {
   const {
@@ -38,7 +38,9 @@ export function Modal(props: PropsWithChildren<PropTypes>) {
     footer,
     hasLogo = true,
     hasCloseIcon = true,
+    transitionDuration,
   } = props;
+
   const [active, setActive] = useState(false);
   const [isMount, setIsMount] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -58,13 +60,13 @@ export function Modal(props: PropsWithChildren<PropTypes>) {
         container.style.overflow = 'hidden';
         timeoutRef.current = setTimeout(() => {
           setActive(true);
-        }, OPEN_DELAY);
+        }, transitionDuration?.enter || OPEN_DELAY);
       } else {
         setActive(false);
         timeoutRef.current = setTimeout(() => {
           setIsMount(false);
           container.style.removeProperty('overflow');
-        }, CLOSED_DELAY);
+        }, transitionDuration?.exit || CLOSED_DELAY);
       }
     }
     return () => {

--- a/widget/ui/src/components/Modal/Modal.types.ts
+++ b/widget/ui/src/components/Modal/Modal.types.ts
@@ -19,4 +19,8 @@ export interface PropTypes {
   footer?: React.ReactNode;
   hasLogo?: boolean;
   hasCloseIcon?: boolean;
+  transitionDuration?: {
+    enter?: number;
+    exit?: number;
+  };
 }


### PR DESCRIPTION
# Summary

Added a transition duration prop to modal component to have a access to change the transition of modal. 


# Checklist:

- [x] I have performed a self-review of my code
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
