### PR TITLE
chore: remove npm whoiam from prepare action

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -22,9 +22,7 @@ runs:
 
     - name: Auth
       if: ${{ inputs.NPM_TOKEN != 0 }}
-      run: |
-        echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
-        npm whoami
+      run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> .npmrc
       env:
         NPM_TOKEN: ${{ inputs.NPM_TOKEN }}
       shell: 'bash'


### PR DESCRIPTION
# Summary

We are forcing using yarn, so we should make sure we don't run any command using npm.