### PR TITLE
fix: add ethers to shared package

### DIFF
--- a/wallets/shared/package.json
+++ b/wallets/shared/package.json
@@ -24,7 +24,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "rango-types": "^0.1.57"
+    "rango-types": "^0.1.57",
+    "ethers": "^5.7.2"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
# Summary

We missed adding `ethers` to `shared` package.
