### PR TITLE
fix: remove auto scroll behavior from collapsible components

### DIFF
--- a/widget/embedded/src/components/CustomCollapsible/CustomCollapsible.tsx
+++ b/widget/embedded/src/components/CustomCollapsible/CustomCollapsible.tsx
@@ -1,12 +1,11 @@
 import type { PropTypes } from './CustomCollapsible.types';
 import type { PropsWithChildren } from 'react';
 
-import React, { useLayoutEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 
 import {
   CollapsibleContent,
   CollapsibleRoot,
-  EXPANDABLE_TRANSITION_DURATION,
   Trigger,
 } from './CustomCollapsible.styles';
 
@@ -21,14 +20,6 @@ export function CustomCollapsible(props: PropsWithChildren<PropTypes>) {
     triggerAnchor,
   } = props;
   const ref = useRef<HTMLDivElement | null>(null);
-
-  useLayoutEffect(() => {
-    if (open && ref.current) {
-      setTimeout(() => {
-        ref?.current?.scrollIntoView({ behavior: 'smooth' });
-      }, EXPANDABLE_TRANSITION_DURATION);
-    }
-  }, [open]);
 
   return (
     <CollapsibleRoot

--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -13,7 +13,7 @@ import {
   Typography,
 } from '@rango-dev/ui';
 import BigNumber from 'bignumber.js';
-import React, { useLayoutEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import {
   PERCENTAGE_CHANGE_MAX_DECIMALS,
@@ -42,7 +42,6 @@ import {
   basicInfoStyles,
   ContainerInfoOutput,
   Content,
-  EXPANDABLE_QUOTE_TRANSITION_DURATION,
   FrameIcon,
   HorizontalSeparator,
   QuoteContainer,
@@ -69,7 +68,6 @@ export function Quote(props: QuoteProps) {
 
   const [expanded, setExpanded] = useState(props.expanded);
   const quoteRef = useRef<HTMLButtonElement | null>(null);
-  const prevExpanded = useRef(expanded);
   const roundedInput = numberToString(
     input.value,
     TOKEN_AMOUNT_MIN_DECIMALS,
@@ -263,14 +261,6 @@ export function Quote(props: QuoteProps) {
   const steps = getQuoteSteps(quote.result?.swaps ?? []);
   const numberOfSteps = steps.length;
   const tooltipContainer = getContainer();
-  useLayoutEffect(() => {
-    if (expanded && !prevExpanded.current && quoteRef.current) {
-      setTimeout(() => {
-        quoteRef?.current?.scrollIntoView({ behavior: 'smooth' });
-      }, EXPANDABLE_QUOTE_TRANSITION_DURATION);
-    }
-    prevExpanded.current = expanded;
-  }, [expanded, prevExpanded]);
 
   return (
     <>


### PR DESCRIPTION
# Summary

In this pull request, we eliminated the auto-scroll feature present in collapsible components such as the quote and fee modal, which used to trigger the scrolling of the entire app utilizing the widget. Our plan is to implement a more robust solution for this behavior in the future.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works