### PR TITLE
fix: fix virtual list flicker in history page

### DIFF
--- a/widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx
+++ b/widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx
@@ -4,6 +4,7 @@ import { i18n } from '@lingui/core';
 import {
   Divider,
   GroupedVirtualizedList,
+  Skeleton,
   SwapListItem,
   Typography,
 } from '@rango-dev/ui';
@@ -50,39 +51,29 @@ export function HistoryGroupedList(props: PropTypes) {
   }, [isLoading, loadMore]);
 
   if (isLoading) {
-    const swaps = [{}, {}];
-
-    const loadingGroups = [
-      {
-        title: i18n.t('Today'),
-        swaps,
-      },
-      {
-        title: i18n.t('This month'),
-        swaps,
-      },
-    ];
+    // The number of items presented in each group.
+    const swaps = [1, 2];
+    const loadingGroups = [swaps, swaps];
     return (
       <>
-        {loadingGroups.map((group) => (
-          <Group key={group.title}>
-            <Time>
-              <Typography
-                variant="label"
-                size="medium"
-                className={groupStyles()}>
-                {group.title}
-              </Typography>
-            </Time>
-            <Divider size={4} />
-            <SwapList>
-              {group.swaps.map((_, index) => {
-                const key = index + group.title;
-                return <SwapListItem isLoading={true} key={key} />;
-              })}
-            </SwapList>
-          </Group>
-        ))}
+        {loadingGroups.map((group, index) => {
+          const key = index;
+          return (
+            <Group key={key}>
+              <Time>
+                <Skeleton variant="text" width={60} size="small" />
+                <Divider size={16} />
+              </Time>
+              <Divider size={4} />
+              <SwapList>
+                {group.map((_, index) => {
+                  const key = index;
+                  return <SwapListItem isLoading={true} key={key} />;
+                })}
+              </SwapList>
+            </Group>
+          );
+        })}
       </>
     );
   }
@@ -111,6 +102,9 @@ export function HistoryGroupedList(props: PropTypes) {
       }}
       itemContent={(index, groupIndex) => {
         const swap = swaps[index];
+        if (!swap) {
+          return null;
+        }
         const firstStep = swap.steps[0];
         const lastStep = swap.steps[swap.steps.length - 1];
         return (


### PR DESCRIPTION
# Summary

When refreshing the widget on the history page, there is a brief flickering of the list of swaps during the initial rendering.

Fixes # (issue)

- [ ] Utilize the defaultItemHeight prop on the GroupedVirtualizedList :
https://github.com/petyosi/react-virtuoso/issues/734
https://github.com/petyosi/react-virtuoso/issues/734#issuecomment-1219926838

- [x] Fix the bug that causes an error when searching for an item that doesn't exist in the list.
- [x] Add Skeleton for the time labels ( today, this month , ... )

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas

Update: 
Due to the limitations of the react-virtuoso package in resolving the issue and its primary function of calculating dimensions for lists, coupled with the fact that the issue is more apparent in development than in a production build, we have chosen not to make any modifications at this time.