### PR TITLE
feat: update active tab warning position

### DIFF
--- a/widget/embedded/src/components/Layout/Layout.styles.ts
+++ b/widget/embedded/src/components/Layout/Layout.styles.ts
@@ -41,6 +41,9 @@ export const Content = styled('div', {
 
 export const Footer = styled('div', {
   padding: '0 $20 $10',
+  '& .footer__alert': {
+    paddingTop: '$10',
+  },
   '& .footer__logo': {
     opacity: 0,
     transition: 'opacity 1s ease-in-out',

--- a/widget/embedded/src/components/Layout/Layout.tsx
+++ b/widget/embedded/src/components/Layout/Layout.tsx
@@ -138,13 +138,13 @@ function Layout(props: PropsWithChildren<PropTypes>) {
 
       <Footer>
         <div className="footer__content">
-          {footer}
           {tabManagerInitiated && !isActiveTab && (
-            <>
-              <Divider size={12} />
+            <div className="footer__alert">
               <ActivateTabAlert onActivateTab={onActivateTab} />
-            </>
+              <Divider size={10} />
+            </div>
           )}
+          {footer}
         </div>
 
         <Divider size={12} />

--- a/widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx
+++ b/widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx
@@ -13,14 +13,12 @@ export function ActivateTabAlert(props: PropTypes) {
           variant="contained"
           size="xxsmall"
           type="warning">
-          {i18n.t('Activate')}
+          {i18n.t('Activate this tab')}
         </Button>
       }
       type="warning"
       variant="alarm"
-      title={i18n.t(
-        'Another tab is open and handles transactions. You can activate this tab.'
-      )}
+      title={i18n.t('Another tab is open and handles transactions.')}
     />
   );
 }

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -23,6 +23,9 @@ const MainContainer = styled('div', {
   gridTemplateColumns: 'auto auto',
   alignItems: 'flex-start',
   height: 700,
+  '& .footer__alert': {
+    paddingTop: '0',
+  },
 });
 export const TIME_TO_NAVIGATE_ANOTHER_PAGE = 300;
 


### PR DESCRIPTION
# Summary

Update active tab warning position

Fixes # (issue)


# How did you test this change?

To see the warning displayed by the widget, open two tabs.

# Checklist:

- [x] I have performed a self-review of my code
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
