### PR TITLE
feat: add full expanded variant to widget

### DIFF
--- a/widget/embedded/src/components/NoResult/NoResult.helpers.ts
+++ b/widget/embedded/src/components/NoResult/NoResult.helpers.ts
@@ -9,6 +9,9 @@ import {
   type QuoteRequestFailed,
 } from '../../types';
 
+const SMALL_NO_ROUTE__ICON_SIZE = 24;
+const LARGE_NO_ROUTE_ICON_SIZE = 60;
+
 export function makeInfo(
   error: NoResultError | QuoteRequestFailed | null,
   disabledLiquiditySources: string[],
@@ -56,4 +59,14 @@ export function makeInfo(
     alert: null,
     description: errorMessages().noResultError.description,
   };
+}
+
+export enum NoRouteIconSize {
+  small = SMALL_NO_ROUTE__ICON_SIZE,
+  large = LARGE_NO_ROUTE_ICON_SIZE,
+}
+
+export enum NoRouteTitleSize {
+  small = 'small',
+  large = 'medium',
 }

--- a/widget/embedded/src/components/NoResult/NoResult.styles.ts
+++ b/widget/embedded/src/components/NoResult/NoResult.styles.ts
@@ -6,8 +6,26 @@ export const Container = styled('div', {
   alignItems: 'center',
 });
 
+export const ErrorDescription = styled('div', {
+  variants: {
+    size: {
+      small: {},
+      large: {
+        maxWidth: '316px',
+      },
+    },
+  },
+});
+
 export const Footer = styled('div', {
-  width: '100%',
+  variants: {
+    size: {
+      small: {
+        width: '100%',
+      },
+      large: {},
+    },
+  },
 });
 
 export const PrefixIcon = styled('div', {

--- a/widget/embedded/src/components/NoResult/NoResult.tsx
+++ b/widget/embedded/src/components/NoResult/NoResult.tsx
@@ -13,16 +13,24 @@ import React from 'react';
 import { errorMessages } from '../../constants/errors';
 import { useAppStore } from '../../store/AppStore';
 
-import { makeInfo } from './NoResult.helpers';
-import { Container, Footer, PrefixIcon } from './NoResult.styles';
+import {
+  makeInfo,
+  NoRouteIconSize,
+  NoRouteTitleSize,
+} from './NoResult.helpers';
+import {
+  Container,
+  ErrorDescription,
+  Footer,
+  PrefixIcon,
+} from './NoResult.styles';
 
 export function NoResult(props: PropTypes) {
-  const { fetch, error } = props;
+  const { fetch, error, size = 'small' } = props;
   const disabledLiquiditySources = useAppStore().getDisabledLiquiditySources();
   const toggleAllLiquiditySources = useAppStore().toggleAllLiquiditySources;
 
   const swappers = useAppStore().swappers();
-
   const info = makeInfo(
     error,
     disabledLiquiditySources,
@@ -32,27 +40,30 @@ export function NoResult(props: PropTypes) {
 
   return (
     <Container>
-      <NoRouteIcon size={24} color="gray" />
+      <NoRouteIcon size={NoRouteIconSize[size]} color="gray" />
       <Divider size={4} />
-      <Typography variant="title" size="small">
+      <Typography variant="title" size={NoRouteTitleSize[size]}>
         {errorMessages().noResultError.title}
       </Typography>
+      {size === 'large' && <Divider size={4} />}
       {!!info.description && (
-        <Typography
-          variant="body"
-          size="small"
-          align="center"
-          color="neutral700">
-          {info.description}
-        </Typography>
+        <ErrorDescription size={size}>
+          <Typography
+            variant="body"
+            size="small"
+            align="center"
+            color="neutral700">
+            {info.description}
+          </Typography>
+        </ErrorDescription>
       )}
-      <Divider size={4} />
+      <Divider size={size === 'large' ? '24' : '4'} />
       {!!info.alert && (
-        <Footer>
+        <Footer size={size}>
           <Alert
             type={info.alert.type}
             title={info.alert.text}
-            titleAlign={'center'}
+            titleAlign={'left'}
             action={
               info.alert.action && (
                 <Button

--- a/widget/embedded/src/components/NoResult/NoResult.types.ts
+++ b/widget/embedded/src/components/NoResult/NoResult.types.ts
@@ -3,6 +3,7 @@ import type { NoResultError, QuoteRequestFailed } from '../../types';
 export interface PropTypes {
   fetch: () => void;
   error: NoResultError | QuoteRequestFailed | null;
+  size?: 'small' | 'large';
 }
 
 type AlertAction = {

--- a/widget/embedded/src/components/Quote/Quote.types.ts
+++ b/widget/embedded/src/components/Quote/Quote.types.ts
@@ -14,6 +14,7 @@ export type QuoteProps = {
   selected?: boolean;
   showModalFee?: boolean;
   onClickAllRoutes?: () => void;
+  fullExpandedMode?: boolean;
 };
 
 export type optionProps = {

--- a/widget/embedded/src/components/Quotes/Quotes.tsx
+++ b/widget/embedded/src/components/Quotes/Quotes.tsx
@@ -2,7 +2,7 @@ import type { PropTypes } from './Quotes.types';
 import type { MultiRouteSimulationResult } from 'rango-sdk';
 
 import { i18n } from '@lingui/core';
-import { Divider, Typography } from '@rango-dev/ui';
+import { Divider, FullExpandedQuote, Typography } from '@rango-dev/ui';
 import React from 'react';
 
 import { QuoteInfo } from '../../containers/QuoteInfo';
@@ -26,6 +26,7 @@ export function Quotes(props: PropTypes) {
     fetch,
     showModalFee,
     hasSort = true,
+    fullExpandedMode = false,
   } = props;
   const {
     selectedQuote,
@@ -69,11 +70,15 @@ export function Quotes(props: PropTypes) {
       {loading &&
         Array.from({ length: ITEM_SKELETON_COUNT }, (_, index) => (
           <React.Fragment key={index}>
-            <QuoteSkeleton
-              tagHidden={false}
-              type="list-item"
-              expanded={false}
-            />
+            {fullExpandedMode ? (
+              <FullExpandedQuote loading />
+            ) : (
+              <QuoteSkeleton
+                tagHidden={false}
+                type="list-item"
+                expanded={false}
+              />
+            )}
             <Divider size={16} />
           </React.Fragment>
         ))}
@@ -106,6 +111,7 @@ export function Quotes(props: PropTypes) {
                       loading={loading}
                       error={quoteError?.options || null}
                       warning={quoteWarning}
+                      fullExpandedMode={fullExpandedMode}
                       onClick={(quote) => {
                         if (!quoteError) {
                           updateQuotePartialState('warning', quoteWarning);
@@ -124,7 +130,11 @@ export function Quotes(props: PropTypes) {
               })
             : showNoResultMessage && (
                 <ErrorsContainer>
-                  <NoResult error={error} fetch={fetch} />
+                  <NoResult
+                    size={fullExpandedMode ? 'large' : 'small'}
+                    error={error}
+                    fetch={fetch}
+                  />
                 </ErrorsContainer>
               )}
         </>

--- a/widget/embedded/src/components/Quotes/Quotes.types.ts
+++ b/widget/embedded/src/components/Quotes/Quotes.types.ts
@@ -6,4 +6,5 @@ export type PropTypes = {
   fetch: (shouldChangeSelectedQuote?: boolean) => void;
   showModalFee?: boolean;
   hasSort?: boolean;
+  fullExpandedMode?: boolean;
 };

--- a/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.styles.ts
+++ b/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.styles.ts
@@ -10,6 +10,18 @@ export const Container = styled('div', {
   [`.${darkTheme} &`]: {
     backgroundColor: '$neutral300',
   },
+
+  variants: {
+    expandMode: {
+      default: {
+        width: '390px',
+      },
+      full: {
+        width: '719px',
+      },
+    },
+  },
+
   '&.is-hidden': {
     width: 0,
     opacity: 0,

--- a/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx
+++ b/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx
@@ -9,6 +9,7 @@ import { LayoutContainer } from '../../components/Layout/Layout.styles';
 import { Quotes } from '../../components/Quotes';
 import { SelectStrategy } from '../../components/Quotes/SelectStrategy';
 import { WIDGET_UI_ID } from '../../constants';
+import { useAppStore } from '../../store/AppStore';
 import { getExpanded } from '../../utils/common';
 
 import { Container, Content } from './ExpandedQuotes.styles';
@@ -19,6 +20,8 @@ export function ExpandedQuotes(props: PropTypes) {
   const { fetch, loading, onClickOnQuote, onClickRefresh, isVisible } = props;
   const [isDelayedVisible, setIsDelayedVisible] = useState(false);
   const containerClass = isDelayedVisible ? '' : 'is-hidden';
+  const { config } = useAppStore();
+  const fullExpandedMode = config?.variant === 'full-expanded';
 
   useEffect(() => {
     let timeout: ReturnType<typeof setTimeout> | null = null;
@@ -43,6 +46,7 @@ export function ExpandedQuotes(props: PropTypes) {
 
   return (
     <Container
+      expandMode={config?.variant === 'full-expanded' ? 'full' : 'default'}
       className={`${containerClass} ${LayoutContainer()}`}
       id={WIDGET_UI_ID.EXPANDED_BOX_ID}>
       <Header
@@ -64,6 +68,7 @@ export function ExpandedQuotes(props: PropTypes) {
           hasSort={false}
           loading={loading}
           onClickOnQuote={onClickOnQuote}
+          fullExpandedMode={fullExpandedMode}
         />
       </Content>
     </Container>

--- a/widget/embedded/src/containers/QuoteInfo/QuoteInfo.tsx
+++ b/widget/embedded/src/containers/QuoteInfo/QuoteInfo.tsx
@@ -25,6 +25,7 @@ export function QuoteInfo(props: PropTypes) {
     showModalFee,
     selected,
     onClickAllRoutes,
+    fullExpandedMode = false,
   } = props;
   const { inputAmount, inputUsdValue, toToken } = useQuoteStore();
 
@@ -65,6 +66,7 @@ export function QuoteInfo(props: PropTypes) {
         type={type}
         expanded={expanded}
         onClickAllRoutes={onClickAllRoutes}
+        fullExpandedMode={fullExpandedMode}
         input={{
           value: inputAmount,
           usdValue: inputUsdValue?.toString() ?? '',

--- a/widget/embedded/src/containers/QuoteInfo/QuoteInfo.types.ts
+++ b/widget/embedded/src/containers/QuoteInfo/QuoteInfo.types.ts
@@ -14,4 +14,5 @@ export type PropTypes = {
   onClickAllRoutes?: () => void;
   selected?: boolean;
   showModalFee?: boolean;
+  fullExpandedMode?: boolean;
 };

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -16,6 +16,7 @@ import { useAppStore } from '../store/AppStore';
 import { useQuoteStore } from '../store/quote';
 import { useUiStore } from '../store/ui';
 import { useWalletsStore } from '../store/wallets';
+import { isVarianExpandable } from '../utils/configs';
 import { getSwapButtonState } from '../utils/swap';
 
 const MainContainer = styled('div', {
@@ -67,7 +68,7 @@ export function Home() {
     warning: quoteWarning,
     needsToWarnEthOnPath,
   });
-  const isExpandable = config?.variant === 'expandable' && !isMobile;
+  const isExpandable = isVarianExpandable(config?.variant) && !isMobile;
   const hasInputs =
     !!inputAmount && !!fromToken && !!toToken && inputAmount !== '0';
   const fetchingQuote = hasInputs && fetchMetaStatus === 'success' && loading;

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -3,7 +3,7 @@ import type { ProviderInterface } from '@rango-dev/wallets-react';
 import type { WalletType } from '@rango-dev/wallets-shared';
 import type { Asset } from 'rango-sdk';
 
-export type WidgetVariant = 'default' | 'expandable';
+export type WidgetVariant = 'default' | 'expanded' | 'full-expanded';
 
 /**
  * The above type defines a set of optional color properties for a widget.
@@ -182,7 +182,8 @@ export type Features = Partial<
  *   - 'language': Visibility state for the language.
  *   - 'experimentalRoute': Enablement state for the experimental route.
  * @property {WidgetVariant} variant
- *   If it is expandable, multiple routes will show up on the home page;
+ *   If it is expanded, multiple routes will show up on the home page;
+ *   If it is full-expanded, multiple routes will show up on the home page with full routes;
  *   if not, you will need to go to a different page to see the suggested routes.
  */
 

--- a/widget/embedded/src/utils/configs.ts
+++ b/widget/embedded/src/utils/configs.ts
@@ -1,4 +1,4 @@
-import type { Tokens } from '../types';
+import type { Tokens, WidgetVariant } from '../types';
 import type { Asset, BlockchainMeta, Token } from 'rango-sdk';
 
 import { RANGO_PUBLIC_API_KEY } from '../constants';
@@ -78,4 +78,8 @@ export const isBlockchainExcludedInConfig = (
     blockchainsConfig &&
     !blockchainsConfig.includes(blockchain.name)
   );
+};
+
+export const isVarianExpandable = (variant?: WidgetVariant) => {
+  return variant === 'expanded' || variant === 'full-expanded';
 };

--- a/widget/playground/src/constants/variants.ts
+++ b/widget/playground/src/constants/variants.ts
@@ -4,7 +4,11 @@ export const VARIANTS = [
     value: 'default',
   },
   {
-    name: 'Expandable',
-    value: 'expandable',
+    name: 'Expanded',
+    value: 'expanded',
+  },
+  {
+    name: 'Full Expanded',
+    value: 'full-expanded',
   },
 ];

--- a/widget/ui/src/components/Alert/Alert.tsx
+++ b/widget/ui/src/components/Alert/Alert.tsx
@@ -45,7 +45,12 @@ export function Alert(props: PropsWithChildren<PropTypes>) {
             </Typography>
           )}
         </TitleContainer>
-        {action ? <div>{action}</div> : null}
+        {action ? (
+          <>
+            <Divider direction="horizontal" size={'20'} />
+            <div>{action}</div>
+          </>
+        ) : null}
       </Main>
       {footer ? (
         <div className={`footer ${isFooterString ? 'description' : ''}`}>

--- a/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.styles.ts
+++ b/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.styles.ts
@@ -158,7 +158,7 @@ export const OutputSection = styled(FlexCenter, {
 
 export const VerticalLine = styled('div', {
   display: 'flex',
-  width: '50%',
+  width: 'calc(50% + 1px)',
   borderRight: '1px dashed',
   height: '$10',
   borderColor: '$info300',

--- a/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.tsx
+++ b/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.tsx
@@ -45,7 +45,7 @@ export function FullExpandedQuote(props: PropTypes) {
     warningLevel,
     tooltipContainer,
     onClick,
-    selected,
+    selected = false,
   } = props;
 
   const steps: DataLoadedProps['steps'] = loading


### PR DESCRIPTION
# Summary

The full expanded variant for the route was added to the widget  We should make sure every part works together correctly:

1. full expanded quote component
2. filter and refresh 
3. errors flow 
4. playground: add a new variant to the playground


# How did you test this change?

You can change **config.variant** to test all variants of the route 
for example:
```
      config = {
        apiKey: '',
        variant: 'full-expanded',
        walletConnectProjectId: WC_PROJECT_ID,
      };
```

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
