### PR TITLE
fix: correct height of widget

### DIFF
--- a/widget/app/public/index.css
+++ b/widget/app/public/index.css
@@ -12,4 +12,6 @@ body {
 
 #app {
   min-height: 100vh;
+  display: flex;
+  justify-content: center;
 }

--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -300,6 +300,8 @@ export function Quote(props: QuoteProps) {
     GAS_FEE_MAX_DECIMALS
   );
 
+  const feeWarning = totalFee.gte(new BigNumber(GAS_FEE_MAX));
+
   return fullExpandedMode ? (
     <FullExpandedQuote
       selected={selected}
@@ -308,6 +310,7 @@ export function Quote(props: QuoteProps) {
       tooltipContainer={getExpanded()}
       steps={steps}
       tags={sortedQuoteTags}
+      feeWarning={feeWarning}
       percentageChange={percentageChange}
       warningLevel={priceImpactWarningLevel}
       outputPrice={{
@@ -345,7 +348,7 @@ export function Quote(props: QuoteProps) {
             quote={quote}
             time={totalTime}
             fee={fee}
-            feeWarning={totalFee.gte(new BigNumber(GAS_FEE_MAX))}
+            feeWarning={feeWarning}
             showModalFee={showModalFee}
             steps={numberOfSteps}
           />

--- a/widget/embedded/src/components/Quotes/Quotes.tsx
+++ b/widget/embedded/src/components/Quotes/Quotes.tsx
@@ -79,7 +79,7 @@ export function Quotes(props: PropTypes) {
                 expanded={false}
               />
             )}
-            <Divider size={16} />
+            {index !== ITEM_SKELETON_COUNT - 1 && <Divider size={16} />}
           </React.Fragment>
         ))}
 
@@ -97,9 +97,10 @@ export function Quotes(props: PropTypes) {
             </>
           )}
           {hasQuotes
-            ? sortQuotes.map((quote) => {
+            ? sortQuotes.map((quote, index) => {
                 const quoteWarning = getQuoteWarning(quote);
                 const quoteError = getQuoteError(quote.swaps);
+                const lastIndex = sortQuotes.length - 1 === index;
 
                 return (
                   <React.Fragment key={quote.requestId}>
@@ -124,7 +125,7 @@ export function Quotes(props: PropTypes) {
                       }}
                       type="list-item"
                     />
-                    <Divider size={16} />
+                    {!lastIndex && <Divider size={16} />}
                   </React.Fragment>
                 );
               })

--- a/widget/embedded/src/containers/App/App.styles.ts
+++ b/widget/embedded/src/containers/App/App.styles.ts
@@ -1,13 +1,9 @@
 import { styled } from '@rango-dev/ui';
 
 export const MainContainer = styled('div', {
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
   fontFamily: '$widget',
   boxSizing: 'border-box',
   textAlign: 'left',
-
   '& *, *::before, *::after': {
     boxSizing: 'inherit',
   },

--- a/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.styles.ts
+++ b/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.styles.ts
@@ -24,6 +24,7 @@ export const Container = styled('div', {
 
   '&.is-hidden': {
     width: 0,
+    height: 0,
     opacity: 0,
     marginLeft: 0,
   },

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -25,7 +25,7 @@ const MainContainer = styled('div', {
   display: 'grid',
   gridTemplateColumns: 'auto auto',
   alignItems: 'flex-start',
-  height: 700,
+  maxHeight: 700,
   '& .footer__alert': {
     paddingTop: '0',
   },

--- a/widget/playground/src/containers/BoundaryGuideContainer/BoundaryGuideContainer.styles.ts
+++ b/widget/playground/src/containers/BoundaryGuideContainer/BoundaryGuideContainer.styles.ts
@@ -12,6 +12,7 @@ export const Container = styled('div', {
   position: 'relative',
   display: 'flex',
   justifyContent: 'center',
+  paddingTop: '40px',
   transition: 'width .5s ease-in-out',
   margin: 'auto',
   height: '100%',
@@ -40,9 +41,8 @@ export const Container = styled('div', {
 
 export const BoundaryGuide = styled('div', {
   position: 'absolute',
-  top: '50%',
+  top: '40px',
   left: 0,
-  transform: 'translate(0, -50%)',
   width: '100%',
   outlineStyle: 'dashed',
   outlineColor: '$neutral600',

--- a/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.styles.ts
+++ b/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.styles.ts
@@ -20,6 +20,12 @@ export const RouteContainer = styled('div', {
   [`.${darkTheme} &`]: {
     backgroundColor: '$neutral500',
   },
+  '&:hover': {
+    backgroundColor: '$neutral300',
+    [`.${darkTheme} &`]: {
+      backgroundColor: '$neutral400',
+    },
+  },
   variants: {
     selected: {
       true: {

--- a/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.tsx
+++ b/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.tsx
@@ -45,6 +45,7 @@ export function FullExpandedQuote(props: PropTypes) {
     warningLevel,
     tooltipContainer,
     onClick,
+    feeWarning,
     selected = false,
   } = props;
 
@@ -64,6 +65,7 @@ export function FullExpandedQuote(props: PropTypes) {
               fee={props.fee}
               time={props.time}
               steps={numberOfSteps}
+              feeWarning={feeWarning}
             />
             <TagsContainer>
               {props.tags.map((tag) => (

--- a/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.types.ts
+++ b/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.types.ts
@@ -10,6 +10,7 @@ type BaseProps = {
   tooltipContainer?: HTMLElement;
   onClick?: () => void;
   selected?: boolean;
+  feeWarning?: boolean;
 };
 
 export type DataLoadedProps = {


### PR DESCRIPTION
# Summary

- [x] fixed the height of the widget (it was always 700px and it was not true)
- [x] added fee warning prop to full-expanded route
- [x] fixed spacing in the last items of the routes list
- [x] added a hover state for the full-expanded route
- [x] made the height of expanded panel height to zero when it's not visible


# Checklist:

- [x] I have performed a self-review of my code
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
