### PR TITLE
fix: fix bugs in displaying quote error modals

### DIFF
--- a/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts
@@ -23,13 +23,12 @@ export function makeAlerts(
   const alertInfo: AlertInfo = {
     alertType: 'warning',
     title: '',
-    action: 'show-info',
+    action: null,
   };
   if (error) {
     alertInfo.alertType = 'error';
     if (error.type === QuoteErrorType.BRIDGE_LIMIT) {
       alertInfo.title = error.recommendation;
-      alertInfo.action = 'show-info';
     }
 
     if (error.type === QuoteErrorType.INSUFFICIENT_SLIPPAGE) {
@@ -50,7 +49,7 @@ export function makeAlerts(
       if (warningLevel === 'high') {
         alertInfo.alertType = 'error';
       }
-      alertInfo.action = null;
+      alertInfo.action = 'show-info';
       alertInfo.title = errorMessages().highValueLossError.title;
     }
     if (warning.type === QuoteWarningType.UNKNOWN_PRICE) {

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -1,3 +1,5 @@
+import type { SelectedQuote } from '../types';
+
 import { i18n } from '@lingui/core';
 import { Button, Divider, styled, WarningIcon } from '@rango-dev/ui';
 import React, { useEffect, useState } from 'react';
@@ -114,6 +116,13 @@ export function Home() {
     }
   };
 
+  const onClickOnQuote = (quote: SelectedQuote) => {
+    if (selectedQuote?.requestId !== quote.requestId) {
+      setShowQuoteWarningModal(false);
+      setSelectedQuote(quote);
+    }
+  };
+
   return (
     <MainContainer>
       <Layout
@@ -215,7 +224,7 @@ export function Home() {
       {isExpandable ? (
         <ExpandedQuotes
           loading={fetchingQuote}
-          onClickOnQuote={(quote) => setSelectedQuote(quote)}
+          onClickOnQuote={onClickOnQuote}
           fetch={fetchQuote}
           onClickRefresh={onClickRefresh}
           isVisible={isVisibleExpanded}


### PR DESCRIPTION
# Summary

Displaying error modals for routes is not accurate in expanded mode. Even when changing the selected route, we continue to show the error modal, even if that route doesn't have a similar error. 
Additionally, the alert for the bridge limit error should remain without any associated action; the action button related to it needs to be removed . 

Fixes # (issue)

- [x] close the quote modal after changing the selected quote
- [x] remove the action from the bridge limit alert

# Checklist:

- [x] I have performed a self-review of my code
