### PR TITLE
feat: add enabling centralized swappers to config

### DIFF
--- a/widget/embedded/src/containers/Settings/Lists.tsx
+++ b/widget/embedded/src/containers/Settings/Lists.tsx
@@ -104,9 +104,8 @@ export function SettingsLists() {
     disabledLiquiditySources
   );
 
-  const bridgeSources = supportedUniqueSwappersGroups.filter(
-    (uniqueItem) =>
-      uniqueItem.type === 'BRIDGE' || uniqueItem.type === 'AGGREGATOR'
+  const bridgeSources = supportedUniqueSwappersGroups.filter((uniqueItem) =>
+    ['BRIDGE', 'AGGREGATOR', 'OFF_CHAIN'].includes(uniqueItem.type)
   );
 
   const totalBridgeSources = bridgeSources.length;

--- a/widget/embedded/src/hooks/useSwapInput.ts
+++ b/widget/embedded/src/hooks/useSwapInput.ts
@@ -46,8 +46,11 @@ export function useSwapInput({
   refetchQuote,
 }: UseSwapInputProps): UseSwapInput {
   const { fetch: fetchQuote, cancelFetch } = useFetchAllQuotes();
-  const { excludeLiquiditySources: configExcludeLiquiditySources, features } =
-    useAppStore().config;
+  const {
+    excludeLiquiditySources: configExcludeLiquiditySources,
+    features,
+    enableCentralizedSwappers,
+  } = useAppStore().config;
   const connectedWallets = useWalletsStore.use.connectedWallets();
 
   const tokens = useAppStore().tokens();
@@ -119,6 +122,7 @@ export function useSwapInput({
         affiliateRef,
         affiliatePercent,
         affiliateWallets,
+        enableCentralizedSwappers,
       });
       if (isFeatureEnabled('experimentalRoute', features)) {
         requestBody.experimental = true;

--- a/widget/embedded/src/pages/LiquiditySourcePage.tsx
+++ b/widget/embedded/src/pages/LiquiditySourcePage.tsx
@@ -44,8 +44,7 @@ export function LiquiditySourcePage({ sourceType }: PropTypes) {
     validTypes.push('DEX');
   }
   if (sourceType === 'Bridges') {
-    validTypes.push('BRIDGE');
-    validTypes.push('AGGREGATOR');
+    validTypes.push('BRIDGE', 'AGGREGATOR', 'OFF_CHAIN');
   }
 
   const liquiditySources = supportedUniqueSwappersGroups.filter((uniqueItem) =>

--- a/widget/embedded/src/store/slices/data.ts
+++ b/widget/embedded/src/store/slices/data.ts
@@ -207,7 +207,10 @@ export const createDataSlice: StateCreator<
   // Actions
   fetch: async () => {
     try {
-      const response = await sdk().getAllMetadata();
+      const { enableCentralizedSwappers } = get().config;
+      const response = await sdk().getAllMetadata({
+        enableCentralizedSwappers,
+      });
 
       set({ fetchStatus: 'success' });
       const blockchains: BlockchainMeta[] = [];

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -185,6 +185,8 @@ export type Features = Partial<
  *   If it is expanded, multiple routes will show up on the home page;
  *   If it is full-expanded, multiple routes will show up on the home page with full routes;
  *   if not, you will need to go to a different page to see the suggested routes.
+ * @property {boolean} enableCentralizedSwappers
+ * If you want to enable routing from the centralized protocols like XO Swap, you could set this parameter to true.
  */
 
 export type WidgetConfig = {
@@ -206,4 +208,5 @@ export type WidgetConfig = {
   excludeLiquiditySources?: boolean;
   features?: Features;
   variant?: WidgetVariant;
+  enableCentralizedSwappers?: boolean;
 };

--- a/widget/embedded/src/utils/swap.ts
+++ b/widget/embedded/src/utils/swap.ts
@@ -478,6 +478,7 @@ export function createQuoteRequestBody(params: {
   affiliatePercent: number | null;
   affiliateWallets: { [key: string]: string } | null;
   destination?: string;
+  enableCentralizedSwappers?: boolean;
 }): BestRouteRequest {
   const {
     fromToken,
@@ -493,6 +494,7 @@ export function createQuoteRequestBody(params: {
     affiliatePercent,
     affiliateWallets,
     destination,
+    enableCentralizedSwappers,
   } = params;
   const selectedWalletsMap = selectedWallets?.reduce(
     (
@@ -544,6 +546,7 @@ export function createQuoteRequestBody(params: {
       ),
       swappersGroupsExclude: false,
     }),
+    enableCentralizedSwappers,
   };
   return requestBody;
 }


### PR DESCRIPTION
# Summary

Add enabling centralized swappers to config to pass to get meta & get route api params.

Fixes # (issue)


# How did you test this change?
by passing `enableCentralizedSwappers` to config & checking the body of meta & qoute api call params


# Checklist:

- [x] I have performed a self-review of my code
