### PR TITLE
feat: update crowdin workflow and add pretranslate step

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -18,16 +18,3 @@ jobs:
         run: node ./scripts/check-conventional-commits/command.mjs
         env:
           REF: ${{ github.ref }}
-
-  localization:
-    if: ${{ github.base_ref == 'main' }}
-    uses: ./.github/workflows/crowdin.yml
-    needs:
-      - check
-    secrets:
-      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-      PAT: ${{ secrets.PAT }}
-    with:
-      create_pull_request: false
-      localization_branch_name: ${{github.head_ref}}

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,15 +1,7 @@
 name: Sync translations using Crowdin
-env:
-  LOCALIZATION_BRANCH_NAME: 'l10n_crowdin_translations'
 
 on:
   workflow_dispatch:
-    inputs:
-      create_pull_request:
-        description: 'It requires pull request'
-        required: false
-        default: true
-        type: boolean
 
   workflow_call:
     secrets:
@@ -22,19 +14,14 @@ on:
       PAT:
         description: 'Add a PAT to secrets.'
         required: true
-    inputs:
-      localization_branch_name:
-        description: 'Target branch name for new commit'
-        required: false
-        type: string
-      create_pull_request:
-        description: 'It requires pull request'
-        type: boolean
-        required: true
 
 jobs:
   crowdin:
     runs-on: ubuntu-latest
+    env:
+      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.PAT }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -47,11 +34,26 @@ jobs:
       - name: Extract new source
         run: yarn run i18n:extract
 
-      - name: Crowdin push & pull translations
+      - name: Crowdin push translations
+        uses: crowdin/github-action@v1
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+          push_sources: true
+          source: translations/en.po
+          translation: translations/%two_letters_code%.po
+          project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
+          token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Crowdin pre-translation
+        run: node ./scripts/crowdin/command.mjs
+
+      - name: Crowdin pull translations
         uses: crowdin/github-action@v1
         id: crowdin-download
         with:
-          upload_sources: true
+          upload_sources: false
           upload_translations: false
           download_translations: true
           source: translations/en.po
@@ -60,8 +62,8 @@ jobs:
           token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
           commit_message: 'chore(translation): update translations [skip ci]'
 
-          localization_branch_name: ${{inputs.localization_branch_name || env.LOCALIZATION_BRANCH_NAME}}
-          create_pull_request: ${{inputs.create_pull_request}}
+          localization_branch_name: 'l10n_crowdin_translations'
+          create_pull_request: true
           pull_request_title: '🤖chore(translation): update translations'
           pull_request_body: 'New Crowdin pull request with translations'
           pull_request_base_branch_name: 'next'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,21 +6,8 @@ on:
       - 'next'
 
 jobs:
-  localization:
-    if: ${{ github.ref == 'refs/heads/next' }}
-    uses: ./.github/workflows/crowdin.yml
-    secrets:
-      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-      PAT: ${{ secrets.PAT }}
-    with:
-      create_pull_request: true
-
   publish:
-    if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs:
-      - localization
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ jobs:
       CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
       CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
       PAT: ${{ secrets.PAT }}
-    with:
-      create_pull_request: true
 
   release:
     runs-on: ubuntu-latest

--- a/scripts/common/errors.mjs
+++ b/scripts/common/errors.mjs
@@ -97,3 +97,10 @@ export class CustomScriptError extends Error {
     super(msg);
   }
 }
+
+export class CrowdinError extends Error {
+  name = 'CrowdinError';
+  constructor(msg) {
+    super(msg);
+  }
+}

--- a/scripts/crowdin/command.mjs
+++ b/scripts/crowdin/command.mjs
@@ -1,0 +1,51 @@
+import { PROJECT_ID, TOKEN } from "./constants.mjs";
+import { 
+  checkPreTranslateStatus, 
+  getLanguageIds, 
+  getMachineTranslationEngineID, 
+  getSourceFileId, 
+  sendPreTranslateRequest 
+} from "./pretranslate.mjs";
+
+const preTranslationOption = {
+  method: 'mt',
+  autoApproveOption: 'all',
+  duplicateTranslations: false,
+  skipApprovedTranslations: true,
+  translateUntranslatedOnly: true,
+  translateWithPerfectMatchOnly: false,
+};
+
+
+async function run() {
+  console.log('🔨 Start pre-translation...');    
+
+  if(!PROJECT_ID || !TOKEN){
+    throw new CrowdinError('environments are not set correctly');
+  }
+
+  console.log('[1/5]', 'Get source file id');
+  const sourceFileId = await getSourceFileId();
+
+  console.log('[2/5]', 'Get target languages ids');
+  const languageIds = await  getLanguageIds();
+  
+  console.log('[3/5]', 'Get machine translation engine id');
+  const engineId = await getMachineTranslationEngineID();
+  preTranslationOption.engineId = engineId ;
+
+  console.log('[4/5]', 'Send pre-translate to crowdin');
+  const preTranslationId = await sendPreTranslateRequest({ sourceFileId, languageIds, preTranslationOption });
+
+  console.log('[5/5]', 'Check pre-translate status:',preTranslationId);
+  const status = await checkPreTranslateStatus(preTranslationId);
+
+  if (status === 'finished'){
+    console.log('✅ Pre-translation finished!');    
+  }
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/crowdin/constants.mjs
+++ b/scripts/crowdin/constants.mjs
@@ -1,0 +1,11 @@
+export const PROJECT_ID = process.env.CROWDIN_PROJECT_ID;
+export const TOKEN =  process.env.CROWDIN_PERSONAL_TOKEN;
+
+export const BASE_URL = `https://api.crowdin.com/api/v2`;
+export const PROJECT_API = `${BASE_URL}/projects/${PROJECT_ID}`;
+export const PRETRANSLATE_API = `${PROJECT_API}/pre-translations`
+export const FILE_API = `${PROJECT_API}/files`
+export const MACHINE_TRANSLATE_API = `${BASE_URL}/mts`;
+
+export const REQUEST_INTERVAL_TIMEOUT = 10_000;
+export const MAXIMUM_PRETRANSLATION_STATUS_CHECK = 20;

--- a/scripts/crowdin/pretranslate.mjs
+++ b/scripts/crowdin/pretranslate.mjs
@@ -1,0 +1,60 @@
+import { CrowdinError } from "../common/errors.mjs";
+import { fetchDataWithAuthorization } from "./utils.mjs";
+
+import { 
+  MAXIMUM_PRETRANSLATION_STATUS_CHECK,
+  PRETRANSLATE_API, 
+  REQUEST_INTERVAL_TIMEOUT, 
+  FILE_API,
+  MACHINE_TRANSLATE_API,
+  PROJECT_API,
+} from "./constants.mjs";
+
+
+export const getMachineTranslationEngineID = async () =>{
+  const responseData = await fetchDataWithAuthorization(MACHINE_TRANSLATE_API);
+  if(!responseData.data || !responseData.data.length){
+    throw new CrowdinError('No data received for machine translation');
+  }
+  return responseData.data[0].data.id;
+}
+
+export const getLanguageIds = async () => {
+  const responseData = await fetchDataWithAuthorization(PROJECT_API);
+  return responseData.data.targetLanguageIds;
+};
+
+export const getSourceFileId = async () => {
+  const responseData = await fetchDataWithAuthorization(FILE_API);
+  if (!responseData.data || !responseData.data.length) {
+    throw new CrowdinError('No data received for source file id');
+  }
+  return responseData.data[0].data.id;
+};
+
+export const sendPreTranslateRequest = async ({ sourceFileId, languageIds, preTranslationOption }) => {
+  const responseData = await fetchDataWithAuthorization(PRETRANSLATE_API, 'POST', {
+    ...preTranslationOption,
+    fileIds: [sourceFileId],
+    languageIds,
+  });
+  return responseData.data.identifier;
+};
+
+export const checkPreTranslateStatus = async (preTranslationId) => {
+  const maxAttempts = MAXIMUM_PRETRANSLATION_STATUS_CHECK;
+  let attempt = 0;
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  while (attempt < maxAttempts) {
+    const responseData = await fetchDataWithAuthorization(`${PRETRANSLATE_API}/${preTranslationId}`);
+    const status = responseData.data.status;
+    if (status === 'finished') {
+      return status;
+    } else {
+      console.log(`Pre-translation status: ${status}. Retrying in 10 seconds...`);
+      await delay(REQUEST_INTERVAL_TIMEOUT);
+      attempt++;
+    }
+  }
+  throw new CrowdinError('Timeout: Pre-translation did not succeed within the specified time.');
+};

--- a/scripts/crowdin/utils.mjs
+++ b/scripts/crowdin/utils.mjs
@@ -1,0 +1,24 @@
+import {TOKEN } from "./constants.mjs";
+
+// Reusable function to handle fetch requests with authorization headers
+export const fetchDataWithAuthorization = async (url, method = 'GET', body = null) => {
+  const options = {
+    method,
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  if (body) {
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, options);
+
+  if (!response.ok) {    
+    throw new CrowdinError(`Failed to fetch data from ${url}. Status: ${response.status}`);
+  }
+
+  return await response.json();
+};


### PR DESCRIPTION
# Summary

crowdin was removed from the publish and check workflows.
From now on, we only have crowdin in the release process
So that for each release:

- First, it extracts the new strings
- Then it pushes new strings to crowdin
- Then the pre-translate script will be called
- Then it downloads the translations for different languages, and opens a PR and merges all new translations to the **Next** branch.
And finally, it continues the release process


# How did you test this change?

To test, you can first take some PRs from **Next** Branch and change the string in some files and merge them into **Next** Branch.
Finally, call the release workflow manually,
In this case, the new strings that are on the next branch must be uploaded to crowdin, pre-translated and new translations must be downloaded for each language and merged in the **Next** branch. And the release process continues


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
