### PR TITLE
fix: fix some swap messages in widget-embedded

### DIFF
--- a/queue-manager/rango-preset/src/actions/executeTransaction.ts
+++ b/queue-manager/rango-preset/src/actions/executeTransaction.ts
@@ -16,6 +16,7 @@ import {
   isNeedBlockQueueForParallel,
   isNetworkMatchedForTransaction,
   isRequiredWalletConnected,
+  isWalletNull,
   resetNetworkStatus,
   signTransaction,
   updateNetworkStatus,
@@ -62,7 +63,7 @@ export async function executeTransaction(
       (w) => !w.accounts?.find((account) => account.walletType === type)
     );
     const description =
-      !wallets || isWalletInCompatible
+      isWalletNull(wallets) || isWalletInCompatible
         ? ERROR_MESSAGE_WAIT_FOR_WALLET_DESCRIPTION(type)
         : ERROR_MESSAGE_WAIT_FOR_WALLET_DESCRIPTION_WRONG_WALLET(type, address);
 

--- a/queue-manager/rango-preset/src/constants.ts
+++ b/queue-manager/rango-preset/src/constants.ts
@@ -10,10 +10,7 @@ export const ERROR_MESSAGE_WAIT_FOR_WALLET_DESCRIPTION_WRONG_WALLET = (
   }`;
 export const ERROR_MESSAGE_WAIT_FOR_WALLET_DESCRIPTION = (
   type: string | null
-): string =>
-  `Please connect to ${
-    type || 'your wallet'
-  } by using bellow button or top right button on page.`;
+): string => `Please connect your ${type ?? ''} wallet.`;
 export const ERROR_MESSAGE_WAIT_FOR_CHANGE_NETWORK = (
   network: string | null
 ): string => `Please change your network to ${network}.`;

--- a/wallets/shared/src/providers.ts
+++ b/wallets/shared/src/providers.ts
@@ -57,8 +57,8 @@ export const subscribeToEvm: Subscribe = ({
   instance?.on('chainChanged', handleChainChanged);
 
   const cleanup = () => {
-    instance?.off('chainChanged', handleAccountsChanged);
-    instance?.off('accountsChanged', handleChainChanged);
+    instance?.off('accountsChanged', handleAccountsChanged);
+    instance?.off('chainChanged', handleChainChanged);
   };
 
   return cleanup;

--- a/widget/embedded/src/QueueManager.tsx
+++ b/widget/embedded/src/QueueManager.tsx
@@ -80,9 +80,6 @@ function QueueManager(props: PropsWithChildren<{ apiKey?: string }>) {
       getSupportedChainNames,
     },
     getSigners,
-    //todo: remove Network type
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
     wallets,
     providers: allProviders,
     switchNetwork,

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -3,15 +3,14 @@ import type {
   PropTypes,
   WidgetContextInterface,
 } from './Wallets.types';
-import type { Wallet } from '../../types/wallets';
 import type { ProvidersOptions } from '../../utils/providers';
 import type { EventHandler } from '@rango-dev/wallets-react';
-import type { Network } from '@rango-dev/wallets-shared';
 import type { PropsWithChildren } from 'react';
 
 import { Events, Provider } from '@rango-dev/wallets-react';
+import { type Network } from '@rango-dev/wallets-shared';
 import { isEvmBlockchain } from 'rango-sdk';
-import React, { createContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useEffect, useRef } from 'react';
 
 import { useWalletProviders } from '../../hooks/useWalletProviders';
 import { AppStoreProvider, useAppStore } from '../../store/AppStore';
@@ -35,7 +34,6 @@ function Main(props: PropsWithChildren<PropTypes>) {
   const walletOptions: ProvidersOptions = {
     walletConnectProjectId: props.config?.walletConnectProjectId,
   };
-  const [accounts, setAccounts] = useState<Wallet[]>([]);
   const { providers } = useWalletProviders(props.config.wallets, walletOptions);
   const { connectWallet, disconnectWallet } = useWalletsStore();
   const onConnectWalletHandler = useRef<OnConnectHandler>();
@@ -67,7 +65,9 @@ function Main(props: PropsWithChildren<PropTypes>) {
           supportedChainNames,
           meta.isContractWallet
         );
-        setAccounts(data);
+        if (data.length) {
+          connectWallet(data, tokens);
+        }
       } else {
         disconnectWallet(type);
       }
@@ -101,12 +101,6 @@ function Main(props: PropsWithChildren<PropTypes>) {
     }
   };
   const isActiveTab = useUiStore.use.isActiveTab();
-
-  useEffect(() => {
-    if (accounts.length) {
-      connectWallet(accounts, tokens);
-    }
-  }, [accounts, tokens]);
 
   return (
     <WidgetContext.Provider


### PR DESCRIPTION
# Summary

Some displayed messages during the swap process are incorrect.

Fixes # (issue)

- [x] The "change network" message is displayed inaccurately for non-EVM blockchains: 
![1](https://github.com/rango-exchange/rango-client/assets/120931880/af0133b7-71ed-4d4e-81db-0bc0f0fcc687)

- [x] Consider displaying a distinct message if the required wallet is not connected, and present a separate message if the connected wallet is associated with a different account :
![2](https://github.com/rango-exchange/rango-client/assets/120931880/0ed48303-9722-45f5-b3ba-04f9094460b5)

# How did you test this change?

Initiate a swap on the Osmosis network, proceed to the sign transaction pop-up, and without signing the transaction, refresh the page. After the page reloads, attempt to connect the necessary wallet on the swap-details page.

# Checklist:

- [x] I have performed a self-review of my code