### PR TITLE
feat: add Portuguese language to widget

### DIFF
--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -1,6 +1,6 @@
 /** @type {import('@lingui/conf').LinguiConfig} */
 module.exports = {
-  locales: ['en', 'es', 'ja', 'fr'],
+  locales: ['en', 'es', 'ja', 'fr', 'pt'],
   sourceLocale: 'en',
   format: 'po',
   catalogs: [

--- a/translations/pt.po
+++ b/translations/pt.po
@@ -1,0 +1,1147 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2024-02-18 15:38+0330\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: pt\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/Quote.tsx:126
+msgid "Slippage Error"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/Quote.tsx:127
+msgid "Slippage Warning"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
+#: widget/embedded/src/components/TokenList/TokenList.tsx:120
+#: widget/embedded/src/pages/HistoryPage.tsx:85
+#: widget/embedded/src/pages/LiquiditySourcePage.tsx:131
+msgid "No results found"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:38
+#: widget/embedded/src/components/TokenList/TokenList.tsx:121
+#: widget/embedded/src/pages/HistoryPage.tsx:87
+#: widget/embedded/src/pages/LiquiditySourcePage.tsx:132
+msgid "Try using different keywords"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:66
+#: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:46
+#: widget/embedded/src/pages/SelectBlockchainPage.tsx:40
+msgid "Select Blockchain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:66
+msgid "All"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:100
+msgid "More +{count}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
+msgid "Activate"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:21
+msgid "Another tab is open and handles transactions. You can activate this tab."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
+msgid "Activate current tab"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:22
+msgid "Currently, some transactions are running and being handled by other browser tab. If you activate this tab, all transactions that are already in the transaction sign step will expire."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:32
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:264
+#: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:237
+msgid "Confirm"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:279
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:354
+msgid "Your {blockchainName} wallets"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:298
+msgid "Insufficient account balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:307
+msgid "Proceed anyway"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:363
+msgid "You need to connect a {blockchainName} wallet."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:430
+msgid "Send to a different address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:441
+msgid "Your destination address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:460
+msgid "Address {destination} doesn't match the blockchain address pattern."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:168
+msgid "Add {chain} chain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:217
+#: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:250
+msgid "Add {blockchainDisplayName} Chain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:222
+#: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:254
+msgid "You should connect a {blockchainDisplayName} supported wallet or choose a different {blockchainDisplayName} address"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:272
+msgid "{blockchainDisplayName} Chain Added"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:276
+msgid "{blockchainDisplayName} is added to your wallet, you can use it to swap."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:286
+msgid "Request Rejected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:287
+msgid "You've rejected adding {blockchainDisplayName} chain to your wallet."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:311
+msgid "Show more wallets"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/HeaderButtons/CancelButton.tsx:14
+msgid "Cancel"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:44
+msgid "Refresh"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:60
+msgid "Notifications"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:73
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:312
+#: widget/embedded/src/pages/SettingsPage.tsx:214
+msgid "Settings"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:83
+msgid "Transactions History"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/HeaderButtons/WalletButton.tsx:14
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:16
+#: widget/embedded/src/constants/messages.ts:5
+msgid "Connect Wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx:118
+#: widget/embedded/src/utils/date.ts:18
+#: widget/embedded/src/utils/time.ts:22
+msgid "Today"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:375
+msgid "Swaps steps"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:25
+msgid "Retry"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:37
+msgid "Reset"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/NotificationContent/NotificationNotFound.tsx:13
+msgid "There are no notifications."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/Quote.tsx:231
+msgid "Yours: {amount} {symbol}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/Quote.tsx:252
+msgid "Minimum required slippage is {minRequiredSlippage}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/Quote.tsx:325
+msgid "See All Routes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:98
+msgid "View more info"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:108
+msgid "Gas & Fee Explanation"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:121
+#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:88
+msgid "Details"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:162
+msgid "Total Payable Fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:182
+msgid "Hide non-payable fees"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:183
+msgid "Show non-payable fees"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:193
+msgid "Description"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:197
+msgid ""
+"The following fees are considered in the transaction output and\n"
+"                you won’t need to pay extra gas for them."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteSummary.tsx:25
+msgid "Swap input"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteSummary.tsx:44
+msgid "Estimated output"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteTrigger .tsx:77
+msgid "Via:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quote/QuoteTrigger .tsx:160
+msgid "Chains:"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
+msgid "Swapping"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:51
+msgid "Gas cost"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:59
+msgid "Receiving"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:67
+msgid "Price impact"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:36
+msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:60
+#: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
+#: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
+msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:69
+msgid "Caution, your slippage is high."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx:73
+#: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:25
+msgid "Change"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:41
+msgid "Change settings"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:51
+msgid "High slippage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:52
+msgid "Low slippage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:56
+msgid " Caution, your slippage is high (={userSlippage}). Your trade may be front run."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:76
+msgid "Confirm anyway"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Slippage/Slippage.tsx:35
+msgid "Slippage tolerance per swap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Slippage/Slippage.tsx:90
+msgid "Custom"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:11
+msgid "Your transaction will be reverted if the price changes unfavorably by more than this percentage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:16
+msgid "Warning"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:17
+msgid "This setting is applied per step (e.g. 1Inch, Thorchain, etc) which means only the step will be reverted, not the whole transaction."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:25
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:246
+msgid "Swap and Bridge"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:33
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:286
+msgid "Request ID"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:64
+msgid "Not found"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:65
+#: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:39
+msgid "Swap with request ID = {requestId} not found."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:214
+msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:230
+msgid "Transaction was not sent."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:232
+msgid "{amount} {symbol} on {blockchain} remain in your wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:257
+msgid "Delete"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:278
+msgid "Try again"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx:50
+msgid "View transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:47
+#: widget/ui/src/components/Wallet/Wallet.helpers.ts:31
+msgid "Connect"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:43
+msgid "Swap Successful"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:71
+msgid "Transaction Failed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:86
+msgid "Done"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:99
+msgid "Diagnosis"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:107
+msgid "See Details"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:13
+msgid "Cancel Swap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:14
+msgid "Are you sure you want to cancel this swap?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:23
+msgid "Yes, Cancel it"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:29
+msgid "No, Continue"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:13
+msgid "Delete Transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:14
+msgid "Are you sure you want to delete this swap?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:23
+msgid "Yes, Delete it"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:29
+msgid "No, Cancel"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:12
+msgid "Change Network"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:20
+msgid "Network Changed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/TokenList/TokenList.tsx:257
+msgid "Select Token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:19
+msgid "Wallet Connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:20
+msgid "Your wallet is connected, you can use it to swap."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:31
+msgid "Failed to Connect"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:33
+msgid "Your wallet is not connected. Please try again."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:42
+msgid "Connecting to your wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:43
+msgid "Click connect in your wallet popup."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:9
+msgid "Failed Network, Please retry your swap."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:11
+msgid "Please reset your liquidity sources."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:12
+msgid "You have limited the liquidity sources and this might result in Rango finding no routes. Please consider resetting your liquidity sources."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:17
+msgid "No Routes Found."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:18
+msgid "Reasons why Rango couldn't find a route: low liquidity on token, very low input amount or no routes available for the selected input/output token combination."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:23
+msgid "Bridge Limit Error: Please increase your amount."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:26
+msgid "Bridge Limit Error: Please decrease your amount."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:31
+msgid "High Price Impact"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:32
+msgid "Price impact is too high!"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:33
+msgid "The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:36
+msgid "Confirm high price impact"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:39
+msgid "Route updated and price impact is too high, try again later!"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:44
+msgid "USD Price Unknown"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:45
+msgid "USD Price Unknown, Cannot calculate Price Impact."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:46
+msgid "USD Price Unknown, Cannot calculate Price Impact. The price impact may be higher than usual. Are you sure to continue the Swap?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/errors.ts:49
+msgid "Confirm USD Price Unknown"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/messages.ts:6
+#: widget/embedded/src/pages/Home.tsx:155
+msgid "Swap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/messages.ts:7
+msgid "Swap anyway"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/messages.ts:8
+msgid "The route goes through Ethereum. Continue?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:13
+msgid "Network Fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:14
+msgid "Protocol Fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:15
+msgid "Affiliate Fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:16
+msgid "Outbound Fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:17
+msgid "Rango Fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:26
+msgid "Fastest Transfer"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:27
+msgid "Maximum Return"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:28
+msgid "Lowest Fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:29
+msgid "Maximum Output"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:30
+msgid "Smart Routing"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/warnings.ts:10
+msgid "Route has been updated."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/warnings.ts:12
+msgid "Output amount changed to {newOutputAmount} ({percentageChange}% change)."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/warnings.ts:20
+msgid "Route swappers has been updated."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/warnings.ts:22
+msgid "Route internal coins has been updated."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:303
+msgid "Confirm Swap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:333
+msgid "Start Swap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:359
+msgid "You get"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/HistoryPage.tsx:67
+msgid "History"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/HistoryPage.tsx:74
+msgid "Search Transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/Home.tsx:172
+msgid "From"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/Home.tsx:215
+msgid "To"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/LanguagePage.tsx:36
+msgid "Language"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/LanguagePage.tsx:43
+msgid "language"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
+#: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:151
+msgid "Exchanges"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
+#: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:112
+msgid "Bridges"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
+msgid "Deselect all"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
+msgid "Select all"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/LiquiditySourcePage.tsx:121
+msgid "Search {sourceType}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/Routes.tsx:77
+msgid "Routes"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
+msgid "Search Blockchain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SelectSwapItemsPage.tsx:72
+msgid "Source"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SelectSwapItemsPage.tsx:73
+msgid "Destination"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SelectSwapItemsPage.tsx:79
+msgid "Swap {type}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SelectSwapItemsPage.tsx:95
+msgid "Search Token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SettingsPage.tsx:86
+msgid "Loading failed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SettingsPage.tsx:102
+msgid "Enabled bridges"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SettingsPage.tsx:119
+msgid "Enabled exchanges"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SettingsPage.tsx:149
+#: widget/embedded/src/pages/ThemePage.tsx:70
+#: widget/embedded/src/pages/ThemePage.tsx:79
+msgid "Theme"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SettingsPage.tsx:161
+msgid "Infinite approval"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SettingsPage.tsx:171
+msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SettingsPage.tsx:221
+msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/SwapDetailsPage.tsx:27
+msgid "The request ID is necessary to display the swap details."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/ThemePage.tsx:34
+msgid "Light"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/ThemePage.tsx:46
+msgid "Dark"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/ThemePage.tsx:58
+msgid "Auto"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/WalletsPage.tsx:72
+#: widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx:30
+msgid "Connect Wallets"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/WalletsPage.tsx:76
+msgid "Choose a wallet to connect."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/date.ts:25
+msgid "This week"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/date.ts:32
+msgid "This month"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/date.ts:39
+msgid "This year"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/swap.ts:125
+msgid "Required: >= {min} {symbol}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/swap.ts:138
+msgid "Required: > {min} {symbol}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/swap.ts:153
+msgid "Required: <= {max} {symbol}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/swap.ts:166
+msgid "Required: < {max} {symbol}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/swap.ts:634
+msgid " for network fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/swap.ts:637
+msgid " for swap"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/swap.ts:640
+msgid " for input and network fee"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/swap.ts:642
+msgid "Needs ≈ {requiredAmount} {symbol}{reason}, but you have {currentAmount} {symbol} in your {blockchain} wallet."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/swap.ts:702
+msgid "Waiting for connecting wallet"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/swap.ts:706
+msgid "Waiting for other running tasks to be finished"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/swap.ts:709
+msgid "Waiting for changing wallet network"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:6
+msgid "Sunday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:7
+msgid "Monday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:8
+msgid "Tuesday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:9
+msgid "Wednesday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:10
+msgid "Thursday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:11
+msgid "Friday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/utils/time.ts:12
+msgid "Saturday"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
+msgid " Error connecting server, please reload the app and try again."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/BottomLogo/BottomLogo.tsx:14
+msgid "Powered By"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/ChangeSlippageButton/ChangeSlippageButton.tsx:14
+msgid "Change Slippage"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx:63
+msgid "{blockchainCategory}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/StepDetails/StepDetails.tsx:74
+#: widget/ui/src/components/StepDetails/StepDetails.tsx:100
+msgid "Swap on {fromChain} via {swapper}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/StepDetails/StepDetails.tsx:107
+msgid "Bridge to {toChain} via {swapper}"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:28
+msgid "Swap Details"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:8
+msgid "Failed"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:10
+msgid "Complete"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:12
+msgid "In progress"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/SwapListItem/SwapToken.tsx:122
+msgid "Waiting for bridge transaction"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/TokenPreview/TokenPreview.tsx:150
+#: widget/ui/src/containers/SwapInput/TokenSection.tsx:56
+#: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:235
+msgid "Chain"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/TokenPreview/TokenPreview.tsx:168
+#: widget/ui/src/containers/SwapInput/TokenSection.tsx:49
+#: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:259
+msgid "Token"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/Wallet/Wallet.helpers.ts:12
+msgid "Connected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/Wallet/Wallet.helpers.ts:13
+msgid "Disconnect"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/Wallet/Wallet.helpers.ts:18
+#: widget/ui/src/components/Wallet/Wallet.helpers.ts:19
+msgid "Install"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/Wallet/Wallet.helpers.ts:24
+msgid "Connecting..."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/Wallet/Wallet.helpers.ts:25
+msgid "Connecting"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/Wallet/Wallet.helpers.ts:30
+msgid "Disconnected"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/components/Wallet/Wallet.helpers.ts:34
+msgid "you need to pass a correct state to Wallet."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/containers/HomePanel/HomePanel.tsx:123
+msgid "SWAP"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
+#: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
+msgid "Balance"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/containers/SwapInput/SwapInput.tsx:62
+msgid "Max"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
+msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:179
+msgid "swap from"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:198
+msgid "maximum amount of asset"
+msgstr ""
+
+#. js-lingui-explicit-id
+#: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
+msgid "swap to"
+msgstr ""

--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -122,6 +122,14 @@ export function Quote(props: QuoteProps) {
         stepState = 'warning';
       }
 
+      let alertTitle = stepHasError
+        ? i18n.t('Slippage Error')
+        : i18n.t('Slippage Warning');
+
+      if (error?.type === QuoteErrorType.BRIDGE_LIMIT) {
+        alertTitle = error?.recommendation;
+      }
+
       return {
         swapper: {
           displayName: getSwapperDisplayName(swap.swapperId, swappers),
@@ -197,11 +205,7 @@ export function Quote(props: QuoteProps) {
               <Alert
                 variant="alarm"
                 type={stepHasError ? 'error' : 'warning'}
-                title={
-                  error?.type === QuoteErrorType.BRIDGE_LIMIT
-                    ? error?.recommendation
-                    : i18n.t(`Slippage ${stepHasError ? 'Error' : 'Warning'}:`)
-                }
+                title={alertTitle}
                 footer={
                   <FooterAlert>
                     {error?.type === QuoteErrorType.BRIDGE_LIMIT && (

--- a/widget/embedded/src/constants/languages.ts
+++ b/widget/embedded/src/constants/languages.ts
@@ -1,6 +1,6 @@
 import type { FlagPropTypes, Language } from '@rango-dev/ui';
 
-import { English, French, Japanese, Spanish } from '@rango-dev/ui';
+import { English, French, Japanese, Portuguese, Spanish } from '@rango-dev/ui';
 
 export type LanguageItem = {
   title: string;
@@ -14,6 +14,7 @@ export const LANGUAGES: LanguageItem[] = [
   { title: 'Spanish', label: 'Español', local: 'es', SVGFlag: Spanish },
   { title: 'French', label: 'Français', local: 'fr', SVGFlag: French },
   { title: 'Japanese', label: '日本語', local: 'ja', SVGFlag: Japanese },
+  { title: 'Portuguese', label: 'Português', local: 'pt', SVGFlag: Portuguese },
 ];
 
 export const DEFAULT_LANGUAGE = 'en';

--- a/widget/embedded/src/pages/SettingsPage.tsx
+++ b/widget/embedded/src/pages/SettingsPage.tsx
@@ -129,18 +129,16 @@ export function SettingsPage() {
     onClick: () => navigate(navigationRoutes.exchanges),
   };
 
-  /*
-   * const languageItem = {
-   *   id: 'language-item',
-   *   title: (
-   *     <Typography variant="title" size="xmedium">
-   *       {i18n.t('Language')}
-   *     </Typography>
-   *   ),
-   *   end: <ChevronRightIcon color="gray" />,
-   *   onClick: () => navigate(navigationRoutes.languages),
-   * };
-   */
+  const languageItem = {
+    id: 'language-item',
+    title: (
+      <Typography variant="title" size="xmedium">
+        {i18n.t('Language')}
+      </Typography>
+    ),
+    end: <ChevronRightIcon color="gray" />,
+    onClick: () => navigate(navigationRoutes.languages),
+  };
 
   const themeItem = {
     id: 'theme-item',
@@ -185,7 +183,7 @@ export function SettingsPage() {
   const settingItems = isLiquidityHidden ? [] : [bridgeItem, exchangeItem];
 
   if (!isLanguageHidden) {
-    // settingItems.push(languageItem);
+    settingItems.push(languageItem);
   }
   if (!theme?.singleTheme && !isThemeHidden) {
     settingItems.push(themeItem);

--- a/widget/playground/src/constants/languages.ts
+++ b/widget/playground/src/constants/languages.ts
@@ -1,8 +1,9 @@
-import { English, French, Japanese, Spanish } from '@rango-dev/ui';
+import { English, French, Japanese, Portuguese, Spanish } from '@rango-dev/ui';
 
 export const LANGUAGES = [
   { name: 'English', value: 'en', Icon: English },
   { name: 'Spanish', value: 'es', Icon: Spanish },
   { name: 'French', value: 'fr', Icon: French },
   { name: 'Japanese', value: 'ja', Icon: Japanese },
+  { name: 'Portuguese', value: 'pt', Icon: Portuguese },
 ];

--- a/widget/ui/src/components/Flags/Portuguese.tsx
+++ b/widget/ui/src/components/Flags/Portuguese.tsx
@@ -1,0 +1,34 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Portuguese(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx="256" cy="256" r="256" fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#6da544" d="M0 512h167l37.9-260.3L167 0H0z" />
+        <path fill="#d80027" d="M512 0H167v512h345z" />
+        <circle cx="167" cy="256" r="89" fill="#ffda44" />
+        <path
+          fill="#d80027"
+          d="M116.9 211.5V267a50 50 0 1 0 100.1 0v-55.6H117z"
+        />
+        <path
+          fill="#eee"
+          d="M167 283.8c-9.2 0-16.7-7.5-16.7-16.7V245h33.4v22c0 9.2-7.5 16.7-16.7 16.7z"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/index.ts
+++ b/widget/ui/src/components/Flags/index.ts
@@ -1,8 +1,9 @@
 import English from './English';
 import French from './French';
 import Japanese from './Japanese';
+import Portuguese from './Portuguese';
 import Spanish from './Spanish';
 
 export type { FlagPropTypes } from './Flags.types';
 
-export { English, Spanish, Japanese, French };
+export { English, Spanish, Japanese, French, Portuguese };

--- a/widget/ui/src/components/I18nManager/I18nManager.tsx
+++ b/widget/ui/src/components/I18nManager/I18nManager.tsx
@@ -15,12 +15,14 @@ import { messages as enMessages } from '../../../../../translations/en';
 import { messages as esMessages } from '../../../../../translations/es';
 import { messages as frMessages } from '../../../../../translations/fr';
 import { messages as jaMessages } from '../../../../../translations/ja';
+import { messages as ptMessages } from '../../../../../translations/pt';
 
 const messages = {
   en: enMessages,
   es: esMessages,
   ja: jaMessages,
   fr: frMessages,
+  pt: ptMessages,
 };
 
 i18n.load(messages);


### PR DESCRIPTION
# Summary

- add Portuguese language to setting section
- add Portuguese language to playground list for default language


# How did you test this change?

If the pt.po file with crowdin translations has not been prepared yet, you can use the crowdin test account in your fork or change the pt.po file manually for convenience and start yarn again for compile new translation.


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
