### PR TITLE
fix: correct set-as-read behavior in swap-details

### DIFF
--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -111,7 +111,7 @@ export function SwapDetails(props: SwapDetailsProps) {
         setAsRead(swap.requestId);
       }
     }
-  }, [swap.status]);
+  }, [swap.status, swap.requestId]);
 
   useEffect(() => {
     if (showSwitchNetwork) {


### PR DESCRIPTION
# Summary

In dapp when we had more than 1 failed or success swaps, when we clicked on notification icon, the setAsRead function doesn't work as we expected.

Fixes # (issue)


# How did you test this change?

Link with alpha branch in dapp.


# Checklist:

- [ ] I have performed a self-review of my code
