### PR TITLE
hotfix: fix tab manager error in Next.js

### DIFF
--- a/widget/embedded/src/components/Layout/Layout.tsx
+++ b/widget/embedded/src/components/Layout/Layout.tsx
@@ -12,7 +12,7 @@ import { isAppLoadedIntoIframe } from '../../hooks/useIframe/useIframe.helpers';
 import { useNavigateBack } from '../../hooks/useNavigateBack';
 import { useTheme } from '../../hooks/useTheme';
 import { useAppStore } from '../../store/AppStore';
-import { setCurrentTabAsActive, useUiStore } from '../../store/ui';
+import { tabManager, useUiStore } from '../../store/ui';
 import { useWalletsStore } from '../../store/wallets';
 import { getContainer } from '../../utils/common';
 import { getPendingSwaps } from '../../utils/queue';
@@ -56,7 +56,7 @@ function Layout(props: PropsWithChildren<PropTypes>) {
   const hasRunningSwap = pendingSwaps.some((swap) => swap.status === 'running');
 
   const onActivateTab = () =>
-    activateCurrentTab(setCurrentTabAsActive, hasRunningSwap);
+    activateCurrentTab(tabManager.forceClaim, hasRunningSwap);
 
   const onConnectWallet = () => {
     header.onWallet?.();

--- a/widget/embedded/src/containers/Widget/Widget.tsx
+++ b/widget/embedded/src/containers/Widget/Widget.tsx
@@ -4,13 +4,14 @@ import type { PropsWithChildren } from 'react';
 import React, { useEffect } from 'react';
 
 import { DEFAULT_CONFIG } from '../../store/slices/config';
-import { destroyTabManager } from '../../store/ui';
+import { tabManager } from '../../store/ui';
 import { Main } from '../App';
 import { WidgetProvider } from '../WidgetProvider';
 
 export function Widget(props: PropsWithChildren<WidgetProps>) {
   useEffect(() => {
-    return destroyTabManager;
+    tabManager.init();
+    return tabManager.destroy;
   }, []);
 
   if (!props.config?.externalWallets) {

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
@@ -7,7 +7,7 @@ import { useLanguage } from '../../hooks/useLanguage';
 import { useAppStore } from '../../store/AppStore';
 import { useNotificationStore } from '../../store/notification';
 import { useQuoteStore } from '../../store/quote';
-import { setCurrentTabAsActive, useUiStore } from '../../store/ui';
+import { tabManager, useUiStore } from '../../store/ui';
 import { useWalletsStore } from '../../store/wallets';
 import { calculateWalletUsdValue } from '../../utils/wallets';
 
@@ -36,7 +36,7 @@ export function WidgetInfo(props: React.PropsWithChildren) {
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   const value: WidgetInfoContextInterface = {
     isActiveTab,
-    setCurrentTabAsActive,
+    setCurrentTabAsActive: tabManager.forceClaim,
     history,
     wallets: {
       isLoading,

--- a/widget/embedded/src/libs/tabManager/tabManager.ts
+++ b/widget/embedded/src/libs/tabManager/tabManager.ts
@@ -18,9 +18,12 @@ export class TabManager implements TabManagerInterface {
     this.channel = new BroadcastChannel(CHANNEL_NAME);
     this.tabId = Math.trunc(Math.random() * MAXIMUM_TAB_ID);
     this.events = events;
+  }
+
+  init = () => {
     this.initEvents();
     void this.tryClaim();
-  }
+  };
 
   /**
    * This is applicable when a user in an inactive tab seeks to activate that tab.

--- a/widget/embedded/src/libs/tabManager/tabManager.types.ts
+++ b/widget/embedded/src/libs/tabManager/tabManager.types.ts
@@ -22,6 +22,7 @@ export type Events = {
 };
 
 export interface TabManagerInterface {
+  init: () => void;
   forceClaim: () => void;
   isClaimed: () => boolean;
   destroy: () => void;

--- a/widget/embedded/src/store/ui.ts
+++ b/widget/embedded/src/store/ui.ts
@@ -45,13 +45,9 @@ export const useUiStore = createSelectors(
   }))
 );
 
-const tabManager: TabManagerInterface = new TabManager({
+export const tabManager: TabManagerInterface = new TabManager({
   onInit: () => useUiStore.setState({ tabManagerInitiated: true }),
   onClaim: () =>
     useUiStore.setState({ isActiveTab: true, showActivateTabModal: false }),
   onRelease: () => useUiStore.setState({ isActiveTab: false }),
 });
-
-export const setCurrentTabAsActive = tabManager.forceClaim;
-
-export const destroyTabManager = tabManager.destroy;


### PR DESCRIPTION
# Summary

We have recently introduced a feature that allows for having a single active tab in the widget, but it has been causing issues with the Next.js build. This pull request addresses the issue by fixing the problem and ensuring that the document object is accessed and relevant event listeners are attached only after the widget has been mounted on the DOM.

# Checklist:

- [x] I have performed a self-review of my code