### PR TITLE
fix: correct default values of hidden features

### DIFF
--- a/widget/embedded/src/store/slices/settings.ts
+++ b/widget/embedded/src/store/slices/settings.ts
@@ -160,9 +160,13 @@ export const createSettingsSlice: StateCreator<
     const isLiquidityHidden = isFeatureHidden('liquiditySource', features);
 
     set({
-      ...(isThemeHidden && { theme: 'auto' }),
-      ...(isLanguageHidden && { language: DEFAULT_LANGUAGE }),
-      ...(isLiquidityHidden && { disabledLiquiditySources: [] }),
+      ...(isThemeHidden && { theme: nextConfig.theme?.mode || 'auto' }),
+      ...(isLanguageHidden && {
+        language: nextConfig.language || DEFAULT_LANGUAGE,
+      }),
+      ...(isLiquidityHidden && {
+        disabledLiquiditySources: nextConfig.liquiditySources || [],
+      }),
     });
   },
 });


### PR DESCRIPTION
# Summary

When a feature is hidden, the default value should be from config.

Fixes # (issue)


# How did you test this change?
hide a feature and give it value from config 


# Checklist:

- [x] I have performed a self-review of my code
