### PR TITLE
feat: add an expand mode for our widget compact

### DIFF
--- a/widget/embedded/src/components/Layout/Layout.styles.ts
+++ b/widget/embedded/src/components/Layout/Layout.styles.ts
@@ -1,19 +1,21 @@
-import { styled } from '@rango-dev/ui';
+import { css, styled } from '@rango-dev/ui';
 
 const WIDGET_HEIGHT = '700px';
 
-export const Container = styled('div', {
-  position: 'relative',
+export const LayoutContainer = css({
+  borderRadius: '$primary',
   display: 'flex',
   flexDirection: 'column',
-  borderRadius: '$primary',
+  overflow: 'hidden',
+  boxShadow: '15px 15px 15px 0px rgba(0, 0, 0, 0.05)',
+});
+
+export const Container = styled('div', {
+  position: 'relative',
   width: '100vw',
   minWidth: '300px',
   maxWidth: '390px',
-  boxShadow: '15px 15px 15px 0px rgba(0, 0, 0, 0.05)',
-  overflow: 'hidden',
   backgroundColor: '$background',
-
   variants: {
     height: {
       auto: {

--- a/widget/embedded/src/components/Layout/Layout.tsx
+++ b/widget/embedded/src/components/Layout/Layout.tsx
@@ -22,7 +22,7 @@ import { ActivateTabModal } from '../common/ActivateTabModal';
 import { BackButton, CancelButton, WalletButton } from '../HeaderButtons';
 
 import { onScrollContentAttachStatusToContainer } from './Layout.helpers';
-import { Container, Content, Footer } from './Layout.styles';
+import { Container, Content, Footer, LayoutContainer } from './Layout.styles';
 
 function Layout(props: PropsWithChildren<PropTypes>) {
   const { connectHeightObserver, disconnectHeightObserver } = useIframe();
@@ -98,7 +98,7 @@ function Layout(props: PropsWithChildren<PropTypes>) {
     <Container
       height={height}
       id={WIDGET_UI_ID.SWAP_BOX_ID}
-      className={activeTheme()}
+      className={`${activeTheme()} ${LayoutContainer()}`}
       ref={containerRef}>
       <Header
         prefix={

--- a/widget/embedded/src/components/NoResult/NoResult.styles.ts
+++ b/widget/embedded/src/components/NoResult/NoResult.styles.ts
@@ -1,11 +1,9 @@
 import { styled } from '@rango-dev/ui';
 
 export const Container = styled('div', {
-  minHeight: '162px',
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'center',
-  justifyContent: 'center',
 });
 
 export const Footer = styled('div', {

--- a/widget/embedded/src/components/NoResult/NoResult.tsx
+++ b/widget/embedded/src/components/NoResult/NoResult.tsx
@@ -52,6 +52,7 @@ export function NoResult(props: PropTypes) {
           <Alert
             type={info.alert.type}
             title={info.alert.text}
+            titleAlign={'center'}
             action={
               info.alert.action && (
                 <Button

--- a/widget/embedded/src/components/Quote/Quote.styles.ts
+++ b/widget/embedded/src/components/Quote/Quote.styles.ts
@@ -123,7 +123,7 @@ export const SummaryContainer = styled('div', {
       listItem: true,
       selected: true,
       css: {
-        border: '1px solid $secondary',
+        outline: '1px solid $secondary',
       },
     },
     {

--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -69,7 +69,7 @@ import {
 } from './Quote.styles';
 import { QuoteCostDetails } from './QuoteCostDetails';
 import { QuoteSummary } from './QuoteSummary';
-import { QuoteTrigger } from './QuoteTrigger ';
+import { QuoteTrigger } from './QuoteTrigger';
 
 export function Quote(props: QuoteProps) {
   const {
@@ -81,6 +81,7 @@ export function Quote(props: QuoteProps) {
     type,
     selected = false,
     tagHidden = true,
+    showModalFee = true,
     onClickAllRoutes,
   } = props;
   const blockchains = useAppStore().blockchains();
@@ -323,11 +324,12 @@ export function Quote(props: QuoteProps) {
           ) : null}
           <div id="portal-root" className={summaryHeaderStyles()}>
             <QuoteCostDetails
-              steps={numberOfSteps}
               quote={quote}
               time={totalTime}
               fee={fee}
               feeWarning={totalFee.gte(new BigNumber(GAS_FEE_MAX))}
+              showModalFee={showModalFee}
+              steps={numberOfSteps}
             />
 
             {showAllRoutesButton && (

--- a/widget/embedded/src/components/Quote/Quote.types.ts
+++ b/widget/embedded/src/components/Quote/Quote.types.ts
@@ -12,6 +12,7 @@ export type QuoteProps = {
   expanded?: boolean;
   tagHidden?: boolean;
   selected?: boolean;
+  showModalFee?: boolean;
   onClickAllRoutes?: () => void;
 };
 
@@ -43,4 +44,5 @@ export type QuoteCostDetailsProps = {
   fee: string;
   time: string;
   feeWarning?: boolean;
+  showModalFee: boolean;
 };

--- a/widget/embedded/src/components/Quote/QuoteCostDetails.tsx
+++ b/widget/embedded/src/components/Quote/QuoteCostDetails.tsx
@@ -57,7 +57,7 @@ const NonPayableFee = (props: { fee: BigNumber; label: string }) => {
 export function QuoteCostDetails(props: QuoteCostDetailsProps) {
   const [open, setOpen] = useState<boolean>(false);
   const [openCollapse, setOpenCollapse] = useState<boolean>(false);
-  const { steps, quote, fee, time, feeWarning } = props;
+  const { steps, quote, fee, time, feeWarning, showModalFee } = props;
   const swaps = quote?.swaps ?? [];
   const container = getContainer();
 
@@ -66,15 +66,19 @@ export function QuoteCostDetails(props: QuoteCostDetailsProps) {
   return (
     <>
       <QuoteCost
-        onClickFee={(e) => {
-          e.stopPropagation();
-          setOpen(!open);
-        }}
+        onClickFee={
+          showModalFee
+            ? (e) => {
+                e.stopPropagation();
+                setOpen(!open);
+              }
+            : undefined
+        }
         fee={fee}
         feeWarning={feeWarning}
         time={time}
         steps={steps}
-        tooltipGas={i18n.t('View more info')}
+        tooltipGas={showModalFee ? i18n.t('View more info') : undefined}
         tooltipContainer={container}
       />
 

--- a/widget/embedded/src/components/Quote/QuoteTrigger.tsx
+++ b/widget/embedded/src/components/Quote/QuoteTrigger.tsx
@@ -9,8 +9,9 @@ import {
   Tooltip,
   Typography,
 } from '@rango-dev/ui';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
+import useMobileDetect from '../../hooks/useMobileDetect';
 import { getContainer } from '../../utils/common';
 import { getUniqueBlockchains } from '../../utils/quote';
 
@@ -24,7 +25,6 @@ import {
 
 const MAX_STEPS = 4;
 const MAX_BLOCKCHAINS = 6;
-const MIN_WIDTH_WINDOW = 375;
 
 const ImageComponent = (props: QuoteTriggerImagesProps) => {
   const tooltipContainer = getContainer();
@@ -48,20 +48,7 @@ export function QuoteTrigger(props: QuoteTriggerProps) {
   const tooltipContainer = getContainer();
   const numberOfSteps = steps.length;
   const blockchains = getUniqueBlockchains(steps);
-  const [isMobile, setIsMobile] = useState(false);
-
-  //choose the screen size
-  const handleResize = () => {
-    if (window.innerWidth < MIN_WIDTH_WINDOW) {
-      setIsMobile(true);
-    } else {
-      setIsMobile(false);
-    }
-  };
-
-  useEffect(() => {
-    window.addEventListener('resize', handleResize);
-  });
+  const isMobile = useMobileDetect();
 
   return (
     <Trigger

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx
@@ -75,7 +75,21 @@ export function HighValueLossWarningModal(props: Props) {
   ];
 
   return (
-    <WatermarkedModal open={open} onClose={onClose} container={getContainer()}>
+    <WatermarkedModal
+      footer={
+        <Button
+          type="primary"
+          size="large"
+          prefix={<WarningIcon />}
+          fullWidth
+          disabled={confirmationDisabled}
+          onClick={onConfirm}>
+          {errorMessages().highValueLossError.confirmMessage}
+        </Button>
+      }
+      open={open}
+      onClose={onClose}
+      container={getContainer()}>
       <MessageBox
         type={type}
         title={errorMessages().highValueLossError.impactTitle}
@@ -94,17 +108,6 @@ export function HighValueLossWarningModal(props: Props) {
           })}
         </Flex>
       </Flex>
-
-      <Divider size={32} />
-      <Button
-        type="primary"
-        size="large"
-        prefix={<WarningIcon />}
-        fullWidth
-        disabled={confirmationDisabled}
-        onClick={onConfirm}>
-        {errorMessages().highValueLossError.confirmMessage}
-      </Button>
     </WatermarkedModal>
   );
 }

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.types.ts
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.types.ts
@@ -1,7 +1,6 @@
 import type { QuoteError, QuoteWarning } from '../../types';
 
 export interface PropTypes {
-  loading: boolean;
   error: QuoteError | null;
   warning: QuoteWarning | null;
   showWarningModal: boolean;

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/UnknownPriceWarningModal.tsx
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/UnknownPriceWarningModal.tsx
@@ -1,6 +1,6 @@
 import type { UnknownPriceWarning } from '../../types';
 
-import { Button, Divider, MessageBox, WarningIcon } from '@rango-dev/ui';
+import { Button, MessageBox, WarningIcon } from '@rango-dev/ui';
 import React from 'react';
 
 import { errorMessages } from '../../constants/errors';
@@ -18,23 +18,26 @@ type Props = {
 export function UnknownPriceWarningModal(props: Props) {
   const { open, onClose, onConfirm, confirmationDisabled } = props;
   return (
-    <WatermarkedModal open={open} onClose={onClose} container={getContainer()}>
+    <WatermarkedModal
+      footer={
+        <Button
+          type="primary"
+          size="large"
+          prefix={<WarningIcon />}
+          fullWidth
+          disabled={confirmationDisabled}
+          onClick={onConfirm}>
+          {errorMessages().unknownPriceError.confirmMessage}
+        </Button>
+      }
+      open={open}
+      onClose={onClose}
+      container={getContainer()}>
       <MessageBox
         type="warning"
         title={errorMessages().unknownPriceError.impactTitle}
         description={errorMessages().unknownPriceError.description}
       />
-
-      <Divider size={32} />
-      <Button
-        type="primary"
-        size="large"
-        prefix={<WarningIcon />}
-        fullWidth
-        disabled={confirmationDisabled}
-        onClick={onConfirm}>
-        {errorMessages().unknownPriceError.confirmMessage}
-      </Button>
     </WatermarkedModal>
   );
 }

--- a/widget/embedded/src/components/Quotes/Quotes.styles.ts
+++ b/widget/embedded/src/components/Quotes/Quotes.styles.ts
@@ -1,0 +1,18 @@
+import { styled } from '@rango-dev/ui';
+
+export const ErrorsContainer = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  flexDirection: 'column',
+  height: '100%',
+});
+
+export const StrategyContent = styled('div', {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const SelectContainer = styled('div', {
+  width: '146px',
+});

--- a/widget/embedded/src/components/Quotes/Quotes.tsx
+++ b/widget/embedded/src/components/Quotes/Quotes.tsx
@@ -1,0 +1,134 @@
+import type { PropTypes } from './Quotes.types';
+import type { MultiRouteSimulationResult } from 'rango-sdk';
+
+import { i18n } from '@lingui/core';
+import { Divider, Typography } from '@rango-dev/ui';
+import React from 'react';
+
+import { QuoteInfo } from '../../containers/QuoteInfo';
+import { getQuoteError } from '../../hooks/useConfirmSwap/useConfirmSwap.helpers';
+import { useAppStore } from '../../store/AppStore';
+import { useQuoteStore } from '../../store/quote';
+import { QuoteErrorType, type SelectedQuote } from '../../types';
+import { getContainer } from '../../utils/common';
+import { generateQuoteWarnings, sortQuotesBy } from '../../utils/quote';
+import { NoResult } from '../NoResult';
+import { QuoteSkeleton } from '../QuoteSkeleton';
+
+import { ErrorsContainer, StrategyContent } from './Quotes.styles';
+import { SelectStrategy } from './SelectStrategy';
+
+const ITEM_SKELETON_COUNT = 3;
+export function Quotes(props: PropTypes) {
+  const {
+    loading,
+    onClickOnQuote,
+    fetch,
+    showModalFee,
+    hasSort = true,
+  } = props;
+  const {
+    selectedQuote,
+    quotes,
+    updateQuotePartialState,
+    fromToken,
+    toToken,
+    sortStrategy,
+    error,
+  } = useQuoteStore();
+  const { slippage, customSlippage } = useAppStore();
+  const tokens = useAppStore().tokens();
+  const hasQuotes = !!quotes && quotes.results.length;
+  const userSlippage = customSlippage ?? slippage;
+  const getQuoteWarning = (quote: MultiRouteSimulationResult) => {
+    if (!fromToken || !toToken || !quotes) {
+      return null;
+    }
+    const mergedQuote: SelectedQuote = {
+      requestAmount: quotes.requestAmount, // Assuming quotes is an array
+      ...quote,
+    };
+
+    return generateQuoteWarnings(mergedQuote, {
+      fromToken,
+      toToken,
+      userSlippage,
+      tokens,
+    });
+  };
+  const showNoResultMessage =
+    error?.type === QuoteErrorType.NO_RESULT ||
+    error?.type === QuoteErrorType.REQUEST_FAILED;
+
+  const sortQuotes = quotes?.results
+    ? sortQuotesBy(sortStrategy, quotes?.results)
+    : [];
+
+  return (
+    <>
+      {loading &&
+        Array.from({ length: ITEM_SKELETON_COUNT }, (_, index) => (
+          <React.Fragment key={index}>
+            <QuoteSkeleton
+              tagHidden={false}
+              type="list-item"
+              expanded={false}
+            />
+            <Divider size={16} />
+          </React.Fragment>
+        ))}
+
+      {!loading && (
+        <>
+          {hasSort && (
+            <>
+              <StrategyContent>
+                <Typography size="xmedium" variant="title">
+                  {i18n.t('Sort by')}
+                </Typography>
+                <SelectStrategy container={getContainer()} />
+              </StrategyContent>
+              <Divider size="10" />
+            </>
+          )}
+          {hasQuotes
+            ? sortQuotes.map((quote) => {
+                const quoteWarning = getQuoteWarning(quote);
+                const quoteError = getQuoteError(quote.swaps);
+
+                return (
+                  <React.Fragment key={quote.requestId}>
+                    <QuoteInfo
+                      showModalFee={showModalFee}
+                      selected={selectedQuote?.requestId === quote.requestId}
+                      tagHidden={false}
+                      quote={{ ...quote, requestAmount: quotes.requestAmount }}
+                      loading={loading}
+                      error={quoteError?.options || null}
+                      warning={quoteWarning}
+                      onClick={(quote) => {
+                        if (!quoteError) {
+                          updateQuotePartialState('warning', quoteWarning);
+                        }
+                        updateQuotePartialState(
+                          'error',
+                          quoteError?.options || null
+                        );
+                        onClickOnQuote(quote);
+                      }}
+                      type="list-item"
+                    />
+                    <Divider size={16} />
+                  </React.Fragment>
+                );
+              })
+            : showNoResultMessage && (
+                <ErrorsContainer>
+                  <NoResult error={error} fetch={fetch} />
+                </ErrorsContainer>
+              )}
+        </>
+      )}
+    </>
+  );
+}

--- a/widget/embedded/src/components/Quotes/Quotes.types.ts
+++ b/widget/embedded/src/components/Quotes/Quotes.types.ts
@@ -1,0 +1,9 @@
+import type { SelectedQuote } from '../../types';
+
+export type PropTypes = {
+  loading: boolean;
+  onClickOnQuote: (quote: SelectedQuote) => void;
+  fetch: (shouldChangeSelectedQuote?: boolean) => void;
+  showModalFee?: boolean;
+  hasSort?: boolean;
+};

--- a/widget/embedded/src/components/Quotes/SelectStrategy.tsx
+++ b/widget/embedded/src/components/Quotes/SelectStrategy.tsx
@@ -1,0 +1,33 @@
+import type { PreferenceType } from 'rango-sdk';
+
+import { Select } from '@rango-dev/ui';
+import React from 'react';
+
+import { ROUTE_STRATEGY } from '../../constants/quote';
+import { useQuoteStore } from '../../store/quote';
+
+import { SelectContainer } from './Quotes.styles';
+
+export function SelectStrategy(props: { container: HTMLElement }) {
+  const { updateQuotePartialState, sortStrategy } = useQuoteStore();
+
+  return (
+    <SelectContainer>
+      <Select
+        container={props.container}
+        options={ROUTE_STRATEGY}
+        value={
+          ROUTE_STRATEGY.find(
+            (strategy) => strategy.value === sortStrategy
+          ) as {
+            value: PreferenceType;
+            label: string;
+          }
+        }
+        handleItemClick={(item) => {
+          updateQuotePartialState('sortStrategy', item.value as PreferenceType);
+        }}
+      />
+    </SelectContainer>
+  );
+}

--- a/widget/embedded/src/components/Quotes/index.ts
+++ b/widget/embedded/src/components/Quotes/index.ts
@@ -1,0 +1,1 @@
+export { Quotes } from './Quotes';

--- a/widget/embedded/src/constants/index.ts
+++ b/widget/embedded/src/constants/index.ts
@@ -6,5 +6,6 @@ export const SCANNER_BASE_URL = 'https://scan.rango.exchange';
 
 export const WIDGET_UI_ID = {
   SWAP_BOX_ID: 'rango-swap-box',
+  EXPANDED_BOX_ID: 'rango-expanded-box',
   ...UI_ID,
 };

--- a/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.styles.ts
+++ b/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.styles.ts
@@ -1,0 +1,30 @@
+import { darkTheme, styled } from '@rango-dev/ui';
+
+export const Container = styled('div', {
+  transition: 'width 0.2s, opacity 0.2s, margin-left 0.2s',
+  height: '700px',
+  width: '390px',
+  opacity: 1,
+  marginLeft: '$16',
+  backgroundColor: '$neutral100',
+  [`.${darkTheme} &`]: {
+    backgroundColor: '$neutral300',
+  },
+  '&.is-hidden': {
+    width: 0,
+    opacity: 0,
+    marginLeft: 0,
+  },
+});
+
+export const Content = styled('div', {
+  position: 'relative',
+  overflow: 'hidden',
+  padding: '$20',
+  flexGrow: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  overflowY: 'auto',
+  borderRadius: '$primary',
+  backgroundColor: '$background',
+});

--- a/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx
+++ b/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx
@@ -1,0 +1,71 @@
+import type { PropTypes } from './ExpandedQuotes.types';
+
+import { i18n } from '@lingui/core';
+import { Header } from '@rango-dev/ui';
+import React, { useEffect, useState } from 'react';
+
+import { HeaderButtons } from '../../components/HeaderButtons';
+import { LayoutContainer } from '../../components/Layout/Layout.styles';
+import { Quotes } from '../../components/Quotes';
+import { SelectStrategy } from '../../components/Quotes/SelectStrategy';
+import { WIDGET_UI_ID } from '../../constants';
+import { getExpanded } from '../../utils/common';
+
+import { Container, Content } from './ExpandedQuotes.styles';
+
+export const TIME_TO_CLOSE_OPEN_EXPANDED = 100;
+
+export function ExpandedQuotes(props: PropTypes) {
+  const { fetch, loading, onClickOnQuote, onClickRefresh, isVisible } = props;
+  const [isDelayedVisible, setIsDelayedVisible] = useState(false);
+  const containerClass = isDelayedVisible ? '' : 'is-hidden';
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+
+    if (isVisible) {
+      timeout = setTimeout(() => {
+        setIsDelayedVisible(true);
+      }, TIME_TO_CLOSE_OPEN_EXPANDED);
+    } else {
+      setIsDelayedVisible(false);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
+
+    return () => {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    };
+  }, [isVisible]);
+
+  return (
+    <Container
+      className={`${containerClass} ${LayoutContainer()}`}
+      id={WIDGET_UI_ID.EXPANDED_BOX_ID}>
+      <Header
+        title={i18n.t('Routes')}
+        suffix={
+          <>
+            <SelectStrategy container={getExpanded()} />
+            <HeaderButtons
+              onClickRefresh={onClickRefresh}
+              hidden={['history', 'notifications', 'settings']}
+            />
+          </>
+        }
+      />
+      <Content>
+        <Quotes
+          showModalFee={false}
+          fetch={fetch}
+          hasSort={false}
+          loading={loading}
+          onClickOnQuote={onClickOnQuote}
+        />
+      </Content>
+    </Container>
+  );
+}

--- a/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.types.ts
+++ b/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.types.ts
@@ -1,0 +1,9 @@
+import type { SelectedQuote } from '../../types';
+
+export type PropTypes = {
+  loading: boolean;
+  onClickOnQuote: (quote: SelectedQuote) => void;
+  fetch: (shouldChangeSelectedQuote?: boolean) => void;
+  onClickRefresh?: () => void;
+  isVisible: boolean;
+};

--- a/widget/embedded/src/containers/ExpandedQuotes/index.ts
+++ b/widget/embedded/src/containers/ExpandedQuotes/index.ts
@@ -1,0 +1,1 @@
+export { ExpandedQuotes } from './ExpandedQuotes';

--- a/widget/embedded/src/containers/Inputs/Inputs.styles.ts
+++ b/widget/embedded/src/containers/Inputs/Inputs.styles.ts
@@ -1,0 +1,12 @@
+import { styled } from '@rango-dev/ui';
+
+export const Container = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '$5',
+  alignSelf: 'stretch',
+});
+
+export const FromContainer = styled('div', {
+  position: 'relative',
+});

--- a/widget/embedded/src/containers/Inputs/Inputs.tsx
+++ b/widget/embedded/src/containers/Inputs/Inputs.tsx
@@ -1,0 +1,165 @@
+import type { PropTypes } from './Inputs.types';
+
+import { i18n } from '@lingui/core';
+import { SwapInput } from '@rango-dev/ui';
+import React from 'react';
+
+import { SwitchFromAndToButton } from '../../components/SwitchFromAndTo';
+import { errorMessages } from '../../constants/errors';
+import {
+  PERCENTAGE_CHANGE_MAX_DECIMALS,
+  PERCENTAGE_CHANGE_MIN_DECIMALS,
+  TOKEN_AMOUNT_MAX_DECIMALS,
+  TOKEN_AMOUNT_MIN_DECIMALS,
+  USD_VALUE_MAX_DECIMALS,
+  USD_VALUE_MIN_DECIMALS,
+} from '../../constants/routing';
+import { useQuoteStore } from '../../store/quote';
+import { useWalletsStore } from '../../store/wallets';
+import { getContainer } from '../../utils/common';
+import { formatTooltipNumbers, numberToString } from '../../utils/numbers';
+import { getPriceImpact, getPriceImpactLevel } from '../../utils/quote';
+import { canComputePriceImpact } from '../../utils/swap';
+import { formatBalance, isFetchingBalance } from '../../utils/wallets';
+
+import { Container, FromContainer } from './Inputs.styles';
+
+export function Inputs(props: PropTypes) {
+  const { fetchingQuote, fetchMetaStatus, onClickToken } = props;
+  const {
+    fromToken,
+    fromBlockchain,
+    toToken,
+    toBlockchain,
+    setInputAmount,
+    inputAmount,
+    inputUsdValue,
+    outputAmount,
+    outputUsdValue,
+    selectedQuote,
+  } = useQuoteStore();
+  const { connectedWallets, getBalanceFor } = useWalletsStore();
+
+  const fromTokenBalance = fromToken ? getBalanceFor(fromToken) : null;
+
+  const fromTokenFormattedBalance =
+    formatBalance(fromTokenBalance)?.amount ?? '0';
+
+  const tokenBalanceReal =
+    !!fromBlockchain && !!fromToken
+      ? numberToString(fromTokenBalance?.amount, fromTokenBalance?.decimals)
+      : '0';
+
+  const fetchingBalance =
+    !!fromBlockchain &&
+    isFetchingBalance(connectedWallets, fromBlockchain.name);
+
+  const priceImpactInputCanNotBeComputed = !canComputePriceImpact(
+    selectedQuote,
+    inputAmount,
+    inputUsdValue
+  );
+
+  const priceImpactOutputCanNotBeComputed = !canComputePriceImpact(
+    selectedQuote,
+    inputAmount,
+    outputUsdValue
+  );
+
+  const percentageChange =
+    !inputUsdValue || !outputUsdValue || !outputUsdValue.gt(0)
+      ? null
+      : getPriceImpact(inputUsdValue.toString(), outputUsdValue.toString());
+  return (
+    <Container>
+      <FromContainer>
+        <SwapInput
+          label={i18n.t('From')}
+          mode="From"
+          onInputChange={setInputAmount}
+          balance={fromTokenFormattedBalance}
+          chain={{
+            displayName: fromBlockchain?.displayName || '',
+            image: fromBlockchain?.logo || '',
+          }}
+          token={{
+            displayName: fromToken?.symbol || '',
+            image: fromToken?.image || '',
+          }}
+          onClickToken={() => onClickToken('from')}
+          price={{
+            value: inputAmount,
+            usdValue: priceImpactInputCanNotBeComputed
+              ? undefined
+              : numberToString(
+                  inputUsdValue,
+                  USD_VALUE_MIN_DECIMALS,
+                  USD_VALUE_MAX_DECIMALS
+                ),
+            realUsdValue: priceImpactInputCanNotBeComputed
+              ? undefined
+              : formatTooltipNumbers(inputUsdValue),
+            error: priceImpactInputCanNotBeComputed
+              ? errorMessages().unknownPriceError.impactTitle
+              : undefined,
+          }}
+          disabled={fetchMetaStatus === 'failed'}
+          loading={fetchMetaStatus === 'loading'}
+          loadingBalance={fetchingBalance}
+          tooltipContainer={getContainer()}
+          onSelectMaxBalance={() => {
+            if (fromTokenFormattedBalance !== '0') {
+              setInputAmount(tokenBalanceReal.split(',').join(''));
+            }
+          }}
+        />
+        <SwitchFromAndToButton />
+      </FromContainer>
+      <SwapInput
+        sharpBottomStyle={!!selectedQuote || fetchingQuote}
+        label={i18n.t('To')}
+        mode="To"
+        fetchingQuote={fetchingQuote}
+        chain={{
+          displayName: toBlockchain?.displayName || '',
+          image: toBlockchain?.logo || '',
+        }}
+        token={{
+          displayName: toToken?.symbol || '',
+          image: toToken?.image || '',
+        }}
+        percentageChange={numberToString(
+          getPriceImpact(inputUsdValue, outputUsdValue),
+          PERCENTAGE_CHANGE_MIN_DECIMALS,
+          PERCENTAGE_CHANGE_MAX_DECIMALS
+        )}
+        warningLevel={getPriceImpactLevel(percentageChange ?? 0)}
+        price={{
+          value: numberToString(
+            outputAmount,
+            TOKEN_AMOUNT_MIN_DECIMALS,
+            TOKEN_AMOUNT_MAX_DECIMALS
+          ),
+          usdValue: priceImpactOutputCanNotBeComputed
+            ? undefined
+            : numberToString(
+                outputUsdValue,
+                USD_VALUE_MIN_DECIMALS,
+                USD_VALUE_MAX_DECIMALS
+              ),
+          realValue: formatTooltipNumbers(outputAmount),
+          realUsdValue: priceImpactOutputCanNotBeComputed
+            ? undefined
+            : formatTooltipNumbers(outputUsdValue),
+          error: priceImpactOutputCanNotBeComputed
+            ? errorMessages().unknownPriceError.impactTitle
+            : undefined,
+        }}
+        onClickToken={() => onClickToken('to')}
+        disabled={fetchMetaStatus === 'failed'}
+        loading={fetchMetaStatus === 'loading'}
+        tooltipContainer={getContainer()}
+      />
+    </Container>
+  );
+}

--- a/widget/embedded/src/containers/Inputs/Inputs.types.ts
+++ b/widget/embedded/src/containers/Inputs/Inputs.types.ts
@@ -1,0 +1,7 @@
+import type { FetchStatus } from '../../store/slices/data';
+
+export type PropTypes = {
+  fetchingQuote: boolean;
+  fetchMetaStatus: FetchStatus;
+  onClickToken: (mode: 'from' | 'to') => void;
+};

--- a/widget/embedded/src/containers/Inputs/index.ts
+++ b/widget/embedded/src/containers/Inputs/index.ts
@@ -1,0 +1,1 @@
+export { Inputs } from './Inputs';

--- a/widget/embedded/src/containers/QuoteInfo/QuoteInfo.tsx
+++ b/widget/embedded/src/containers/QuoteInfo/QuoteInfo.tsx
@@ -22,6 +22,7 @@ export function QuoteInfo(props: PropTypes) {
     expanded = false,
     tagHidden,
     onClick,
+    showModalFee,
     selected,
     onClickAllRoutes,
   } = props;
@@ -57,6 +58,7 @@ export function QuoteInfo(props: PropTypes) {
       <Quote
         quote={quote}
         error={error}
+        showModalFee={showModalFee}
         warning={warning}
         tagHidden={tagHidden}
         selected={selected}

--- a/widget/embedded/src/containers/QuoteInfo/QuoteInfo.types.ts
+++ b/widget/embedded/src/containers/QuoteInfo/QuoteInfo.types.ts
@@ -13,4 +13,5 @@ export type PropTypes = {
   expanded?: boolean;
   onClickAllRoutes?: () => void;
   selected?: boolean;
+  showModalFee?: boolean;
 };

--- a/widget/embedded/src/hooks/useMobileDetect.ts
+++ b/widget/embedded/src/hooks/useMobileDetect.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+const MIN_WIDTH_WINDOW = 768;
+
+const useMobileDetect = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  const handleResize = () => {
+    setIsMobile(window.innerWidth < MIN_WIDTH_WINDOW);
+  };
+
+  useEffect(() => {
+    handleResize(); // Initial check
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return isMobile;
+};
+
+export default useMobileDetect;

--- a/widget/embedded/src/hooks/useSwapInput.ts
+++ b/widget/embedded/src/hooks/useSwapInput.ts
@@ -58,6 +58,8 @@ export function useSwapInput({
     selectedQuote,
     sortStrategy,
     resetQuote,
+    error,
+    warning,
     setSelectedQuote,
     updateQuotePartialState,
   } = useQuoteStore();
@@ -184,7 +186,7 @@ export function useSwapInput({
     }
     if (shouldSkipRequest) {
       setLoading(false);
-      if (selectedQuote) {
+      if (selectedQuote || error || warning) {
         resetQuote();
       }
       return;

--- a/widget/embedded/src/index.ts
+++ b/widget/embedded/src/index.ts
@@ -7,6 +7,7 @@ import type {
   WidgetColorsKeys,
   WidgetConfig,
   WidgetTheme,
+  WidgetVariant,
 } from './types';
 import type {
   PendingSwapWithQueueID,
@@ -89,6 +90,7 @@ export type {
   HandleWalletsUpdate,
   ConnectedWallet,
   Tokens,
+  WidgetVariant,
 };
 export {
   Widget,

--- a/widget/embedded/src/pages/ConfirmSwapPage.tsx
+++ b/widget/embedded/src/pages/ConfirmSwapPage.tsx
@@ -282,7 +282,6 @@ export function ConfirmSwapPage() {
       <QuoteWarningsAndErrors
         warning={quoteWarning}
         error={quoteError}
-        loading={fetchingConfirmationQuote}
         refetchQuote={onRefresh}
         showWarningModal={showQuoteWarningModal}
         confirmationDisabled={!isActiveTab}

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -1,89 +1,58 @@
 import { i18n } from '@lingui/core';
-import { Button, Divider, styled, SwapInput, WarningIcon } from '@rango-dev/ui';
+import { Button, Divider, styled, WarningIcon } from '@rango-dev/ui';
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { HeaderButtons } from '../components/HeaderButtons';
 import { Layout, PageContainer } from '../components/Layout';
 import { QuoteWarningsAndErrors } from '../components/QuoteWarningsAndErrors';
-import { SwitchFromAndToButton } from '../components/SwitchFromAndTo';
-import { errorMessages } from '../constants/errors';
 import { navigationRoutes } from '../constants/navigationRoutes';
-import {
-  PERCENTAGE_CHANGE_MAX_DECIMALS,
-  PERCENTAGE_CHANGE_MIN_DECIMALS,
-  TOKEN_AMOUNT_MAX_DECIMALS,
-  TOKEN_AMOUNT_MIN_DECIMALS,
-  USD_VALUE_MAX_DECIMALS,
-  USD_VALUE_MIN_DECIMALS,
-} from '../constants/routing';
+import { ExpandedQuotes } from '../containers/ExpandedQuotes';
+import { Inputs } from '../containers/Inputs';
 import { QuoteInfo } from '../containers/QuoteInfo';
+import useMobileDetect from '../hooks/useMobileDetect';
 import { useSwapInput } from '../hooks/useSwapInput';
 import { useAppStore } from '../store/AppStore';
 import { useQuoteStore } from '../store/quote';
 import { useUiStore } from '../store/ui';
 import { useWalletsStore } from '../store/wallets';
-import { getContainer } from '../utils/common';
-import { formatTooltipNumbers, numberToString } from '../utils/numbers';
-import { getPriceImpact, getPriceImpactLevel } from '../utils/quote';
-import { canComputePriceImpact, getSwapButtonState } from '../utils/swap';
-import { formatBalance, isFetchingBalance } from '../utils/wallets';
+import { getSwapButtonState } from '../utils/swap';
 
-const FromContainer = styled('div', {
-  position: 'relative',
+const MainContainer = styled('div', {
+  display: 'grid',
+  gridTemplateColumns: 'auto auto',
+  alignItems: 'flex-start',
+  height: 700,
 });
+export const TIME_TO_NAVIGATE_ANOTHER_PAGE = 300;
 
-const InputsContainer = styled('div', {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 5,
-  alignSelf: 'stretch',
-});
 export function Home() {
   const navigate = useNavigate();
   const {
     fromToken,
-    fromBlockchain,
     toToken,
-    toBlockchain,
-    setInputAmount,
     inputAmount,
-    inputUsdValue,
-    outputAmount,
-    outputUsdValue,
     selectedQuote,
     refetchQuote,
     error: quoteError,
     warning: quoteWarning,
     quotes,
+    setSelectedQuote,
     resetQuoteWallets,
     setQuoteWarningsConfirmed,
     updateQuotePartialState,
   } = useQuoteStore();
-  const { fetch: fetchQuote, loading } = useSwapInput({ refetchQuote });
+  const [isVisibleExpanded, setIsVisibleExpanded] = useState<boolean>(false);
+  const isMobile = useMobileDetect();
 
+  const { fetch: fetchQuote, loading } = useSwapInput({ refetchQuote });
   const { config, fetchStatus: fetchMetaStatus } = useAppStore();
 
-  const { connectedWallets, getBalanceFor } = useWalletsStore();
+  const { connectedWallets } = useWalletsStore();
   const { isActiveTab } = useUiStore();
   const [showQuoteWarningModal, setShowQuoteWarningModal] = useState(false);
-  const fetchingBalance =
-    !!fromBlockchain &&
-    isFetchingBalance(connectedWallets, fromBlockchain.name);
 
   const needsToWarnEthOnPath = false;
-
-  const priceImpactInputCanNotBeComputed = !canComputePriceImpact(
-    selectedQuote,
-    inputAmount,
-    inputUsdValue
-  );
-
-  const priceImpactOutputCanNotBeComputed = !canComputePriceImpact(
-    selectedQuote,
-    inputAmount,
-    outputUsdValue
-  );
 
   const swapButtonState = getSwapButtonState({
     fetchMetaStatus,
@@ -95,204 +64,148 @@ export function Home() {
     warning: quoteWarning,
     needsToWarnEthOnPath,
   });
+  const isExpandable = config?.variant === 'expandable' && !isMobile;
+  const hasInputs =
+    !!inputAmount && !!fromToken && !!toToken && inputAmount !== '0';
+  const fetchingQuote = hasInputs && fetchMetaStatus === 'success' && loading;
 
-  const fromTokenBalance = fromToken ? getBalanceFor(fromToken) : null;
-
-  const fromTokenFormattedBalance =
-    formatBalance(fromTokenBalance)?.amount ?? '0';
-
-  const tokenBalanceReal =
-    !!fromBlockchain && !!fromToken && fromTokenBalance?.amount
-      ? numberToString(fromTokenBalance?.amount, fromTokenBalance?.decimals)
-      : '0';
-
-  const fetchingQuote =
-    fetchMetaStatus === 'success' &&
-    !!inputAmount &&
-    !!fromToken &&
-    !!toToken &&
-    loading;
+  const hasValidQuotes =
+    !isExpandable || (isExpandable && quotes?.results.length);
+  const hasWarningOrError = quoteWarning || quoteError;
+  const showMessages = hasValidQuotes && hasWarningOrError;
 
   useEffect(() => {
     resetQuoteWallets();
     updateQuotePartialState('refetchQuote', true);
   }, []);
 
-  const percentageChange =
-    !inputUsdValue || !outputUsdValue || !outputUsdValue.gt(0)
-      ? null
-      : getPriceImpact(inputUsdValue.toString(), outputUsdValue.toString());
+  useEffect(() => {
+    setIsVisibleExpanded(hasInputs);
+  }, [hasInputs]);
+
+  const onClickRefresh =
+    (!!selectedQuote || quoteError) && !showQuoteWarningModal
+      ? fetchQuote
+      : undefined;
+
+  const onHandleNavigation = (route: string) => {
+    if (isExpandable && isVisibleExpanded) {
+      setIsVisibleExpanded(false);
+      setTimeout(() => {
+        navigate(route);
+      }, TIME_TO_NAVIGATE_ANOTHER_PAGE);
+    } else {
+      navigate(route);
+    }
+  };
 
   return (
-    <Layout
-      height="auto"
-      footer={
-        <Button
-          type="primary"
-          size="large"
-          disabled={swapButtonState.disabled || !isActiveTab}
-          prefix={
-            swapButtonState.action === 'confirm-warning' && <WarningIcon />
-          }
-          fullWidth
-          onClick={() => {
-            if (swapButtonState.action === 'connect-wallet') {
-              navigate(navigationRoutes.wallets);
-            } else if (swapButtonState.action === 'confirm-warning') {
-              setShowQuoteWarningModal(true);
-            } else {
-              navigate(navigationRoutes.confirmSwap);
+    <MainContainer>
+      <Layout
+        height="auto"
+        footer={
+          <Button
+            type="primary"
+            size="large"
+            disabled={swapButtonState.disabled || !isActiveTab}
+            prefix={
+              swapButtonState.action === 'confirm-warning' && <WarningIcon />
             }
-          }}>
-          {swapButtonState.title}
-        </Button>
-      }
-      header={{
-        onWallet: () => {
-          navigate(navigationRoutes.wallets);
-        },
-        hasBackButton: false,
-        title: config.title || i18n.t('Swap'),
-        suffix: (
-          <HeaderButtons
-            onClickRefresh={
-              (!!selectedQuote || quoteError) && !showQuoteWarningModal
-                ? fetchQuote
-                : undefined
-            }
-            onClickHistory={() => navigate(navigationRoutes.swaps)}
-            onClickSettings={() => navigate(navigationRoutes.settings)}
-          />
-        ),
-      }}>
-      <PageContainer>
-        <InputsContainer>
-          <FromContainer>
-            <SwapInput
-              label={i18n.t('From')}
-              mode="From"
-              onInputChange={setInputAmount}
-              balance={fromTokenFormattedBalance}
-              chain={{
-                displayName: fromBlockchain?.displayName || '',
-                image: fromBlockchain?.logo || '',
-              }}
-              token={{
-                displayName: fromToken?.symbol || '',
-                image: fromToken?.image || '',
-              }}
-              onClickToken={() => navigate(navigationRoutes.fromSwap)}
-              price={{
-                value: inputAmount,
-                usdValue: priceImpactInputCanNotBeComputed
-                  ? undefined
-                  : numberToString(
-                      inputUsdValue,
-                      USD_VALUE_MIN_DECIMALS,
-                      USD_VALUE_MAX_DECIMALS
-                    ),
-                realUsdValue: priceImpactInputCanNotBeComputed
-                  ? undefined
-                  : formatTooltipNumbers(inputUsdValue),
-                error: priceImpactInputCanNotBeComputed
-                  ? errorMessages().unknownPriceError.impactTitle
-                  : undefined,
-              }}
-              disabled={fetchMetaStatus === 'failed'}
-              loading={fetchMetaStatus === 'loading'}
-              loadingBalance={fetchingBalance}
-              tooltipContainer={getContainer()}
-              onSelectMaxBalance={() => {
-                setInputAmount(tokenBalanceReal.split(',').join(''));
+            fullWidth
+            onClick={() => {
+              if (swapButtonState.action === 'connect-wallet') {
+                onHandleNavigation(navigationRoutes.wallets);
+              } else if (swapButtonState.action === 'confirm-warning') {
+                setShowQuoteWarningModal(true);
+              } else {
+                onHandleNavigation(navigationRoutes.confirmSwap);
+              }
+            }}>
+            {swapButtonState.title}
+          </Button>
+        }
+        header={{
+          onWallet: () => {
+            onHandleNavigation(navigationRoutes.wallets);
+          },
+          hasBackButton: false,
+          title: config.title || i18n.t('Swap'),
+          suffix: (
+            <HeaderButtons
+              hidden={isExpandable ? ['refresh'] : undefined}
+              onClickRefresh={onClickRefresh}
+              onClickHistory={() => onHandleNavigation(navigationRoutes.swaps)}
+              onClickSettings={() => {
+                onHandleNavigation(navigationRoutes.settings);
               }}
             />
-            <SwitchFromAndToButton />
-          </FromContainer>
-          <SwapInput
-            sharpBottomStyle={!!selectedQuote || fetchingQuote}
-            label={i18n.t('To')}
-            mode="To"
+          ),
+        }}>
+        <PageContainer>
+          <Inputs
             fetchingQuote={fetchingQuote}
-            chain={{
-              displayName: toBlockchain?.displayName || '',
-              image: toBlockchain?.logo || '',
+            fetchMetaStatus={fetchMetaStatus}
+            onClickToken={(mode) => {
+              onHandleNavigation(
+                mode === 'from'
+                  ? navigationRoutes.fromSwap
+                  : navigationRoutes.toSwap
+              );
             }}
-            token={{
-              displayName: toToken?.symbol || '',
-              image: toToken?.image || '',
-            }}
-            percentageChange={numberToString(
-              getPriceImpact(inputUsdValue, outputUsdValue),
-              PERCENTAGE_CHANGE_MIN_DECIMALS,
-              PERCENTAGE_CHANGE_MAX_DECIMALS
-            )}
-            warningLevel={getPriceImpactLevel(percentageChange ?? 0)}
-            price={{
-              value: numberToString(
-                outputAmount,
-                TOKEN_AMOUNT_MIN_DECIMALS,
-                TOKEN_AMOUNT_MAX_DECIMALS
-              ),
-              usdValue: priceImpactOutputCanNotBeComputed
-                ? undefined
-                : numberToString(
-                    outputUsdValue,
-                    USD_VALUE_MIN_DECIMALS,
-                    USD_VALUE_MAX_DECIMALS
-                  ),
-              realValue: formatTooltipNumbers(outputAmount),
-              realUsdValue: priceImpactOutputCanNotBeComputed
-                ? undefined
-                : formatTooltipNumbers(outputUsdValue),
-              error: priceImpactOutputCanNotBeComputed
-                ? errorMessages().unknownPriceError.impactTitle
-                : undefined,
-            }}
-            onClickToken={() => navigate(navigationRoutes.toSwap)}
-            disabled={fetchMetaStatus === 'failed'}
-            loading={fetchMetaStatus === 'loading'}
-            tooltipContainer={getContainer()}
           />
-        </InputsContainer>
-        <Divider size="2" />
-        <QuoteInfo
-          quote={selectedQuote}
-          loading={fetchingQuote}
-          error={quoteError}
-          tagHidden={false}
-          warning={quoteWarning}
-          type="basic"
-          onClickAllRoutes={
-            !!quotes && quotes.results.length > 1
-              ? () => {
-                  updateQuotePartialState('refetchQuote', false);
-                  navigate(navigationRoutes.routes);
-                }
-              : undefined
-          }
-        />
-        {quoteWarning || quoteError ? (
-          <>
-            <Divider size="10" />
-            <QuoteWarningsAndErrors
-              warning={quoteWarning}
-              error={quoteError}
+          <Divider size="2" />
+          {!isExpandable ? (
+            <QuoteInfo
+              quote={selectedQuote}
               loading={fetchingQuote}
-              refetchQuote={fetchQuote}
-              showWarningModal={showQuoteWarningModal}
-              confirmationDisabled={!isActiveTab}
-              onOpenWarningModal={() => setShowQuoteWarningModal(true)}
-              onCloseWarningModal={() => setShowQuoteWarningModal(false)}
-              onConfirmWarningModal={() => {
-                setShowQuoteWarningModal(false);
-                setQuoteWarningsConfirmed(true);
-                navigate(navigationRoutes.confirmSwap);
-              }}
-              onChangeSettings={() => navigate(navigationRoutes.settings)}
+              error={quoteError}
+              tagHidden={false}
+              warning={quoteWarning}
+              type="basic"
+              onClickAllRoutes={
+                !!quotes && quotes.results.length > 1
+                  ? () => {
+                      updateQuotePartialState('refetchQuote', false);
+                      onHandleNavigation(navigationRoutes.routes);
+                    }
+                  : undefined
+              }
             />
-          </>
-        ) : null}
-      </PageContainer>
-    </Layout>
+          ) : null}
+
+          {showMessages ? (
+            <>
+              <Divider size="10" />
+              <QuoteWarningsAndErrors
+                warning={quoteWarning}
+                error={quoteError}
+                refetchQuote={fetchQuote}
+                showWarningModal={showQuoteWarningModal}
+                confirmationDisabled={!isActiveTab}
+                onOpenWarningModal={() => setShowQuoteWarningModal(true)}
+                onCloseWarningModal={() => setShowQuoteWarningModal(false)}
+                onConfirmWarningModal={() => {
+                  setShowQuoteWarningModal(false);
+                  setQuoteWarningsConfirmed(true);
+                  onHandleNavigation(navigationRoutes.confirmSwap);
+                }}
+                onChangeSettings={() =>
+                  onHandleNavigation(navigationRoutes.settings)
+                }
+              />
+            </>
+          ) : null}
+        </PageContainer>
+      </Layout>
+      {isExpandable ? (
+        <ExpandedQuotes
+          loading={fetchingQuote}
+          onClickOnQuote={(quote) => setSelectedQuote(quote)}
+          fetch={fetchQuote}
+          onClickRefresh={onClickRefresh}
+          isVisible={isVisibleExpanded}
+        />
+      ) : null}
+    </MainContainer>
   );
 }

--- a/widget/embedded/src/pages/Routes.tsx
+++ b/widget/embedded/src/pages/Routes.tsx
@@ -1,34 +1,16 @@
 import type { SelectedQuote } from '../types';
-import type { MultiRouteSimulationResult, PreferenceType } from 'rango-sdk';
 
 import { i18n } from '@lingui/core';
-import { Divider, Select, styled, Typography } from '@rango-dev/ui';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { HeaderButtons } from '../components/HeaderButtons';
 import { Layout, PageContainer } from '../components/Layout';
-import { QuoteSkeleton } from '../components/QuoteSkeleton';
+import { Quotes } from '../components/Quotes';
 import { navigationRoutes } from '../constants/navigationRoutes';
-import { ROUTE_STRATEGY } from '../constants/quote';
-import { QuoteInfo } from '../containers/QuoteInfo';
-import { getQuoteError } from '../hooks/useConfirmSwap/useConfirmSwap.helpers';
 import { useNavigateBack } from '../hooks/useNavigateBack';
 import { useSwapInput } from '../hooks/useSwapInput';
-import { useAppStore } from '../store/AppStore';
 import { useQuoteStore } from '../store/quote';
-import { getContainer } from '../utils/common';
-import { generateQuoteWarnings, sortQuotesBy } from '../utils/quote';
-
-const ITEM_SKELETON_COUNT = 3;
-const StrategyContent = styled('div', {
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  '& .select_content': {
-    width: '146px',
-  },
-});
 
 export function RoutesPage() {
   const navigate = useNavigate();
@@ -36,23 +18,11 @@ export function RoutesPage() {
 
   const {
     selectedQuote,
-    quotes,
     refetchQuote,
     setSelectedQuote,
     updateQuotePartialState,
-    fromToken,
-    toToken,
-    sortStrategy,
     error: quoteError,
   } = useQuoteStore();
-  const { slippage, customSlippage } = useAppStore();
-  const tokens = useAppStore().tokens();
-
-  const sortQuotes = quotes?.results
-    ? sortQuotesBy(sortStrategy, quotes?.results)
-    : [];
-
-  const userSlippage = customSlippage ?? slippage;
 
   const { fetch: fetchQuote, loading: fetchingQuote } = useSwapInput({
     refetchQuote,
@@ -63,22 +33,7 @@ export function RoutesPage() {
     updateQuotePartialState('refetchQuote', false);
     navigateBack();
   };
-  const getQuoteWarning = (quote: MultiRouteSimulationResult) => {
-    if (!fromToken || !toToken || !quotes) {
-      return null;
-    }
-    const mergedQuote: SelectedQuote = {
-      requestAmount: quotes.requestAmount, // Assuming quotes is an array
-      ...quote,
-    };
 
-    return generateQuoteWarnings(mergedQuote, {
-      fromToken,
-      toToken,
-      userSlippage,
-      tokens,
-    });
-  };
   const settings_url = `../${navigationRoutes.settings}`;
   const wallets_url = `../${navigationRoutes.wallets}`;
   return (
@@ -102,67 +57,11 @@ export function RoutesPage() {
         ),
       }}>
       <PageContainer>
-        <StrategyContent>
-          <Typography size="xmedium" variant="title">
-            {i18n.t('Sort by')}
-          </Typography>
-          <div className="select_content">
-            <Select
-              container={getContainer()}
-              options={ROUTE_STRATEGY}
-              value={ROUTE_STRATEGY.find(
-                (strategy) => strategy.value === sortStrategy
-              )}
-              handleItemClick={(item) => {
-                updateQuotePartialState(
-                  'sortStrategy',
-                  item.value as PreferenceType
-                );
-              }}
-            />
-          </div>
-        </StrategyContent>
-        <Divider size="10" />
-
-        {fetchingQuote
-          ? Array.from({ length: ITEM_SKELETON_COUNT }, (_, index) => (
-              <React.Fragment key={index}>
-                <QuoteSkeleton
-                  tagHidden={false}
-                  type="list-item"
-                  expanded={false}
-                />
-                <Divider size={16} />
-              </React.Fragment>
-            ))
-          : !!quotes &&
-            sortQuotes.map((quote) => {
-              const quoteWarning = getQuoteWarning(quote);
-              const quoteError = getQuoteError(quote.swaps);
-
-              return (
-                <React.Fragment key={quote.requestId}>
-                  <QuoteInfo
-                    selected={selectedQuote?.requestId === quote.requestId}
-                    tagHidden={false}
-                    quote={{ ...quote, requestAmount: quotes.requestAmount }}
-                    loading={fetchingQuote}
-                    error={quoteError?.options || null}
-                    warning={quoteWarning}
-                    onClick={(quote) => {
-                      updateQuotePartialState('warning', quoteWarning);
-                      updateQuotePartialState(
-                        'error',
-                        quoteError?.options || null
-                      );
-                      onClickOnQuote(quote);
-                    }}
-                    type="list-item"
-                  />
-                  <Divider size={16} />
-                </React.Fragment>
-              );
-            })}
+        <Quotes
+          fetch={fetchQuote}
+          loading={fetchingQuote}
+          onClickOnQuote={onClickOnQuote}
+        />
       </PageContainer>
     </Layout>
   );

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -3,6 +3,8 @@ import type { ProviderInterface } from '@rango-dev/wallets-react';
 import type { WalletType } from '@rango-dev/wallets-shared';
 import type { Asset } from 'rango-sdk';
 
+export type WidgetVariant = 'default' | 'expandable';
+
 /**
  * The above type defines a set of optional color properties for a widget.
  * @property {string} background
@@ -179,6 +181,9 @@ export type Features = Partial<
  *   - 'connectWalletButton': Visibility state for the wallet connect icon.
  *   - 'language': Visibility state for the language.
  *   - 'experimentalRoute': Enablement state for the experimental route.
+ * @property {WidgetVariant} variant
+ *   If it is expandable, multiple routes will show up on the home page;
+ *   if not, you will need to go to a different page to see the suggested routes.
  */
 
 export type WidgetConfig = {
@@ -199,4 +204,5 @@ export type WidgetConfig = {
   externalWallets?: boolean;
   enableNewLiquiditySources?: boolean;
   features?: Features;
+  variant?: WidgetVariant;
 };

--- a/widget/embedded/src/utils/common.ts
+++ b/widget/embedded/src/utils/common.ts
@@ -34,3 +34,6 @@ export function containsText(text: string, searchText: string): boolean {
 
 export const getContainer = () =>
   document.getElementById(WIDGET_UI_ID.SWAP_BOX_ID) as HTMLElement;
+
+export const getExpanded = () =>
+  document.getElementById(WIDGET_UI_ID.EXPANDED_BOX_ID) as HTMLElement;

--- a/widget/playground/src/components/ItemPicker/ItemPicker.styles.ts
+++ b/widget/playground/src/components/ItemPicker/ItemPicker.styles.ts
@@ -34,6 +34,9 @@ export const Container = styled('div', {
   display: 'flex',
   flexDirection: 'column',
   width: '100%',
+  '.title_typography': {
+    textTransform: 'capitalize',
+  },
 });
 
 export const Title = styled('div', {

--- a/widget/playground/src/components/ItemPicker/ItemPicker.tsx
+++ b/widget/playground/src/components/ItemPicker/ItemPicker.tsx
@@ -1,6 +1,13 @@
 import type { PropTypes } from './ItemPicker.types';
 
-import { ChevronRightIcon, Divider, Image, Typography } from '@rango-dev/ui';
+import {
+  ChevronRightIcon,
+  Divider,
+  Image,
+  InfoIcon,
+  Tooltip,
+  Typography,
+} from '@rango-dev/ui';
 import React from 'react';
 
 import { Container, InputContainer, Title } from './ItemPicker.styles';
@@ -13,6 +20,7 @@ function ItemPicker(props: PropTypes) {
     iconTitle,
     hasLogo,
     placeholder,
+    tooltip,
     disabled,
   } = props;
 
@@ -25,6 +33,13 @@ function ItemPicker(props: PropTypes) {
         <Typography size="medium" variant="body">
           {title}
         </Typography>
+        <Divider size={4} direction="horizontal" />
+
+        {tooltip && (
+          <Tooltip content={tooltip} side="top">
+            <InfoIcon size={14} color="gray" />
+          </Tooltip>
+        )}
       </Title>
       <Divider size={4} />
       <InputContainer
@@ -46,7 +61,11 @@ function ItemPicker(props: PropTypes) {
               <Divider size={4} direction="horizontal" />
             </>
           )}
-          <Typography size="medium" variant="label" color="neutral700">
+          <Typography
+            className="title_typography"
+            size="medium"
+            variant="label"
+            color="neutral700">
             {label || placeholder}
           </Typography>
         </Title>

--- a/widget/playground/src/components/ItemPicker/ItemPicker.types.ts
+++ b/widget/playground/src/components/ItemPicker/ItemPicker.types.ts
@@ -9,4 +9,5 @@ export interface PropTypes {
   placeholder?: string;
   hasLogo?: boolean;
   disabled?: boolean;
+  tooltip?: React.ReactNode;
 }

--- a/widget/playground/src/constants/variants.ts
+++ b/widget/playground/src/constants/variants.ts
@@ -1,0 +1,10 @@
+export const VARIANTS = [
+  {
+    name: 'Default',
+    value: 'default',
+  },
+  {
+    name: 'Expandable',
+    value: 'expandable',
+  },
+];

--- a/widget/playground/src/containers/StyleLayout/StyleLayout.General.tsx
+++ b/widget/playground/src/containers/StyleLayout/StyleLayout.General.tsx
@@ -1,8 +1,10 @@
+import type { WidgetVariant } from '@rango-dev/widget-embedded';
 import type { ChangeEvent } from 'react';
 
 import {
   BorderRadiusIcon,
   Divider,
+  ExternalLinkIcon,
   FontIcon,
   LanguageIcon,
   Typography,
@@ -20,6 +22,7 @@ import {
   FONTS,
   LANGUAGES,
 } from '../../constants';
+import { VARIANTS } from '../../constants/variants';
 import { useConfigStore } from '../../store/config';
 
 import { Field, FieldTitle, GeneralContainer } from './StyleLayout.styles';
@@ -31,6 +34,8 @@ export function General() {
   const onBack = () => setModalState(null);
   const onChangeLanguage = useConfigStore.use.onChangeLanguage();
   const onChangeTheme = useConfigStore.use.onChangeTheme();
+  const onChangeVariant = useConfigStore.use.onChangeVariant();
+
   const borderRadius = useConfigStore.use.config().theme?.borderRadius;
 
   const secondaryBorderRadius =
@@ -38,6 +43,8 @@ export function General() {
   const fontFamily =
     useConfigStore.use.config().theme?.fontFamily || FONTS[0].value;
   const language = useConfigStore.use.config().language || LANGUAGES[0].value;
+  const variant = useConfigStore.use.config().variant || VARIANTS[0].value;
+
   const { resetLanguage } = useWidget();
 
   const handleFontChange = (value: string) => {
@@ -46,6 +53,15 @@ export function General() {
         name: 'fontFamily',
         value: value === FONTS[0].value ? undefined : value,
       });
+    }
+    onBack();
+  };
+
+  const handleVariantChange = (value: string) => {
+    if (value) {
+      onChangeVariant(
+        value === VARIANTS[0].value ? undefined : (value as WidgetVariant)
+      );
     }
     onBack();
   };
@@ -130,6 +146,20 @@ export function General() {
           title="Fonts"
           iconTitle={<FontIcon size={18} />}
         />
+
+        <Divider size={24} />
+        <ItemPicker
+          onClick={() => setModalState(ModalState.DEFAULT_VARIANT)}
+          value={{ label: variant }}
+          title="Variants"
+          tooltip={
+            <div>
+              You can display all potential routes next to the
+              <br /> widget box by selecting the expandable option.
+            </div>
+          }
+          iconTitle={<ExternalLinkIcon color="gray" size={18} />}
+        />
       </GeneralContainer>
       {modalState === ModalState.DEFAULT_FONT && (
         <OverlayPanel onBack={onBack}>
@@ -143,7 +173,18 @@ export function General() {
           />
         </OverlayPanel>
       )}
-
+      {modalState === ModalState.DEFAULT_VARIANT && (
+        <OverlayPanel onBack={onBack}>
+          <SingleList
+            onChange={handleVariantChange}
+            title="Variants"
+            icon={<ExternalLinkIcon color="gray" size={18} />}
+            defaultValue={variant}
+            list={VARIANTS}
+            searchPlaceholder="Search Variant"
+          />
+        </OverlayPanel>
+      )}
       {modalState === ModalState.DEFAULT_LANGUAGE && (
         <OverlayPanel onBack={onBack}>
           <SingleList

--- a/widget/playground/src/containers/StyleLayout/StyleLayout.types.ts
+++ b/widget/playground/src/containers/StyleLayout/StyleLayout.types.ts
@@ -28,4 +28,5 @@ export type CustomColorsTypes = {
 export enum ModalState {
   DEFAULT_FONT = 'font',
   DEFAULT_LANGUAGE = 'language',
+  DEFAULT_VARIANT = 'variant',
 }

--- a/widget/playground/src/store/config.ts
+++ b/widget/playground/src/store/config.ts
@@ -6,6 +6,7 @@ import type {
   WidgetColors,
   WidgetColorsKeys,
   WidgetConfig,
+  WidgetVariant,
 } from '@rango-dev/widget-embedded';
 import type { Asset } from 'rango-sdk';
 
@@ -71,6 +72,7 @@ interface ConfigState {
   onSelectTheme: (colors: { light: WidgetColors; dark: WidgetColors }) => void;
   onChangeLanguage: (value: string) => void;
   resetConfig: () => void;
+  onChangeVariant: (variant?: WidgetVariant) => void;
 }
 
 export const initialConfig: WidgetConfig = {
@@ -78,6 +80,7 @@ export const initialConfig: WidgetConfig = {
   walletConnectProjectId: getConfig('WC_PROJECT_ID'),
   amount: undefined,
   externalWallets: false,
+  variant: 'default',
   from: {
     blockchain: undefined,
     token: undefined,
@@ -118,6 +121,10 @@ export const useConfigStore = createSelectors(
         onChangeApiKey: (apiKey) =>
           set((state) => {
             state.config.apiKey = apiKey;
+          }),
+        onChangeVariant: (variant) =>
+          set((state) => {
+            state.config.variant = variant;
           }),
         onChangeBlockChains: (chains, type) =>
           set((state) => {

--- a/widget/ui/src/components/Alert/Alert.styles.ts
+++ b/widget/ui/src/components/Alert/Alert.styles.ts
@@ -4,7 +4,9 @@ export const Container = styled('div', {
   display: 'flex',
   flexDirection: 'column',
   borderRadius: '$xs',
-
+  '.title_typography': {
+    width: '100%',
+  },
   '.title_typography:first-letter': {
     textTransform: 'uppercase',
   },

--- a/widget/ui/src/components/QuoteCost/QuoteCost.styles.ts
+++ b/widget/ui/src/components/QuoteCost/QuoteCost.styles.ts
@@ -31,6 +31,8 @@ const blinker = keyframes({
 export const itemStyles = css({
   display: 'flex',
   alignItems: 'center',
+  cursor: 'default',
+
   '&.feeSection': {
     cursor: 'pointer',
     '&:hover': {


### PR DESCRIPTION
# Summary

For showing routes, an option should be added to widget to show routes in front of swap box. We are calling it Expand mode and it only needs to be added to Home.

Fixes # (issue)

- [x] Route display should be a separate component so that we can use it both in the routes page and in expand mode.
- [x] Display the errors in the routes component
- [x] Implement expand mode in config and playground
- [x] Errors shouldn't appear on the home page when extended mode is enabled.
- [x] Add an animation for opening the box


# How did you test this change?
In the playground, a general section has been added to the functional setting, where you can test the extendable mode

- [ ] When errors happen, they ought to show up appropriately in both expand and non-expand modes.
- [ ] The animation works properly
- [ ] The route display works correctly

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
