### PR TITLE
feat: add more languages to widget

### DIFF
--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -1,6 +1,6 @@
 /** @type {import('@lingui/conf').LinguiConfig} */
 module.exports = {
-  locales: ['en', 'es', 'ja', 'fr', 'pt'],
+  locales: ['en', 'es', 'ja', 'fr', 'pt', 'zh', 'ru', 'de', 'uk', 'sv', 'fi', 'nl', 'el', 'it', 'pl'],
   sourceLocale: 'en',
   format: 'po',
   catalogs: [

--- a/translations/de.po
+++ b/translations/de.po
@@ -1,22 +1,17 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-06 17:24+0330\n"
+"POT-Creation-Date: 2024-03-10 11:57+0330\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: pt\n"
-"Project-Id-Version: rango\n"
+"Language: de\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-02-20 09:32\n"
+"PO-Revision-Date: \n"
 "Last-Translator: \n"
-"Language-Team: Portuguese\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: rango\n"
-"X-Crowdin-Project-ID: 622238\n"
-"X-Crowdin-Language: pt-PT\n"
-"X-Crowdin-File: en.po\n"
-"X-Crowdin-File-ID: 30\n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
@@ -24,7 +19,7 @@ msgstr ""
 #: widget/embedded/src/pages/HistoryPage.tsx:85
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:131
 msgid "No results found"
-msgstr "Nenhum resultado encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:38
@@ -32,24 +27,24 @@ msgstr "Nenhum resultado encontrado"
 #: widget/embedded/src/pages/HistoryPage.tsx:87
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:132
 msgid "Try using different keywords"
-msgstr "Tente usar palavras-chave diferentes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:66
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:46
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:40
 msgid "Select Blockchain"
-msgstr "Selecione a Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:66
 msgid "All"
-msgstr "TODOS"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:100
 msgid "More +{count}"
-msgstr "Mais +{count}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
@@ -64,221 +59,221 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
 msgid "Activate current tab"
-msgstr "Ativar a aba atual"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:22
 msgid "Currently, some transactions are running and being handled by other browser tab. If you activate this tab, all transactions that are already in the transaction sign step will expire."
-msgstr "No momento, algumas transações estão sendo executadas e sendo tratadas por outra aba do navegador. Se você ativar essa aba, todas as transações que já estão na etapa de sinal de transação irão expirar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:32
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:269
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:237
 msgid "Confirm"
-msgstr "Confirmar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:284
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:359
 msgid "Your {blockchainName} wallets"
-msgstr "Suas carteiras {blockchainName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:303
 msgid "Insufficient account balance"
-msgstr "Saldo de conta insuficiente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:312
 msgid "Proceed anyway"
-msgstr "Continuar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:368
 msgid "You need to connect a {blockchainName} wallet."
-msgstr "Você precisa conectar uma carteira {blockchainName}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
-msgstr "Enviar para outro endereço"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
-msgstr "Seu endereço de destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
-msgstr "O endereço {destination} não corresponde ao padrão do endereço da blockchain."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:168
 msgid "Add {chain} chain"
-msgstr "Adiciona cadeia {chain}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:217
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:250
 msgid "Add {blockchainDisplayName} Chain"
-msgstr "Adicionar Corrente {blockchainDisplayName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:222
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:254
 msgid "You should connect a {blockchainDisplayName} supported wallet or choose a different {blockchainDisplayName} address"
-msgstr "Você deve conectar uma carteira com suporte do {blockchainDisplayName} ou escolher um endereço {blockchainDisplayName} diferente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:272
 msgid "{blockchainDisplayName} Chain Added"
-msgstr "{blockchainDisplayName} Cadeia Adicionada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:276
 msgid "{blockchainDisplayName} is added to your wallet, you can use it to swap."
-msgstr "{blockchainDisplayName} foi adicionado à sua carteira, você pode usá-lo para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:286
 msgid "Request Rejected"
-msgstr "Pedido rejeitado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:287
 msgid "You've rejected adding {blockchainDisplayName} chain to your wallet."
-msgstr "Você rejeitou adicionar {blockchainDisplayName} corrente à sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:311
 msgid "Show more wallets"
-msgstr "Mostrar mais carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/CancelButton.tsx:14
 msgid "Cancel"
-msgstr "cancelar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
-msgstr "atualizar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
-msgstr "notificações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
 #: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
-msgstr "Confirgurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
-msgstr "Histórico de transações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/WalletButton.tsx:14
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:16
 #: widget/embedded/src/constants/messages.ts:5
 msgid "Connect Wallet"
-msgstr "Conectar Carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx:118
 #: widget/embedded/src/utils/date.ts:18
 #: widget/embedded/src/utils/time.ts:22
 msgid "Today"
-msgstr "hoje"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:375
 msgid "Swaps steps"
-msgstr "Etapas de troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
-msgstr "Repetir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
 #: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NotificationContent/NotificationNotFound.tsx:13
 msgid "There are no notifications."
-msgstr "Não há notificações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
-msgstr "Erro Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
-msgstr "Aviso Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
-msgstr "Sua: {amount} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
-msgstr "Mínimo de slippage necessário é {minRequiredSlippage}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
-msgstr "Ver todas as rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
-msgstr "Ver mais informações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
-msgstr "Explicação de Gás e Taxa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
-msgstr "detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
-msgstr "Taxa total a pagar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
-msgstr "Ocultar taxas não-pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
-msgstr "Mostrar tarifas não pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
-msgstr "Descrição:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
@@ -286,28 +281,26 @@ msgid ""
 "The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
 msgstr ""
-"As seguintes tarifas são consideradas no resultado da transação e\n"
-"                você não precisará pagar gás extra por elas."
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:25
 msgid "Swap input"
-msgstr "Swap input"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:44
 msgid "Estimated output"
-msgstr "Saída estimada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
-msgstr "Via:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
-msgstr "Correntas:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quotes/Quotes.tsx:92
@@ -317,720 +310,720 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
 msgid "Swapping"
-msgstr "Swapping"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:51
 msgid "Gas cost"
-msgstr "Custo de gás"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:59
 msgid "Receiving"
-msgstr "Recebimento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:67
 msgid "Price impact"
-msgstr "Impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Você precisa aumentar o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Recomendamos que você aumente o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
-msgstr "Cuidado, seu slippage está alto."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx:73
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:25
 msgid "Change"
-msgstr "Troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:41
 msgid "Change settings"
-msgstr "Alterar configurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:51
 msgid "High slippage"
-msgstr "Alto slide"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:52
 msgid "Low slippage"
-msgstr "Slippage Baixo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:56
 msgid " Caution, your slippage is high (={userSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={userSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:76
 msgid "Confirm anyway"
-msgstr "Confirmar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:35
 msgid "Slippage tolerance per swap"
-msgstr "Tolerância do slippage por swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
-msgstr "Personalizado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:11
 msgid "Your transaction will be reverted if the price changes unfavorably by more than this percentage"
-msgstr "Sua transação será revertida se o preço mudar desfavoravelmente, mais do que esta porcentagem"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:16
 msgid "Warning"
-msgstr "ATENÇÃO"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:17
 msgid "This setting is applied per step (e.g. 1Inch, Thorchain, etc) which means only the step will be reverted, not the whole transaction."
-msgstr "Essa configuração é aplicada por passo (por exemplo, 1Inch, Thorchain, etc), que significa que apenas o passo será revertido, não toda a transação."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:25
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:246
 msgid "Swap and Bridge"
-msgstr "Inverter e Ponte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:33
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:286
 msgid "Request ID"
-msgstr "Solicitar ID"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:64
 msgid "Not found"
-msgstr "Não encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:65
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:39
 msgid "Swap with request ID = {requestId} not found."
-msgstr "Trocar com o ID de requisição = {requestId} não encontrado."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:214
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
-msgstr "Você recebeu {amount} {token} em carteira {conciseAddress} na cadeia {chain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:230
 msgid "Transaction was not sent."
-msgstr "Transação não foi enviada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:232
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
-msgstr "{amount} {symbol} em {blockchain} permanece em sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:257
 msgid "Delete"
-msgstr "excluir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:278
 msgid "Try again"
-msgstr "Tente novamente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx:50
 msgid "View transaction"
-msgstr "Ver transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:47
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:31
 msgid "Connect"
-msgstr "Conectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:43
 msgid "Swap Successful"
-msgstr "Troca bem sucedida"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:71
 msgid "Transaction Failed"
-msgstr "Transação Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:86
 msgid "Done"
-msgstr "Concluído"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:98
 msgid "Diagnosis"
-msgstr "Diagnóstico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:105
 msgid "See Details"
-msgstr "Ver Detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:13
 msgid "Cancel Swap"
-msgstr "Cancelar Swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:14
 msgid "Are you sure you want to cancel this swap?"
-msgstr "Tem certeza que deseja cancelar este swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:22
 msgid "Yes, Cancel it"
-msgstr "Sim, Cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:26
 msgid "No, Continue"
-msgstr "Não, continuar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:13
 msgid "Delete Transaction"
-msgstr "Excluir Transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:14
 msgid "Are you sure you want to delete this swap?"
-msgstr "Tem certeza que deseja excluir esta troca?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:22
 msgid "Yes, Delete it"
-msgstr "Sim, exclua-o"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:27
 msgid "No, Cancel"
-msgstr "Não, cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:12
 msgid "Change Network"
-msgstr "Alterar rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:20
 msgid "Network Changed"
-msgstr "Rede alterada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
-msgstr "Selecione o Token"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:19
 msgid "Wallet Connected"
-msgstr "Carteira conectada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:20
 msgid "Your wallet is connected, you can use it to swap."
-msgstr "Sua carteira está conectada, você pode usá-la para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:31
 msgid "Failed to Connect"
-msgstr "Falha na conexão"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:33
 msgid "Your wallet is not connected. Please try again."
-msgstr "Sua carteira não está conectada. Por favor, tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:42
 msgid "Connecting to your wallet"
-msgstr "Conectando-se à sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:43
 msgid "Click connect in your wallet popup."
-msgstr "Clique em conectar no pop-up da sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:9
 msgid "Failed Network, Please retry your swap."
-msgstr "Falha na Rede, tente novamente sua alternância."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:11
 msgid "Please reset your liquidity sources."
-msgstr "Por favor, redefina suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:12
 msgid "You have limited the liquidity sources and this might result in Rango finding no routes. Please consider resetting your liquidity sources."
-msgstr "Você limitou as fontes de liquidez e isso pode resultar em que o Rango não encontre nenhuma rota. Por favor, considere redefinir suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:17
 msgid "No Routes Found."
-msgstr "Nenhuma rota encontrada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:18
 msgid "Reasons why Rango couldn't find a route: low liquidity on token, very low input amount or no routes available for the selected input/output token combination."
-msgstr "Motivos porque Rango não conseguiu encontrar uma rota: baixa liquidez no token, quantidade muito baixa de entrada ou nenhuma rota disponível para a combinação selecionada de entrada/saída do token."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:23
 msgid "Bridge Limit Error: Please increase your amount."
-msgstr "Erro no limite da ponte: Por favor, aumente o seu valor."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:26
 msgid "Bridge Limit Error: Please decrease your amount."
-msgstr "Erro no limite da ponte: Por favor, reduza seu montante."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:31
 msgid "High Price Impact"
-msgstr "Impacto de preço alto"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:32
 msgid "Price impact is too high!"
-msgstr "O impacto nos preços é muito alto!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:33
 msgid "The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap."
-msgstr "O impacto no preço é significativamente maior do que o valor permitido. Se você tem certeza, continue, caso contrário, altere o swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:36
 msgid "Confirm high price impact"
-msgstr "Confirmar alto impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:39
 msgid "Route updated and price impact is too high, try again later!"
-msgstr "A rota atualizada e o impacto nos preços é muito alto, tente novamente mais tarde!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:44
 msgid "USD Price Unknown"
-msgstr "Preço em USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:45
 msgid "USD Price Unknown, Cannot calculate Price Impact."
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto de preços."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:46
 msgid "USD Price Unknown, Cannot calculate Price Impact. The price impact may be higher than usual. Are you sure to continue the Swap?"
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto do preço. O impacto do preço pode ser maior do que o normal. Tem certeza que deseja continuar o Swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:49
 msgid "Confirm USD Price Unknown"
-msgstr "Confirmar preço de USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
 #: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
-msgstr "Trocar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:7
 msgid "Swap anyway"
-msgstr "Trocar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:8
 msgid "The route goes through Ethereum. Continue?"
-msgstr "A rota passa pelo Ethereum. Continuar?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:13
 msgid "Network Fee"
-msgstr "Taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:14
 msgid "Protocol Fee"
-msgstr "Taxa do Protocolo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:15
 msgid "Affiliate Fee"
-msgstr "Taxa de afiliado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:16
 msgid "Outbound Fee"
-msgstr "Taxa de Saída"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:17
 msgid "Rango Fee"
-msgstr "Taxa de Rango"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
 msgid "Smart Routing"
-msgstr "Roteamento inteligente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
-msgstr "Taxa mais baixa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:36
 msgid "Fastest Transfer"
-msgstr "Mais Rápido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:40
 msgid "Maximum Return"
-msgstr "Retorno Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:44
 msgid "Maximum Output"
-msgstr "Produção Máxima"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
 msgid "Route has been updated."
-msgstr "Rota foi atualizada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:12
 msgid "Output amount changed to {newOutputAmount} ({percentageChange}% change)."
-msgstr "Valor de saída alterado para {newOutputAmount} ( Alteração de{percentageChange}%)."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:20
 msgid "Route swappers has been updated."
-msgstr "Os trocadores de rota foram atualizados."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:22
 msgid "Route internal coins has been updated."
-msgstr "Moedas internas do itinerário foram atualizadas."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
 #: widget/embedded/src/pages/Routes.tsx:48
 msgid "Routes"
-msgstr "Rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:77
 msgid "From"
-msgstr "De"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:120
 msgid "To"
-msgstr "Para"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:47
 msgid "Light"
-msgstr "Fino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:56
 msgid "Dark"
-msgstr "Escuro"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:65
 msgid "Auto"
-msgstr "Automático"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:133
 msgid "Loading failed"
-msgstr "Falha no carregamento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:149
 msgid "Enabled bridges"
-msgstr "Pontes habilitados"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:167
 msgid "Enabled exchanges"
-msgstr "Trocas ativadas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:185
 #: widget/embedded/src/pages/LanguagePage.tsx:38
 msgid "Language"
-msgstr "IDIOMA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:198
 msgid "Infinite approval"
-msgstr "Aprovação infinita"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:208
 msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Ativar o modo de 'aprovação infinita' concede acesso irrestrito a contratos inteligentes de DEXes/Bridges, permitindo-lhes utilizar o valor do token aprovado, sem limitações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:228
 msgid "Theme"
-msgstr "Tema"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
-msgstr "Confirmar troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
-msgstr "Trocar de início"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
-msgstr "Você recebe"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:67
 msgid "History"
-msgstr "Histórico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:74
 msgid "Search Transaction"
-msgstr "Pesquisar transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
-msgstr "Idioma"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:151
 msgid "Exchanges"
-msgstr "Trocas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:112
 msgid "Bridges"
-msgstr "Pontes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Deselect all"
-msgstr "Desmarcar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Select all"
-msgstr "Selecionar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:121
 msgid "Search {sourceType}"
-msgstr "Pesquisar em {sourceType}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
-msgstr "Pesquisar Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:72
 msgid "Source"
-msgstr "fonte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:73
 msgid "Destination"
-msgstr "Destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:79
 msgid "Swap {type}"
-msgstr "Trocar {type}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:95
 msgid "Search Token"
-msgstr "Token de pesquisa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
-msgstr "Atualmente, você está no modo campanha com restrições sobre fontes de liquidez. Gostaria de mudar este modo e usar todas as fontes de liquidez disponíveis?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
-msgstr "O ID da requisição é necessário para exibir os detalhes do swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
 #: widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx:30
 msgid "Connect Wallets"
-msgstr "Conectar Carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:76
 msgid "Choose a wallet to connect."
-msgstr "Escolha uma carteira para se conectar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:25
 msgid "This week"
-msgstr "Esta semana"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:32
 msgid "This month"
-msgstr "Este Mês"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:39
 msgid "This year"
-msgstr "Esse ano"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:125
 msgid "Required: >= {min} {symbol}"
-msgstr "Obrigatório: >= {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:138
 msgid "Required: > {min} {symbol}"
-msgstr "Obrigatório: > {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:153
 msgid "Required: <= {max} {symbol}"
-msgstr "Obrigatório: <= {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:166
 msgid "Required: < {max} {symbol}"
-msgstr "Obrigatório: < {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:634
 msgid " for network fee"
-msgstr " para taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:637
 msgid " for swap"
-msgstr " para troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:640
 msgid " for input and network fee"
-msgstr " por taxa de entrada e de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:642
 msgid "Needs ≈ {requiredAmount} {symbol}{reason}, but you have {currentAmount} {symbol} in your {blockchain} wallet."
-msgstr "Precisa de {requiredAmount} {symbol}{reason}, mas você tem {currentAmount} {symbol} na sua carteira {blockchain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:702
 msgid "Waiting for connecting wallet"
-msgstr "Aguardando conexão da carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:706
 msgid "Waiting for other running tasks to be finished"
-msgstr "Aguardando o término de outras tarefas em execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:709
 msgid "Waiting for changing wallet network"
-msgstr "Aguardando mudança da rede de carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:6
 msgid "Sunday"
-msgstr "domingo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:7
 msgid "Monday"
-msgstr "Segunda-Feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:8
 msgid "Tuesday"
-msgstr "Terça-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:9
 msgid "Wednesday"
-msgstr "quarta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:10
 msgid "Thursday"
-msgstr "quinta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:11
 msgid "Friday"
-msgstr "Sexta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:12
 msgid "Saturday"
-msgstr "sábado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
-msgstr " Erro ao conectar ao servidor, por favor recarregue o app e tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/BottomLogo/BottomLogo.tsx:14
 msgid "Powered By"
-msgstr "Desenvolvido por"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/ChangeSlippageButton/ChangeSlippageButton.tsx:14
 msgid "Change Slippage"
-msgstr "Alterar Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx:63
@@ -1041,120 +1034,120 @@ msgstr ""
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:74
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:100
 msgid "Swap on {fromChain} via {swapper}"
-msgstr "Trocar em {fromChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:107
 msgid "Bridge to {toChain} via {swapper}"
-msgstr "Ponte para {toChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:28
 msgid "Swap Details"
-msgstr "Trocar detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:8
 msgid "Failed"
-msgstr "Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:10
 msgid "Complete"
-msgstr "Complete"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:12
 msgid "In progress"
-msgstr "Em Execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapToken.tsx:122
 msgid "Waiting for bridge transaction"
-msgstr "Aguardando a transação da bridge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:150
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:56
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:235
 msgid "Chain"
-msgstr "Corrente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:168
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:49
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:259
 msgid "Token"
-msgstr "Identificador"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:12
 msgid "Connected"
-msgstr "Conectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:13
 msgid "Disconnect"
-msgstr "Desconectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:18
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:19
 msgid "Install"
-msgstr "Instale"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:24
 msgid "Connecting..."
-msgstr "Conectandochar@@0"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:25
 msgid "Connecting"
-msgstr "Conectando"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:30
 msgid "Disconnected"
-msgstr "Desconectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:34
 msgid "you need to pass a correct state to Wallet."
-msgstr "você precisa passar um estado correto para o Wallet."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/HomePanel/HomePanel.tsx:123
 msgid "SWAP"
-msgstr "TROCA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
-msgstr "Saldo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:62
 msgid "Max"
-msgstr "Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={selectedSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:179
 msgid "swap from"
-msgstr "trocar de"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:198
 msgid "maximum amount of asset"
-msgstr "quantidade máxima de ativos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
-msgstr "trocar para"
+msgstr ""

--- a/translations/el.po
+++ b/translations/el.po
@@ -1,22 +1,17 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-06 17:24+0330\n"
+"POT-Creation-Date: 2024-03-10 13:29+0330\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: pt\n"
-"Project-Id-Version: rango\n"
+"Language: el\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-02-20 09:32\n"
+"PO-Revision-Date: \n"
 "Last-Translator: \n"
-"Language-Team: Portuguese\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: rango\n"
-"X-Crowdin-Project-ID: 622238\n"
-"X-Crowdin-Language: pt-PT\n"
-"X-Crowdin-File: en.po\n"
-"X-Crowdin-File-ID: 30\n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
@@ -24,7 +19,7 @@ msgstr ""
 #: widget/embedded/src/pages/HistoryPage.tsx:85
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:131
 msgid "No results found"
-msgstr "Nenhum resultado encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:38
@@ -32,24 +27,24 @@ msgstr "Nenhum resultado encontrado"
 #: widget/embedded/src/pages/HistoryPage.tsx:87
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:132
 msgid "Try using different keywords"
-msgstr "Tente usar palavras-chave diferentes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:66
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:46
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:40
 msgid "Select Blockchain"
-msgstr "Selecione a Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:66
 msgid "All"
-msgstr "TODOS"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:100
 msgid "More +{count}"
-msgstr "Mais +{count}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
@@ -64,221 +59,221 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
 msgid "Activate current tab"
-msgstr "Ativar a aba atual"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:22
 msgid "Currently, some transactions are running and being handled by other browser tab. If you activate this tab, all transactions that are already in the transaction sign step will expire."
-msgstr "No momento, algumas transações estão sendo executadas e sendo tratadas por outra aba do navegador. Se você ativar essa aba, todas as transações que já estão na etapa de sinal de transação irão expirar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:32
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:269
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:237
 msgid "Confirm"
-msgstr "Confirmar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:284
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:359
 msgid "Your {blockchainName} wallets"
-msgstr "Suas carteiras {blockchainName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:303
 msgid "Insufficient account balance"
-msgstr "Saldo de conta insuficiente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:312
 msgid "Proceed anyway"
-msgstr "Continuar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:368
 msgid "You need to connect a {blockchainName} wallet."
-msgstr "Você precisa conectar uma carteira {blockchainName}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
-msgstr "Enviar para outro endereço"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
-msgstr "Seu endereço de destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
-msgstr "O endereço {destination} não corresponde ao padrão do endereço da blockchain."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:168
 msgid "Add {chain} chain"
-msgstr "Adiciona cadeia {chain}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:217
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:250
 msgid "Add {blockchainDisplayName} Chain"
-msgstr "Adicionar Corrente {blockchainDisplayName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:222
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:254
 msgid "You should connect a {blockchainDisplayName} supported wallet or choose a different {blockchainDisplayName} address"
-msgstr "Você deve conectar uma carteira com suporte do {blockchainDisplayName} ou escolher um endereço {blockchainDisplayName} diferente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:272
 msgid "{blockchainDisplayName} Chain Added"
-msgstr "{blockchainDisplayName} Cadeia Adicionada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:276
 msgid "{blockchainDisplayName} is added to your wallet, you can use it to swap."
-msgstr "{blockchainDisplayName} foi adicionado à sua carteira, você pode usá-lo para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:286
 msgid "Request Rejected"
-msgstr "Pedido rejeitado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:287
 msgid "You've rejected adding {blockchainDisplayName} chain to your wallet."
-msgstr "Você rejeitou adicionar {blockchainDisplayName} corrente à sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:311
 msgid "Show more wallets"
-msgstr "Mostrar mais carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/CancelButton.tsx:14
 msgid "Cancel"
-msgstr "cancelar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
-msgstr "atualizar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
-msgstr "notificações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
 #: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
-msgstr "Confirgurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
-msgstr "Histórico de transações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/WalletButton.tsx:14
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:16
 #: widget/embedded/src/constants/messages.ts:5
 msgid "Connect Wallet"
-msgstr "Conectar Carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx:118
 #: widget/embedded/src/utils/date.ts:18
 #: widget/embedded/src/utils/time.ts:22
 msgid "Today"
-msgstr "hoje"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:375
 msgid "Swaps steps"
-msgstr "Etapas de troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
-msgstr "Repetir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
 #: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NotificationContent/NotificationNotFound.tsx:13
 msgid "There are no notifications."
-msgstr "Não há notificações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
-msgstr "Erro Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
-msgstr "Aviso Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
-msgstr "Sua: {amount} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
-msgstr "Mínimo de slippage necessário é {minRequiredSlippage}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
-msgstr "Ver todas as rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
-msgstr "Ver mais informações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
-msgstr "Explicação de Gás e Taxa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
-msgstr "detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
-msgstr "Taxa total a pagar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
-msgstr "Ocultar taxas não-pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
-msgstr "Mostrar tarifas não pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
-msgstr "Descrição:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
@@ -286,28 +281,26 @@ msgid ""
 "The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
 msgstr ""
-"As seguintes tarifas são consideradas no resultado da transação e\n"
-"                você não precisará pagar gás extra por elas."
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:25
 msgid "Swap input"
-msgstr "Swap input"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:44
 msgid "Estimated output"
-msgstr "Saída estimada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
-msgstr "Via:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
-msgstr "Correntas:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quotes/Quotes.tsx:92
@@ -317,720 +310,720 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
 msgid "Swapping"
-msgstr "Swapping"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:51
 msgid "Gas cost"
-msgstr "Custo de gás"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:59
 msgid "Receiving"
-msgstr "Recebimento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:67
 msgid "Price impact"
-msgstr "Impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Você precisa aumentar o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Recomendamos que você aumente o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
-msgstr "Cuidado, seu slippage está alto."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx:73
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:25
 msgid "Change"
-msgstr "Troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:41
 msgid "Change settings"
-msgstr "Alterar configurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:51
 msgid "High slippage"
-msgstr "Alto slide"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:52
 msgid "Low slippage"
-msgstr "Slippage Baixo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:56
 msgid " Caution, your slippage is high (={userSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={userSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:76
 msgid "Confirm anyway"
-msgstr "Confirmar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:35
 msgid "Slippage tolerance per swap"
-msgstr "Tolerância do slippage por swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
-msgstr "Personalizado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:11
 msgid "Your transaction will be reverted if the price changes unfavorably by more than this percentage"
-msgstr "Sua transação será revertida se o preço mudar desfavoravelmente, mais do que esta porcentagem"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:16
 msgid "Warning"
-msgstr "ATENÇÃO"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:17
 msgid "This setting is applied per step (e.g. 1Inch, Thorchain, etc) which means only the step will be reverted, not the whole transaction."
-msgstr "Essa configuração é aplicada por passo (por exemplo, 1Inch, Thorchain, etc), que significa que apenas o passo será revertido, não toda a transação."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:25
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:246
 msgid "Swap and Bridge"
-msgstr "Inverter e Ponte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:33
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:286
 msgid "Request ID"
-msgstr "Solicitar ID"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:64
 msgid "Not found"
-msgstr "Não encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:65
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:39
 msgid "Swap with request ID = {requestId} not found."
-msgstr "Trocar com o ID de requisição = {requestId} não encontrado."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:214
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
-msgstr "Você recebeu {amount} {token} em carteira {conciseAddress} na cadeia {chain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:230
 msgid "Transaction was not sent."
-msgstr "Transação não foi enviada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:232
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
-msgstr "{amount} {symbol} em {blockchain} permanece em sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:257
 msgid "Delete"
-msgstr "excluir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:278
 msgid "Try again"
-msgstr "Tente novamente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx:50
 msgid "View transaction"
-msgstr "Ver transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:47
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:31
 msgid "Connect"
-msgstr "Conectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:43
 msgid "Swap Successful"
-msgstr "Troca bem sucedida"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:71
 msgid "Transaction Failed"
-msgstr "Transação Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:86
 msgid "Done"
-msgstr "Concluído"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:98
 msgid "Diagnosis"
-msgstr "Diagnóstico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:105
 msgid "See Details"
-msgstr "Ver Detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:13
 msgid "Cancel Swap"
-msgstr "Cancelar Swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:14
 msgid "Are you sure you want to cancel this swap?"
-msgstr "Tem certeza que deseja cancelar este swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:22
 msgid "Yes, Cancel it"
-msgstr "Sim, Cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:26
 msgid "No, Continue"
-msgstr "Não, continuar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:13
 msgid "Delete Transaction"
-msgstr "Excluir Transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:14
 msgid "Are you sure you want to delete this swap?"
-msgstr "Tem certeza que deseja excluir esta troca?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:22
 msgid "Yes, Delete it"
-msgstr "Sim, exclua-o"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:27
 msgid "No, Cancel"
-msgstr "Não, cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:12
 msgid "Change Network"
-msgstr "Alterar rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:20
 msgid "Network Changed"
-msgstr "Rede alterada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
-msgstr "Selecione o Token"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:19
 msgid "Wallet Connected"
-msgstr "Carteira conectada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:20
 msgid "Your wallet is connected, you can use it to swap."
-msgstr "Sua carteira está conectada, você pode usá-la para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:31
 msgid "Failed to Connect"
-msgstr "Falha na conexão"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:33
 msgid "Your wallet is not connected. Please try again."
-msgstr "Sua carteira não está conectada. Por favor, tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:42
 msgid "Connecting to your wallet"
-msgstr "Conectando-se à sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:43
 msgid "Click connect in your wallet popup."
-msgstr "Clique em conectar no pop-up da sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:9
 msgid "Failed Network, Please retry your swap."
-msgstr "Falha na Rede, tente novamente sua alternância."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:11
 msgid "Please reset your liquidity sources."
-msgstr "Por favor, redefina suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:12
 msgid "You have limited the liquidity sources and this might result in Rango finding no routes. Please consider resetting your liquidity sources."
-msgstr "Você limitou as fontes de liquidez e isso pode resultar em que o Rango não encontre nenhuma rota. Por favor, considere redefinir suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:17
 msgid "No Routes Found."
-msgstr "Nenhuma rota encontrada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:18
 msgid "Reasons why Rango couldn't find a route: low liquidity on token, very low input amount or no routes available for the selected input/output token combination."
-msgstr "Motivos porque Rango não conseguiu encontrar uma rota: baixa liquidez no token, quantidade muito baixa de entrada ou nenhuma rota disponível para a combinação selecionada de entrada/saída do token."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:23
 msgid "Bridge Limit Error: Please increase your amount."
-msgstr "Erro no limite da ponte: Por favor, aumente o seu valor."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:26
 msgid "Bridge Limit Error: Please decrease your amount."
-msgstr "Erro no limite da ponte: Por favor, reduza seu montante."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:31
 msgid "High Price Impact"
-msgstr "Impacto de preço alto"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:32
 msgid "Price impact is too high!"
-msgstr "O impacto nos preços é muito alto!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:33
 msgid "The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap."
-msgstr "O impacto no preço é significativamente maior do que o valor permitido. Se você tem certeza, continue, caso contrário, altere o swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:36
 msgid "Confirm high price impact"
-msgstr "Confirmar alto impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:39
 msgid "Route updated and price impact is too high, try again later!"
-msgstr "A rota atualizada e o impacto nos preços é muito alto, tente novamente mais tarde!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:44
 msgid "USD Price Unknown"
-msgstr "Preço em USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:45
 msgid "USD Price Unknown, Cannot calculate Price Impact."
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto de preços."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:46
 msgid "USD Price Unknown, Cannot calculate Price Impact. The price impact may be higher than usual. Are you sure to continue the Swap?"
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto do preço. O impacto do preço pode ser maior do que o normal. Tem certeza que deseja continuar o Swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:49
 msgid "Confirm USD Price Unknown"
-msgstr "Confirmar preço de USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
 #: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
-msgstr "Trocar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:7
 msgid "Swap anyway"
-msgstr "Trocar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:8
 msgid "The route goes through Ethereum. Continue?"
-msgstr "A rota passa pelo Ethereum. Continuar?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:13
 msgid "Network Fee"
-msgstr "Taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:14
 msgid "Protocol Fee"
-msgstr "Taxa do Protocolo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:15
 msgid "Affiliate Fee"
-msgstr "Taxa de afiliado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:16
 msgid "Outbound Fee"
-msgstr "Taxa de Saída"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:17
 msgid "Rango Fee"
-msgstr "Taxa de Rango"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
 msgid "Smart Routing"
-msgstr "Roteamento inteligente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
-msgstr "Taxa mais baixa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:36
 msgid "Fastest Transfer"
-msgstr "Mais Rápido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:40
 msgid "Maximum Return"
-msgstr "Retorno Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:44
 msgid "Maximum Output"
-msgstr "Produção Máxima"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
 msgid "Route has been updated."
-msgstr "Rota foi atualizada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:12
 msgid "Output amount changed to {newOutputAmount} ({percentageChange}% change)."
-msgstr "Valor de saída alterado para {newOutputAmount} ( Alteração de{percentageChange}%)."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:20
 msgid "Route swappers has been updated."
-msgstr "Os trocadores de rota foram atualizados."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:22
 msgid "Route internal coins has been updated."
-msgstr "Moedas internas do itinerário foram atualizadas."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
 #: widget/embedded/src/pages/Routes.tsx:48
 msgid "Routes"
-msgstr "Rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:77
 msgid "From"
-msgstr "De"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:120
 msgid "To"
-msgstr "Para"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:47
 msgid "Light"
-msgstr "Fino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:56
 msgid "Dark"
-msgstr "Escuro"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:65
 msgid "Auto"
-msgstr "Automático"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:133
 msgid "Loading failed"
-msgstr "Falha no carregamento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:149
 msgid "Enabled bridges"
-msgstr "Pontes habilitados"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:167
 msgid "Enabled exchanges"
-msgstr "Trocas ativadas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:185
 #: widget/embedded/src/pages/LanguagePage.tsx:38
 msgid "Language"
-msgstr "IDIOMA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:198
 msgid "Infinite approval"
-msgstr "Aprovação infinita"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:208
 msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Ativar o modo de 'aprovação infinita' concede acesso irrestrito a contratos inteligentes de DEXes/Bridges, permitindo-lhes utilizar o valor do token aprovado, sem limitações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:228
 msgid "Theme"
-msgstr "Tema"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
-msgstr "Confirmar troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
-msgstr "Trocar de início"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
-msgstr "Você recebe"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:67
 msgid "History"
-msgstr "Histórico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:74
 msgid "Search Transaction"
-msgstr "Pesquisar transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
-msgstr "Idioma"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:151
 msgid "Exchanges"
-msgstr "Trocas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:112
 msgid "Bridges"
-msgstr "Pontes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Deselect all"
-msgstr "Desmarcar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Select all"
-msgstr "Selecionar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:121
 msgid "Search {sourceType}"
-msgstr "Pesquisar em {sourceType}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
-msgstr "Pesquisar Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:72
 msgid "Source"
-msgstr "fonte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:73
 msgid "Destination"
-msgstr "Destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:79
 msgid "Swap {type}"
-msgstr "Trocar {type}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:95
 msgid "Search Token"
-msgstr "Token de pesquisa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
-msgstr "Atualmente, você está no modo campanha com restrições sobre fontes de liquidez. Gostaria de mudar este modo e usar todas as fontes de liquidez disponíveis?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
-msgstr "O ID da requisição é necessário para exibir os detalhes do swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
 #: widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx:30
 msgid "Connect Wallets"
-msgstr "Conectar Carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:76
 msgid "Choose a wallet to connect."
-msgstr "Escolha uma carteira para se conectar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:25
 msgid "This week"
-msgstr "Esta semana"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:32
 msgid "This month"
-msgstr "Este Mês"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:39
 msgid "This year"
-msgstr "Esse ano"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:125
 msgid "Required: >= {min} {symbol}"
-msgstr "Obrigatório: >= {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:138
 msgid "Required: > {min} {symbol}"
-msgstr "Obrigatório: > {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:153
 msgid "Required: <= {max} {symbol}"
-msgstr "Obrigatório: <= {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:166
 msgid "Required: < {max} {symbol}"
-msgstr "Obrigatório: < {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:634
 msgid " for network fee"
-msgstr " para taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:637
 msgid " for swap"
-msgstr " para troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:640
 msgid " for input and network fee"
-msgstr " por taxa de entrada e de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:642
 msgid "Needs ≈ {requiredAmount} {symbol}{reason}, but you have {currentAmount} {symbol} in your {blockchain} wallet."
-msgstr "Precisa de {requiredAmount} {symbol}{reason}, mas você tem {currentAmount} {symbol} na sua carteira {blockchain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:702
 msgid "Waiting for connecting wallet"
-msgstr "Aguardando conexão da carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:706
 msgid "Waiting for other running tasks to be finished"
-msgstr "Aguardando o término de outras tarefas em execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:709
 msgid "Waiting for changing wallet network"
-msgstr "Aguardando mudança da rede de carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:6
 msgid "Sunday"
-msgstr "domingo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:7
 msgid "Monday"
-msgstr "Segunda-Feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:8
 msgid "Tuesday"
-msgstr "Terça-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:9
 msgid "Wednesday"
-msgstr "quarta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:10
 msgid "Thursday"
-msgstr "quinta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:11
 msgid "Friday"
-msgstr "Sexta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:12
 msgid "Saturday"
-msgstr "sábado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
-msgstr " Erro ao conectar ao servidor, por favor recarregue o app e tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/BottomLogo/BottomLogo.tsx:14
 msgid "Powered By"
-msgstr "Desenvolvido por"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/ChangeSlippageButton/ChangeSlippageButton.tsx:14
 msgid "Change Slippage"
-msgstr "Alterar Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx:63
@@ -1041,120 +1034,120 @@ msgstr ""
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:74
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:100
 msgid "Swap on {fromChain} via {swapper}"
-msgstr "Trocar em {fromChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:107
 msgid "Bridge to {toChain} via {swapper}"
-msgstr "Ponte para {toChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:28
 msgid "Swap Details"
-msgstr "Trocar detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:8
 msgid "Failed"
-msgstr "Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:10
 msgid "Complete"
-msgstr "Complete"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:12
 msgid "In progress"
-msgstr "Em Execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapToken.tsx:122
 msgid "Waiting for bridge transaction"
-msgstr "Aguardando a transação da bridge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:150
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:56
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:235
 msgid "Chain"
-msgstr "Corrente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:168
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:49
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:259
 msgid "Token"
-msgstr "Identificador"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:12
 msgid "Connected"
-msgstr "Conectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:13
 msgid "Disconnect"
-msgstr "Desconectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:18
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:19
 msgid "Install"
-msgstr "Instale"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:24
 msgid "Connecting..."
-msgstr "Conectandochar@@0"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:25
 msgid "Connecting"
-msgstr "Conectando"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:30
 msgid "Disconnected"
-msgstr "Desconectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:34
 msgid "you need to pass a correct state to Wallet."
-msgstr "você precisa passar um estado correto para o Wallet."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/HomePanel/HomePanel.tsx:123
 msgid "SWAP"
-msgstr "TROCA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
-msgstr "Saldo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:62
 msgid "Max"
-msgstr "Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={selectedSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:179
 msgid "swap from"
-msgstr "trocar de"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:198
 msgid "maximum amount of asset"
-msgstr "quantidade máxima de ativos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
-msgstr "trocar para"
+msgstr ""

--- a/translations/en.po
+++ b/translations/en.po
@@ -48,13 +48,13 @@ msgstr "More +{count}"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
-msgid "Activate"
-msgstr "Activate"
+msgid "Activate this tab"
+msgstr "Activate this tab"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:21
-msgid "Another tab is open and handles transactions. You can activate this tab."
-msgstr "Another tab is open and handles transactions. You can activate this tab."
+msgid "Another tab is open and handles transactions."
+msgstr "Another tab is open and handles transactions."
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
@@ -95,17 +95,17 @@ msgid "You need to connect a {blockchainName} wallet."
 msgstr "You need to connect a {blockchainName} wallet."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:435
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
 msgstr "Send to a different address"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:446
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
 msgstr "Your destination address"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:465
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
 msgstr "Address {destination} doesn't match the blockchain address pattern."
 
@@ -157,24 +157,24 @@ msgid "Cancel"
 msgstr "Cancel"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:44
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
 msgstr "Refresh"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:60
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
 msgstr "Notifications"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:73
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:312
-#: widget/embedded/src/pages/SettingsPage.tsx:212
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
+#: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
 msgstr "Settings"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:83
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
 msgstr "Transactions History"
 
@@ -199,12 +199,13 @@ msgid "Swaps steps"
 msgstr "Swaps steps"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:25
+#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
 msgstr "Retry"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:37
+#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
+#: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
 msgstr "Reset"
 
@@ -214,68 +215,68 @@ msgid "There are no notifications."
 msgstr "There are no notifications."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:126
+#: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
 msgstr "Slippage Error"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:127
+#: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
 msgstr "Slippage Warning"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:231
+#: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
 msgstr "Yours: {amount} {symbol}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:252
+#: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
 msgstr "Minimum required slippage is {minRequiredSlippage}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:325
+#: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
 msgstr "See All Routes"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:98
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
 msgstr "View more info"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:108
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
 msgstr "Gas & Fee Explanation"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:121
-#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:88
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
+#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
 msgstr "Details"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:162
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
 msgstr "Total Payable Fee"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:182
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
 msgstr "Hide non-payable fees"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:183
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
 msgstr "Show non-payable fees"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:193
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
 msgstr "Description"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:197
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
 msgid ""
 "The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
@@ -294,14 +295,19 @@ msgid "Estimated output"
 msgstr "Estimated output"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteTrigger .tsx:77
+#: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
 msgstr "Via:"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteTrigger .tsx:160
+#: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
 msgstr "Chains:"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quotes/Quotes.tsx:92
+msgid "Sort by"
+msgstr "Sort by"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
@@ -324,19 +330,19 @@ msgid "Price impact"
 msgstr "Price impact"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:36
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
 msgstr "You need to increase slippage to at least {minRequiredSlippage} for this route."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:60
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
 msgstr "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:69
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
 msgstr "Caution, your slippage is high."
 
@@ -377,7 +383,7 @@ msgid "Slippage tolerance per swap"
 msgstr "Slippage tolerance per swap"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Slippage/Slippage.tsx:90
+#: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
 msgstr "Custom"
 
@@ -531,7 +537,7 @@ msgid "Network Changed"
 msgstr "Network Changed"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/TokenList/TokenList.tsx:257
+#: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
 msgstr "Select Token"
 
@@ -647,7 +653,7 @@ msgstr "Confirm USD Price Unknown"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
-#: widget/embedded/src/pages/Home.tsx:155
+#: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
 msgstr "Swap"
 
@@ -687,29 +693,29 @@ msgid "Rango Fee"
 msgstr "Rango Fee"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:26
-msgid "Fastest Transfer"
-msgstr "Fastest Transfer"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:27
-msgid "Maximum Return"
-msgstr "Maximum Return"
-
-#. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
+msgid "Smart Routing"
+msgstr "Smart Routing"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
 msgstr "Lowest Fee"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:29
-msgid "Maximum Output"
-msgstr "Maximum Output"
+#: widget/embedded/src/constants/quote.ts:36
+msgid "Fastest Transfer"
+msgstr "Fastest Transfer"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:30
-msgid "Smart Routing"
-msgstr "Smart Routing"
+#: widget/embedded/src/constants/quote.ts:40
+msgid "Maximum Return"
+msgstr "Maximum Return"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:44
+msgid "Maximum Output"
+msgstr "Maximum Output"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
@@ -732,17 +738,84 @@ msgid "Route internal coins has been updated."
 msgstr "Route internal coins has been updated."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:303
+#: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
+#: widget/embedded/src/pages/Routes.tsx:48
+msgid "Routes"
+msgstr "Routes"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Inputs/Inputs.tsx:77
+msgid "From"
+msgstr "From"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Inputs/Inputs.tsx:120
+msgid "To"
+msgstr "To"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:47
+msgid "Light"
+msgstr "Light"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:56
+msgid "Dark"
+msgstr "Dark"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:65
+msgid "Auto"
+msgstr "Auto"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:133
+msgid "Loading failed"
+msgstr "Loading failed"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:149
+msgid "Enabled bridges"
+msgstr "Enabled bridges"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:167
+msgid "Enabled exchanges"
+msgstr "Enabled exchanges"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:185
+#: widget/embedded/src/pages/LanguagePage.tsx:38
+msgid "Language"
+msgstr "Language"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:198
+msgid "Infinite approval"
+msgstr "Infinite approval"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:208
+msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
+msgstr "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:228
+msgid "Theme"
+msgstr "Theme"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
 msgstr "Confirm Swap"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:333
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
 msgstr "Start Swap"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:359
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
 msgstr "You get"
 
@@ -757,23 +830,7 @@ msgid "Search Transaction"
 msgstr "Search Transaction"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:172
-msgid "From"
-msgstr "From"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:213
-msgid "To"
-msgstr "To"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/LanguagePage.tsx:36
-#: widget/embedded/src/pages/SettingsPage.tsx:136
-msgid "Language"
-msgstr "Language"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/LanguagePage.tsx:43
+#: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
 msgstr "language"
 
@@ -805,11 +862,6 @@ msgid "Search {sourceType}"
 msgstr "Search {sourceType}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Routes.tsx:77
-msgid "Routes"
-msgstr "Routes"
-
-#. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
 msgstr "Search Blockchain"
@@ -835,39 +887,7 @@ msgid "Search Token"
 msgstr "Search Token"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:86
-msgid "Loading failed"
-msgstr "Loading failed"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:102
-msgid "Enabled bridges"
-msgstr "Enabled bridges"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:119
-msgid "Enabled exchanges"
-msgstr "Enabled exchanges"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:147
-#: widget/embedded/src/pages/ThemePage.tsx:70
-#: widget/embedded/src/pages/ThemePage.tsx:79
-msgid "Theme"
-msgstr "Theme"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:159
-msgid "Infinite approval"
-msgstr "Infinite approval"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:169
-msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:219
+#: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
 msgstr "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
 
@@ -875,21 +895,6 @@ msgstr "Currently, you're in campaign mode with restrictions on liquidity source
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
 msgstr "The request ID is necessary to display the swap details."
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:34
-msgid "Light"
-msgstr "Light"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:46
-msgid "Dark"
-msgstr "Dark"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:58
-msgid "Auto"
-msgstr "Auto"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72

--- a/translations/es.po
+++ b/translations/es.po
@@ -53,13 +53,13 @@ msgstr "Más +{count}"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
-msgid "Activate"
-msgstr "Activar"
+msgid "Activate this tab"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:21
-msgid "Another tab is open and handles transactions. You can activate this tab."
-msgstr "Otra pestaña es abierta y gestiona transacciones. Puedes activar esta pestaña."
+msgid "Another tab is open and handles transactions."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
@@ -100,17 +100,17 @@ msgid "You need to connect a {blockchainName} wallet."
 msgstr "Necesitas conectar un monedero {blockchainName}."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:435
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
 msgstr "Enviar a una dirección diferente"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:446
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
 msgstr "Su dirección de destino"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:465
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
 msgstr "La dirección {destination} no coincide con el patrón de dirección de la cadena de bloques."
 
@@ -162,24 +162,24 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:44
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
 msgstr "Refrescar"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:60
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
 msgstr "Notificaciones"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:73
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:312
-#: widget/embedded/src/pages/SettingsPage.tsx:212
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
+#: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
 msgstr "Ajustes"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:83
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
 msgstr "Historial de transacciones"
 
@@ -204,12 +204,13 @@ msgid "Swaps steps"
 msgstr "Intercambiar pasos"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:25
+#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
 msgstr "Reintentar"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:37
+#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
+#: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
 msgstr "Reset"
 
@@ -219,71 +220,73 @@ msgid "There are no notifications."
 msgstr "No hay notificaciones."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:126
+#: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
 msgstr "Error de deslizamiento"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:127
+#: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
 msgstr "Advertencia de deslizamiento"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:231
+#: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
 msgstr "Tu: {amount} {symbol}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:252
+#: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
 msgstr "El deslizamiento mínimo requerido es {minRequiredSlippage}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:325
+#: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
 msgstr "Ver todas las rutas"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:98
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
 msgstr "Ver más información"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:108
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
 msgstr "Explicación de gas y comisión"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:121
-#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:88
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
+#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
 msgstr "Detalles"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:162
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
 msgstr "Tarifa total a pagar"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:182
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
 msgstr "Ocultar tarifas no pagables"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:183
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
 msgstr "Mostrar tarifas no pagables"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:193
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
 msgstr "Descripción"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:197
-msgid "The following fees are considered in the transaction output and\n"
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
+msgid ""
+"The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
-msgstr "Las siguientes comisiones se consideran en la salida de la transacción y\n"
+msgstr ""
+"Las siguientes comisiones se consideran en la salida de la transacción y\n"
 "                no necesitarás pagar gas adicional por ellas."
 
 #. js-lingui-explicit-id
@@ -297,14 +300,19 @@ msgid "Estimated output"
 msgstr "Salida estimada"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteTrigger .tsx:77
+#: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
 msgstr "Vía:"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteTrigger .tsx:160
+#: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
 msgstr "Cadenas:"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quotes/Quotes.tsx:92
+msgid "Sort by"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
@@ -327,19 +335,19 @@ msgid "Price impact"
 msgstr "Impacto del precio"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:36
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
 msgstr "Necesitas aumentar el deslizamiento a al menos {minRequiredSlippage} para esta ruta."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:60
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
 msgstr "Te recomendamos que aumentes el deslizamiento a al menos {minRequiredSlippage} para esta ruta."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:69
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
 msgstr "Precaución, tu deslizamiento es alto."
 
@@ -380,7 +388,7 @@ msgid "Slippage tolerance per swap"
 msgstr "Tolerancia de deslizamiento por intercambio"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Slippage/Slippage.tsx:90
+#: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
 msgstr "Personalizado"
 
@@ -534,7 +542,7 @@ msgid "Network Changed"
 msgstr "Red cambiada"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/TokenList/TokenList.tsx:257
+#: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
 msgstr "Seleccionar token"
 
@@ -650,7 +658,7 @@ msgstr "Confirmar el precio de USD desconocido"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
-#: widget/embedded/src/pages/Home.tsx:155
+#: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
 msgstr "Intercambiar"
 
@@ -690,29 +698,29 @@ msgid "Rango Fee"
 msgstr "Tarifa Rango"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:26
-msgid "Fastest Transfer"
-msgstr "Transferencia más rápida"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:27
-msgid "Maximum Return"
-msgstr "Devolución máxima"
-
-#. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
+msgid "Smart Routing"
+msgstr "Ruta inteligente"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
 msgstr "Tarifa más baja"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:29
-msgid "Maximum Output"
-msgstr "Salida máxima"
+#: widget/embedded/src/constants/quote.ts:36
+msgid "Fastest Transfer"
+msgstr "Transferencia más rápida"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:30
-msgid "Smart Routing"
-msgstr "Ruta inteligente"
+#: widget/embedded/src/constants/quote.ts:40
+msgid "Maximum Return"
+msgstr "Devolución máxima"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:44
+msgid "Maximum Output"
+msgstr "Salida máxima"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
@@ -735,17 +743,84 @@ msgid "Route internal coins has been updated."
 msgstr "Se han actualizado las monedas internas de la ruta."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:303
+#: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
+#: widget/embedded/src/pages/Routes.tsx:48
+msgid "Routes"
+msgstr "Rutas"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Inputs/Inputs.tsx:77
+msgid "From"
+msgstr "De"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Inputs/Inputs.tsx:120
+msgid "To"
+msgstr "A"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:47
+msgid "Light"
+msgstr "Claro"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:56
+msgid "Dark"
+msgstr "Oscuro"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:65
+msgid "Auto"
+msgstr "Auto"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:133
+msgid "Loading failed"
+msgstr "Error al cargar"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:149
+msgid "Enabled bridges"
+msgstr "Puentes habilitados"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:167
+msgid "Enabled exchanges"
+msgstr "Intercambios habilitados"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:185
+#: widget/embedded/src/pages/LanguagePage.tsx:38
+msgid "Language"
+msgstr "Idioma"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:198
+msgid "Infinite approval"
+msgstr "Aprobación infinita"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:208
+msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
+msgstr "Habilitar el modo 'Aprobación infinita' permite el acceso sin restricciones a contratos inteligentes de DEXes/Bridges, permitiéndoles utilizar la cantidad de token aprobada sin limitaciones."
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:228
+msgid "Theme"
+msgstr "Tema"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
 msgstr "Confirmar intercambio"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:333
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
 msgstr "Iniciar intercambio"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:359
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
 msgstr "Obtienes"
 
@@ -760,23 +835,7 @@ msgid "Search Transaction"
 msgstr "Buscar transacción"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:172
-msgid "From"
-msgstr "De"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:213
-msgid "To"
-msgstr "A"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/LanguagePage.tsx:36
-#: widget/embedded/src/pages/SettingsPage.tsx:136
-msgid "Language"
-msgstr "Idioma"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/LanguagePage.tsx:43
+#: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
 msgstr "idioma"
 
@@ -808,11 +867,6 @@ msgid "Search {sourceType}"
 msgstr "Buscar {sourceType}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Routes.tsx:77
-msgid "Routes"
-msgstr "Rutas"
-
-#. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
 msgstr "Buscar Blockchain"
@@ -838,39 +892,7 @@ msgid "Search Token"
 msgstr "Buscar token"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:86
-msgid "Loading failed"
-msgstr "Error al cargar"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:102
-msgid "Enabled bridges"
-msgstr "Puentes habilitados"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:119
-msgid "Enabled exchanges"
-msgstr "Intercambios habilitados"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:147
-#: widget/embedded/src/pages/ThemePage.tsx:70
-#: widget/embedded/src/pages/ThemePage.tsx:79
-msgid "Theme"
-msgstr "Tema"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:159
-msgid "Infinite approval"
-msgstr "Aprobación infinita"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:169
-msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Habilitar el modo 'Aprobación infinita' permite el acceso sin restricciones a contratos inteligentes de DEXes/Bridges, permitiéndoles utilizar la cantidad de token aprobada sin limitaciones."
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:219
+#: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
 msgstr "Actualmente estás en modo campaña con restricciones sobre las fuentes de liquidez. ¿Le gustaría desconectar de este modo y hacer uso de todas las fuentes de liquidez disponibles?"
 
@@ -878,21 +900,6 @@ msgstr "Actualmente estás en modo campaña con restricciones sobre las fuentes 
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
 msgstr "El ID de solicitud es necesario para mostrar los detalles del intercambio."
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:34
-msgid "Light"
-msgstr "Claro"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:46
-msgid "Dark"
-msgstr "Oscuro"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:58
-msgid "Auto"
-msgstr "Auto"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
@@ -1151,4 +1158,3 @@ msgstr "cantidad máxima de activos"
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
 msgstr "cambiar a"
-

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -1,22 +1,17 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-06 17:24+0330\n"
+"POT-Creation-Date: 2024-03-10 13:29+0330\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: pt\n"
-"Project-Id-Version: rango\n"
+"Language: fi\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-02-20 09:32\n"
+"PO-Revision-Date: \n"
 "Last-Translator: \n"
-"Language-Team: Portuguese\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: rango\n"
-"X-Crowdin-Project-ID: 622238\n"
-"X-Crowdin-Language: pt-PT\n"
-"X-Crowdin-File: en.po\n"
-"X-Crowdin-File-ID: 30\n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
@@ -24,7 +19,7 @@ msgstr ""
 #: widget/embedded/src/pages/HistoryPage.tsx:85
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:131
 msgid "No results found"
-msgstr "Nenhum resultado encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:38
@@ -32,24 +27,24 @@ msgstr "Nenhum resultado encontrado"
 #: widget/embedded/src/pages/HistoryPage.tsx:87
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:132
 msgid "Try using different keywords"
-msgstr "Tente usar palavras-chave diferentes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:66
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:46
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:40
 msgid "Select Blockchain"
-msgstr "Selecione a Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:66
 msgid "All"
-msgstr "TODOS"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:100
 msgid "More +{count}"
-msgstr "Mais +{count}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
@@ -64,221 +59,221 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
 msgid "Activate current tab"
-msgstr "Ativar a aba atual"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:22
 msgid "Currently, some transactions are running and being handled by other browser tab. If you activate this tab, all transactions that are already in the transaction sign step will expire."
-msgstr "No momento, algumas transações estão sendo executadas e sendo tratadas por outra aba do navegador. Se você ativar essa aba, todas as transações que já estão na etapa de sinal de transação irão expirar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:32
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:269
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:237
 msgid "Confirm"
-msgstr "Confirmar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:284
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:359
 msgid "Your {blockchainName} wallets"
-msgstr "Suas carteiras {blockchainName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:303
 msgid "Insufficient account balance"
-msgstr "Saldo de conta insuficiente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:312
 msgid "Proceed anyway"
-msgstr "Continuar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:368
 msgid "You need to connect a {blockchainName} wallet."
-msgstr "Você precisa conectar uma carteira {blockchainName}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
-msgstr "Enviar para outro endereço"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
-msgstr "Seu endereço de destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
-msgstr "O endereço {destination} não corresponde ao padrão do endereço da blockchain."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:168
 msgid "Add {chain} chain"
-msgstr "Adiciona cadeia {chain}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:217
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:250
 msgid "Add {blockchainDisplayName} Chain"
-msgstr "Adicionar Corrente {blockchainDisplayName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:222
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:254
 msgid "You should connect a {blockchainDisplayName} supported wallet or choose a different {blockchainDisplayName} address"
-msgstr "Você deve conectar uma carteira com suporte do {blockchainDisplayName} ou escolher um endereço {blockchainDisplayName} diferente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:272
 msgid "{blockchainDisplayName} Chain Added"
-msgstr "{blockchainDisplayName} Cadeia Adicionada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:276
 msgid "{blockchainDisplayName} is added to your wallet, you can use it to swap."
-msgstr "{blockchainDisplayName} foi adicionado à sua carteira, você pode usá-lo para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:286
 msgid "Request Rejected"
-msgstr "Pedido rejeitado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:287
 msgid "You've rejected adding {blockchainDisplayName} chain to your wallet."
-msgstr "Você rejeitou adicionar {blockchainDisplayName} corrente à sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:311
 msgid "Show more wallets"
-msgstr "Mostrar mais carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/CancelButton.tsx:14
 msgid "Cancel"
-msgstr "cancelar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
-msgstr "atualizar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
-msgstr "notificações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
 #: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
-msgstr "Confirgurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
-msgstr "Histórico de transações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/WalletButton.tsx:14
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:16
 #: widget/embedded/src/constants/messages.ts:5
 msgid "Connect Wallet"
-msgstr "Conectar Carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx:118
 #: widget/embedded/src/utils/date.ts:18
 #: widget/embedded/src/utils/time.ts:22
 msgid "Today"
-msgstr "hoje"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:375
 msgid "Swaps steps"
-msgstr "Etapas de troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
-msgstr "Repetir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
 #: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NotificationContent/NotificationNotFound.tsx:13
 msgid "There are no notifications."
-msgstr "Não há notificações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
-msgstr "Erro Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
-msgstr "Aviso Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
-msgstr "Sua: {amount} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
-msgstr "Mínimo de slippage necessário é {minRequiredSlippage}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
-msgstr "Ver todas as rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
-msgstr "Ver mais informações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
-msgstr "Explicação de Gás e Taxa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
-msgstr "detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
-msgstr "Taxa total a pagar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
-msgstr "Ocultar taxas não-pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
-msgstr "Mostrar tarifas não pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
-msgstr "Descrição:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
@@ -286,28 +281,26 @@ msgid ""
 "The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
 msgstr ""
-"As seguintes tarifas são consideradas no resultado da transação e\n"
-"                você não precisará pagar gás extra por elas."
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:25
 msgid "Swap input"
-msgstr "Swap input"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:44
 msgid "Estimated output"
-msgstr "Saída estimada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
-msgstr "Via:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
-msgstr "Correntas:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quotes/Quotes.tsx:92
@@ -317,720 +310,720 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
 msgid "Swapping"
-msgstr "Swapping"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:51
 msgid "Gas cost"
-msgstr "Custo de gás"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:59
 msgid "Receiving"
-msgstr "Recebimento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:67
 msgid "Price impact"
-msgstr "Impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Você precisa aumentar o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Recomendamos que você aumente o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
-msgstr "Cuidado, seu slippage está alto."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx:73
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:25
 msgid "Change"
-msgstr "Troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:41
 msgid "Change settings"
-msgstr "Alterar configurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:51
 msgid "High slippage"
-msgstr "Alto slide"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:52
 msgid "Low slippage"
-msgstr "Slippage Baixo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:56
 msgid " Caution, your slippage is high (={userSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={userSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:76
 msgid "Confirm anyway"
-msgstr "Confirmar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:35
 msgid "Slippage tolerance per swap"
-msgstr "Tolerância do slippage por swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
-msgstr "Personalizado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:11
 msgid "Your transaction will be reverted if the price changes unfavorably by more than this percentage"
-msgstr "Sua transação será revertida se o preço mudar desfavoravelmente, mais do que esta porcentagem"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:16
 msgid "Warning"
-msgstr "ATENÇÃO"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:17
 msgid "This setting is applied per step (e.g. 1Inch, Thorchain, etc) which means only the step will be reverted, not the whole transaction."
-msgstr "Essa configuração é aplicada por passo (por exemplo, 1Inch, Thorchain, etc), que significa que apenas o passo será revertido, não toda a transação."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:25
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:246
 msgid "Swap and Bridge"
-msgstr "Inverter e Ponte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:33
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:286
 msgid "Request ID"
-msgstr "Solicitar ID"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:64
 msgid "Not found"
-msgstr "Não encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:65
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:39
 msgid "Swap with request ID = {requestId} not found."
-msgstr "Trocar com o ID de requisição = {requestId} não encontrado."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:214
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
-msgstr "Você recebeu {amount} {token} em carteira {conciseAddress} na cadeia {chain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:230
 msgid "Transaction was not sent."
-msgstr "Transação não foi enviada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:232
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
-msgstr "{amount} {symbol} em {blockchain} permanece em sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:257
 msgid "Delete"
-msgstr "excluir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:278
 msgid "Try again"
-msgstr "Tente novamente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx:50
 msgid "View transaction"
-msgstr "Ver transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:47
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:31
 msgid "Connect"
-msgstr "Conectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:43
 msgid "Swap Successful"
-msgstr "Troca bem sucedida"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:71
 msgid "Transaction Failed"
-msgstr "Transação Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:86
 msgid "Done"
-msgstr "Concluído"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:98
 msgid "Diagnosis"
-msgstr "Diagnóstico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:105
 msgid "See Details"
-msgstr "Ver Detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:13
 msgid "Cancel Swap"
-msgstr "Cancelar Swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:14
 msgid "Are you sure you want to cancel this swap?"
-msgstr "Tem certeza que deseja cancelar este swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:22
 msgid "Yes, Cancel it"
-msgstr "Sim, Cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:26
 msgid "No, Continue"
-msgstr "Não, continuar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:13
 msgid "Delete Transaction"
-msgstr "Excluir Transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:14
 msgid "Are you sure you want to delete this swap?"
-msgstr "Tem certeza que deseja excluir esta troca?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:22
 msgid "Yes, Delete it"
-msgstr "Sim, exclua-o"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:27
 msgid "No, Cancel"
-msgstr "Não, cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:12
 msgid "Change Network"
-msgstr "Alterar rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:20
 msgid "Network Changed"
-msgstr "Rede alterada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
-msgstr "Selecione o Token"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:19
 msgid "Wallet Connected"
-msgstr "Carteira conectada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:20
 msgid "Your wallet is connected, you can use it to swap."
-msgstr "Sua carteira está conectada, você pode usá-la para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:31
 msgid "Failed to Connect"
-msgstr "Falha na conexão"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:33
 msgid "Your wallet is not connected. Please try again."
-msgstr "Sua carteira não está conectada. Por favor, tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:42
 msgid "Connecting to your wallet"
-msgstr "Conectando-se à sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:43
 msgid "Click connect in your wallet popup."
-msgstr "Clique em conectar no pop-up da sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:9
 msgid "Failed Network, Please retry your swap."
-msgstr "Falha na Rede, tente novamente sua alternância."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:11
 msgid "Please reset your liquidity sources."
-msgstr "Por favor, redefina suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:12
 msgid "You have limited the liquidity sources and this might result in Rango finding no routes. Please consider resetting your liquidity sources."
-msgstr "Você limitou as fontes de liquidez e isso pode resultar em que o Rango não encontre nenhuma rota. Por favor, considere redefinir suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:17
 msgid "No Routes Found."
-msgstr "Nenhuma rota encontrada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:18
 msgid "Reasons why Rango couldn't find a route: low liquidity on token, very low input amount or no routes available for the selected input/output token combination."
-msgstr "Motivos porque Rango não conseguiu encontrar uma rota: baixa liquidez no token, quantidade muito baixa de entrada ou nenhuma rota disponível para a combinação selecionada de entrada/saída do token."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:23
 msgid "Bridge Limit Error: Please increase your amount."
-msgstr "Erro no limite da ponte: Por favor, aumente o seu valor."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:26
 msgid "Bridge Limit Error: Please decrease your amount."
-msgstr "Erro no limite da ponte: Por favor, reduza seu montante."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:31
 msgid "High Price Impact"
-msgstr "Impacto de preço alto"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:32
 msgid "Price impact is too high!"
-msgstr "O impacto nos preços é muito alto!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:33
 msgid "The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap."
-msgstr "O impacto no preço é significativamente maior do que o valor permitido. Se você tem certeza, continue, caso contrário, altere o swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:36
 msgid "Confirm high price impact"
-msgstr "Confirmar alto impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:39
 msgid "Route updated and price impact is too high, try again later!"
-msgstr "A rota atualizada e o impacto nos preços é muito alto, tente novamente mais tarde!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:44
 msgid "USD Price Unknown"
-msgstr "Preço em USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:45
 msgid "USD Price Unknown, Cannot calculate Price Impact."
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto de preços."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:46
 msgid "USD Price Unknown, Cannot calculate Price Impact. The price impact may be higher than usual. Are you sure to continue the Swap?"
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto do preço. O impacto do preço pode ser maior do que o normal. Tem certeza que deseja continuar o Swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:49
 msgid "Confirm USD Price Unknown"
-msgstr "Confirmar preço de USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
 #: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
-msgstr "Trocar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:7
 msgid "Swap anyway"
-msgstr "Trocar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:8
 msgid "The route goes through Ethereum. Continue?"
-msgstr "A rota passa pelo Ethereum. Continuar?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:13
 msgid "Network Fee"
-msgstr "Taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:14
 msgid "Protocol Fee"
-msgstr "Taxa do Protocolo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:15
 msgid "Affiliate Fee"
-msgstr "Taxa de afiliado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:16
 msgid "Outbound Fee"
-msgstr "Taxa de Saída"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:17
 msgid "Rango Fee"
-msgstr "Taxa de Rango"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
 msgid "Smart Routing"
-msgstr "Roteamento inteligente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
-msgstr "Taxa mais baixa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:36
 msgid "Fastest Transfer"
-msgstr "Mais Rápido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:40
 msgid "Maximum Return"
-msgstr "Retorno Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:44
 msgid "Maximum Output"
-msgstr "Produção Máxima"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
 msgid "Route has been updated."
-msgstr "Rota foi atualizada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:12
 msgid "Output amount changed to {newOutputAmount} ({percentageChange}% change)."
-msgstr "Valor de saída alterado para {newOutputAmount} ( Alteração de{percentageChange}%)."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:20
 msgid "Route swappers has been updated."
-msgstr "Os trocadores de rota foram atualizados."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:22
 msgid "Route internal coins has been updated."
-msgstr "Moedas internas do itinerário foram atualizadas."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
 #: widget/embedded/src/pages/Routes.tsx:48
 msgid "Routes"
-msgstr "Rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:77
 msgid "From"
-msgstr "De"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:120
 msgid "To"
-msgstr "Para"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:47
 msgid "Light"
-msgstr "Fino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:56
 msgid "Dark"
-msgstr "Escuro"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:65
 msgid "Auto"
-msgstr "Automático"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:133
 msgid "Loading failed"
-msgstr "Falha no carregamento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:149
 msgid "Enabled bridges"
-msgstr "Pontes habilitados"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:167
 msgid "Enabled exchanges"
-msgstr "Trocas ativadas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:185
 #: widget/embedded/src/pages/LanguagePage.tsx:38
 msgid "Language"
-msgstr "IDIOMA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:198
 msgid "Infinite approval"
-msgstr "Aprovação infinita"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:208
 msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Ativar o modo de 'aprovação infinita' concede acesso irrestrito a contratos inteligentes de DEXes/Bridges, permitindo-lhes utilizar o valor do token aprovado, sem limitações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:228
 msgid "Theme"
-msgstr "Tema"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
-msgstr "Confirmar troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
-msgstr "Trocar de início"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
-msgstr "Você recebe"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:67
 msgid "History"
-msgstr "Histórico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:74
 msgid "Search Transaction"
-msgstr "Pesquisar transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
-msgstr "Idioma"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:151
 msgid "Exchanges"
-msgstr "Trocas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:112
 msgid "Bridges"
-msgstr "Pontes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Deselect all"
-msgstr "Desmarcar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Select all"
-msgstr "Selecionar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:121
 msgid "Search {sourceType}"
-msgstr "Pesquisar em {sourceType}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
-msgstr "Pesquisar Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:72
 msgid "Source"
-msgstr "fonte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:73
 msgid "Destination"
-msgstr "Destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:79
 msgid "Swap {type}"
-msgstr "Trocar {type}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:95
 msgid "Search Token"
-msgstr "Token de pesquisa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
-msgstr "Atualmente, você está no modo campanha com restrições sobre fontes de liquidez. Gostaria de mudar este modo e usar todas as fontes de liquidez disponíveis?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
-msgstr "O ID da requisição é necessário para exibir os detalhes do swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
 #: widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx:30
 msgid "Connect Wallets"
-msgstr "Conectar Carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:76
 msgid "Choose a wallet to connect."
-msgstr "Escolha uma carteira para se conectar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:25
 msgid "This week"
-msgstr "Esta semana"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:32
 msgid "This month"
-msgstr "Este Mês"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:39
 msgid "This year"
-msgstr "Esse ano"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:125
 msgid "Required: >= {min} {symbol}"
-msgstr "Obrigatório: >= {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:138
 msgid "Required: > {min} {symbol}"
-msgstr "Obrigatório: > {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:153
 msgid "Required: <= {max} {symbol}"
-msgstr "Obrigatório: <= {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:166
 msgid "Required: < {max} {symbol}"
-msgstr "Obrigatório: < {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:634
 msgid " for network fee"
-msgstr " para taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:637
 msgid " for swap"
-msgstr " para troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:640
 msgid " for input and network fee"
-msgstr " por taxa de entrada e de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:642
 msgid "Needs ≈ {requiredAmount} {symbol}{reason}, but you have {currentAmount} {symbol} in your {blockchain} wallet."
-msgstr "Precisa de {requiredAmount} {symbol}{reason}, mas você tem {currentAmount} {symbol} na sua carteira {blockchain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:702
 msgid "Waiting for connecting wallet"
-msgstr "Aguardando conexão da carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:706
 msgid "Waiting for other running tasks to be finished"
-msgstr "Aguardando o término de outras tarefas em execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:709
 msgid "Waiting for changing wallet network"
-msgstr "Aguardando mudança da rede de carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:6
 msgid "Sunday"
-msgstr "domingo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:7
 msgid "Monday"
-msgstr "Segunda-Feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:8
 msgid "Tuesday"
-msgstr "Terça-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:9
 msgid "Wednesday"
-msgstr "quarta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:10
 msgid "Thursday"
-msgstr "quinta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:11
 msgid "Friday"
-msgstr "Sexta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:12
 msgid "Saturday"
-msgstr "sábado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
-msgstr " Erro ao conectar ao servidor, por favor recarregue o app e tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/BottomLogo/BottomLogo.tsx:14
 msgid "Powered By"
-msgstr "Desenvolvido por"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/ChangeSlippageButton/ChangeSlippageButton.tsx:14
 msgid "Change Slippage"
-msgstr "Alterar Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx:63
@@ -1041,120 +1034,120 @@ msgstr ""
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:74
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:100
 msgid "Swap on {fromChain} via {swapper}"
-msgstr "Trocar em {fromChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:107
 msgid "Bridge to {toChain} via {swapper}"
-msgstr "Ponte para {toChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:28
 msgid "Swap Details"
-msgstr "Trocar detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:8
 msgid "Failed"
-msgstr "Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:10
 msgid "Complete"
-msgstr "Complete"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:12
 msgid "In progress"
-msgstr "Em Execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapToken.tsx:122
 msgid "Waiting for bridge transaction"
-msgstr "Aguardando a transação da bridge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:150
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:56
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:235
 msgid "Chain"
-msgstr "Corrente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:168
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:49
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:259
 msgid "Token"
-msgstr "Identificador"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:12
 msgid "Connected"
-msgstr "Conectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:13
 msgid "Disconnect"
-msgstr "Desconectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:18
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:19
 msgid "Install"
-msgstr "Instale"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:24
 msgid "Connecting..."
-msgstr "Conectandochar@@0"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:25
 msgid "Connecting"
-msgstr "Conectando"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:30
 msgid "Disconnected"
-msgstr "Desconectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:34
 msgid "you need to pass a correct state to Wallet."
-msgstr "você precisa passar um estado correto para o Wallet."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/HomePanel/HomePanel.tsx:123
 msgid "SWAP"
-msgstr "TROCA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
-msgstr "Saldo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:62
 msgid "Max"
-msgstr "Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={selectedSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:179
 msgid "swap from"
-msgstr "trocar de"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:198
 msgid "maximum amount of asset"
-msgstr "quantidade máxima de ativos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
-msgstr "trocar para"
+msgstr ""

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -53,13 +53,13 @@ msgstr "Plus +{count}"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
-msgid "Activate"
-msgstr "Activer"
+msgid "Activate this tab"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:21
-msgid "Another tab is open and handles transactions. You can activate this tab."
-msgstr "Un autre onglet est ouvert et gère les transactions. Vous pouvez activer cet onglet."
+msgid "Another tab is open and handles transactions."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
@@ -100,17 +100,17 @@ msgid "You need to connect a {blockchainName} wallet."
 msgstr "Vous devez connecter un portefeuille {blockchainName}."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:435
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
 msgstr "Envoyer à une autre adresse"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:446
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
 msgstr "Votre adresse de destination"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:465
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
 msgstr "L'adresse {destination} ne correspond pas au modèle d'adresse blockchain."
 
@@ -162,24 +162,24 @@ msgid "Cancel"
 msgstr "Abandonner"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:44
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
 msgstr "Rafraîchir"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:60
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
 msgstr "Notifications"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:73
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:312
-#: widget/embedded/src/pages/SettingsPage.tsx:212
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
+#: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
 msgstr "Réglages"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:83
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
 msgstr "Historique des transactions"
 
@@ -204,12 +204,13 @@ msgid "Swaps steps"
 msgstr "Étapes d'échange"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:25
+#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
 msgstr "Réessayer"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:37
+#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
+#: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
 msgstr "Reset"
 
@@ -219,71 +220,73 @@ msgid "There are no notifications."
 msgstr "Il n'y a pas de notifications."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:126
+#: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
 msgstr "Erreur de Slippage"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:127
+#: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
 msgstr "Avertissement de Slippage"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:231
+#: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
 msgstr "Vous: {amount} {symbol}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:252
+#: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
 msgstr "Le slippage minimum requis est {minRequiredSlippage}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:325
+#: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
 msgstr "Voir toutes les routes"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:98
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
 msgstr "Voir plus d'infos"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:108
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
 msgstr "Explication du gaz et des frais"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:121
-#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:88
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
+#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
 msgstr "Détails du produit"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:162
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
 msgstr "Total des frais payables"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:182
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
 msgstr "Masquer les frais non payables"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:183
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
 msgstr "Afficher les frais non payants"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:193
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
 msgstr "Libellé"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:197
-msgid "The following fees are considered in the transaction output and\n"
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
+msgid ""
+"The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
-msgstr "Les frais suivants sont pris en compte dans la production de la transaction et\n"
+msgstr ""
+"Les frais suivants sont pris en compte dans la production de la transaction et\n"
 "                vous n'aurez pas besoin de payer du gaz supplémentaire pour eux."
 
 #. js-lingui-explicit-id
@@ -297,14 +300,19 @@ msgid "Estimated output"
 msgstr "Sortie estimée"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteTrigger .tsx:77
+#: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
 msgstr "Via:"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteTrigger .tsx:160
+#: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
 msgstr "Chaînes :"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quotes/Quotes.tsx:92
+msgid "Sort by"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
@@ -327,19 +335,19 @@ msgid "Price impact"
 msgstr "Impact des prix"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:36
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
 msgstr "Vous devez augmenter le slippage à au moins {minRequiredSlippage} pour cette route."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:60
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
 msgstr "Nous vous recommandons d'augmenter le slippage à au moins {minRequiredSlippage} pour cette route."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:69
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
 msgstr "Attention, votre slippage est élevé."
 
@@ -380,7 +388,7 @@ msgid "Slippage tolerance per swap"
 msgstr "Tolérance avec glissement par swap"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Slippage/Slippage.tsx:90
+#: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
 msgstr "Personnalisé"
 
@@ -534,7 +542,7 @@ msgid "Network Changed"
 msgstr "Réseau modifié"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/TokenList/TokenList.tsx:257
+#: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
 msgstr "Sélectionner un jeton"
 
@@ -650,7 +658,7 @@ msgstr "Confirmer le prix en USD inconnu"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
-#: widget/embedded/src/pages/Home.tsx:155
+#: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
 msgstr "Permuter"
 
@@ -690,29 +698,29 @@ msgid "Rango Fee"
 msgstr "Frais de Rango"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:26
-msgid "Fastest Transfer"
-msgstr "Transfert le plus rapide"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:27
-msgid "Maximum Return"
-msgstr "Retour maximum"
-
-#. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
+msgid "Smart Routing"
+msgstr "Routage intelligent"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
 msgstr "Frais les plus bas"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:29
-msgid "Maximum Output"
-msgstr "Sortie maximale"
+#: widget/embedded/src/constants/quote.ts:36
+msgid "Fastest Transfer"
+msgstr "Transfert le plus rapide"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:30
-msgid "Smart Routing"
-msgstr "Routage intelligent"
+#: widget/embedded/src/constants/quote.ts:40
+msgid "Maximum Return"
+msgstr "Retour maximum"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:44
+msgid "Maximum Output"
+msgstr "Sortie maximale"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
@@ -735,17 +743,84 @@ msgid "Route internal coins has been updated."
 msgstr "Les pièces internes de la route ont été mises à jour."
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:303
+#: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
+#: widget/embedded/src/pages/Routes.tsx:48
+msgid "Routes"
+msgstr "Routes"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Inputs/Inputs.tsx:77
+msgid "From"
+msgstr "A partir de"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Inputs/Inputs.tsx:120
+msgid "To"
+msgstr "À"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:47
+msgid "Light"
+msgstr "Lumière"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:56
+msgid "Dark"
+msgstr "Sombre"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:65
+msgid "Auto"
+msgstr "Automatique"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:133
+msgid "Loading failed"
+msgstr "Échec du chargement"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:149
+msgid "Enabled bridges"
+msgstr "Ponts de connexion activés"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:167
+msgid "Enabled exchanges"
+msgstr "Échanges activés"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:185
+#: widget/embedded/src/pages/LanguagePage.tsx:38
+msgid "Language"
+msgstr "Langue"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:198
+msgid "Infinite approval"
+msgstr "Approbation infinie"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:208
+msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
+msgstr "Activer le mode « approbation infinie» permet un accès illimité aux contrats intelligents de DEXes/Ponts, leur permettant d'utiliser le montant de jeton approuvé sans restrictions."
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:228
+msgid "Theme"
+msgstr "Thème"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
 msgstr "Confirmer l'échange"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:333
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
 msgstr "Début de l'échange"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:359
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
 msgstr "Vous obtenez"
 
@@ -760,23 +835,7 @@ msgid "Search Transaction"
 msgstr "Rechercher une transaction"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:172
-msgid "From"
-msgstr "A partir de"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:213
-msgid "To"
-msgstr "À"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/LanguagePage.tsx:36
-#: widget/embedded/src/pages/SettingsPage.tsx:136
-msgid "Language"
-msgstr "Langue"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/LanguagePage.tsx:43
+#: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
 msgstr "Langue"
 
@@ -808,11 +867,6 @@ msgid "Search {sourceType}"
 msgstr "Rechercher dans {sourceType}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Routes.tsx:77
-msgid "Routes"
-msgstr "Routes"
-
-#. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
 msgstr "Rechercher dans la Blockchain"
@@ -838,39 +892,7 @@ msgid "Search Token"
 msgstr "Jeton de recherche"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:86
-msgid "Loading failed"
-msgstr "Échec du chargement"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:102
-msgid "Enabled bridges"
-msgstr "Ponts de connexion activés"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:119
-msgid "Enabled exchanges"
-msgstr "Échanges activés"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:147
-#: widget/embedded/src/pages/ThemePage.tsx:70
-#: widget/embedded/src/pages/ThemePage.tsx:79
-msgid "Theme"
-msgstr "Thème"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:159
-msgid "Infinite approval"
-msgstr "Approbation infinie"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:169
-msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Activer le mode « approbation infinie» permet un accès illimité aux contrats intelligents de DEXes/Ponts, leur permettant d'utiliser le montant de jeton approuvé sans restrictions."
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:219
+#: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
 msgstr "Actuellement, vous êtes en mode campagne avec des restrictions sur les sources de liquidités. Voulez-vous sortir de ce mode et utiliser toutes les sources de liquidités disponibles ?"
 
@@ -878,21 +900,6 @@ msgstr "Actuellement, vous êtes en mode campagne avec des restrictions sur les 
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
 msgstr "L'identifiant de la requête est nécessaire pour afficher les détails du swap."
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:34
-msgid "Light"
-msgstr "Lumière"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:46
-msgid "Dark"
-msgstr "Sombre"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:58
-msgid "Auto"
-msgstr "Automatique"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
@@ -1151,4 +1158,3 @@ msgstr "montant maximum d'actif"
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
 msgstr "swap vers"
-

--- a/translations/it.po
+++ b/translations/it.po
@@ -1,22 +1,17 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-06 17:24+0330\n"
+"POT-Creation-Date: 2024-03-10 13:29+0330\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: pt\n"
-"Project-Id-Version: rango\n"
+"Language: it\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-02-20 09:32\n"
+"PO-Revision-Date: \n"
 "Last-Translator: \n"
-"Language-Team: Portuguese\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: rango\n"
-"X-Crowdin-Project-ID: 622238\n"
-"X-Crowdin-Language: pt-PT\n"
-"X-Crowdin-File: en.po\n"
-"X-Crowdin-File-ID: 30\n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
@@ -24,7 +19,7 @@ msgstr ""
 #: widget/embedded/src/pages/HistoryPage.tsx:85
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:131
 msgid "No results found"
-msgstr "Nenhum resultado encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:38
@@ -32,24 +27,24 @@ msgstr "Nenhum resultado encontrado"
 #: widget/embedded/src/pages/HistoryPage.tsx:87
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:132
 msgid "Try using different keywords"
-msgstr "Tente usar palavras-chave diferentes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:66
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:46
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:40
 msgid "Select Blockchain"
-msgstr "Selecione a Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:66
 msgid "All"
-msgstr "TODOS"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:100
 msgid "More +{count}"
-msgstr "Mais +{count}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
@@ -64,221 +59,221 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
 msgid "Activate current tab"
-msgstr "Ativar a aba atual"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:22
 msgid "Currently, some transactions are running and being handled by other browser tab. If you activate this tab, all transactions that are already in the transaction sign step will expire."
-msgstr "No momento, algumas transações estão sendo executadas e sendo tratadas por outra aba do navegador. Se você ativar essa aba, todas as transações que já estão na etapa de sinal de transação irão expirar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:32
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:269
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:237
 msgid "Confirm"
-msgstr "Confirmar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:284
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:359
 msgid "Your {blockchainName} wallets"
-msgstr "Suas carteiras {blockchainName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:303
 msgid "Insufficient account balance"
-msgstr "Saldo de conta insuficiente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:312
 msgid "Proceed anyway"
-msgstr "Continuar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:368
 msgid "You need to connect a {blockchainName} wallet."
-msgstr "Você precisa conectar uma carteira {blockchainName}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
-msgstr "Enviar para outro endereço"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
-msgstr "Seu endereço de destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
-msgstr "O endereço {destination} não corresponde ao padrão do endereço da blockchain."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:168
 msgid "Add {chain} chain"
-msgstr "Adiciona cadeia {chain}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:217
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:250
 msgid "Add {blockchainDisplayName} Chain"
-msgstr "Adicionar Corrente {blockchainDisplayName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:222
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:254
 msgid "You should connect a {blockchainDisplayName} supported wallet or choose a different {blockchainDisplayName} address"
-msgstr "Você deve conectar uma carteira com suporte do {blockchainDisplayName} ou escolher um endereço {blockchainDisplayName} diferente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:272
 msgid "{blockchainDisplayName} Chain Added"
-msgstr "{blockchainDisplayName} Cadeia Adicionada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:276
 msgid "{blockchainDisplayName} is added to your wallet, you can use it to swap."
-msgstr "{blockchainDisplayName} foi adicionado à sua carteira, você pode usá-lo para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:286
 msgid "Request Rejected"
-msgstr "Pedido rejeitado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:287
 msgid "You've rejected adding {blockchainDisplayName} chain to your wallet."
-msgstr "Você rejeitou adicionar {blockchainDisplayName} corrente à sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:311
 msgid "Show more wallets"
-msgstr "Mostrar mais carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/CancelButton.tsx:14
 msgid "Cancel"
-msgstr "cancelar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
-msgstr "atualizar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
-msgstr "notificações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
 #: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
-msgstr "Confirgurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
-msgstr "Histórico de transações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/WalletButton.tsx:14
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:16
 #: widget/embedded/src/constants/messages.ts:5
 msgid "Connect Wallet"
-msgstr "Conectar Carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx:118
 #: widget/embedded/src/utils/date.ts:18
 #: widget/embedded/src/utils/time.ts:22
 msgid "Today"
-msgstr "hoje"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:375
 msgid "Swaps steps"
-msgstr "Etapas de troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
-msgstr "Repetir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
 #: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NotificationContent/NotificationNotFound.tsx:13
 msgid "There are no notifications."
-msgstr "Não há notificações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
-msgstr "Erro Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
-msgstr "Aviso Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
-msgstr "Sua: {amount} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
-msgstr "Mínimo de slippage necessário é {minRequiredSlippage}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
-msgstr "Ver todas as rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
-msgstr "Ver mais informações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
-msgstr "Explicação de Gás e Taxa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
-msgstr "detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
-msgstr "Taxa total a pagar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
-msgstr "Ocultar taxas não-pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
-msgstr "Mostrar tarifas não pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
-msgstr "Descrição:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
@@ -286,28 +281,26 @@ msgid ""
 "The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
 msgstr ""
-"As seguintes tarifas são consideradas no resultado da transação e\n"
-"                você não precisará pagar gás extra por elas."
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:25
 msgid "Swap input"
-msgstr "Swap input"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:44
 msgid "Estimated output"
-msgstr "Saída estimada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
-msgstr "Via:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
-msgstr "Correntas:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quotes/Quotes.tsx:92
@@ -317,720 +310,720 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
 msgid "Swapping"
-msgstr "Swapping"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:51
 msgid "Gas cost"
-msgstr "Custo de gás"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:59
 msgid "Receiving"
-msgstr "Recebimento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:67
 msgid "Price impact"
-msgstr "Impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Você precisa aumentar o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Recomendamos que você aumente o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
-msgstr "Cuidado, seu slippage está alto."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx:73
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:25
 msgid "Change"
-msgstr "Troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:41
 msgid "Change settings"
-msgstr "Alterar configurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:51
 msgid "High slippage"
-msgstr "Alto slide"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:52
 msgid "Low slippage"
-msgstr "Slippage Baixo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:56
 msgid " Caution, your slippage is high (={userSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={userSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:76
 msgid "Confirm anyway"
-msgstr "Confirmar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:35
 msgid "Slippage tolerance per swap"
-msgstr "Tolerância do slippage por swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
-msgstr "Personalizado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:11
 msgid "Your transaction will be reverted if the price changes unfavorably by more than this percentage"
-msgstr "Sua transação será revertida se o preço mudar desfavoravelmente, mais do que esta porcentagem"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:16
 msgid "Warning"
-msgstr "ATENÇÃO"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:17
 msgid "This setting is applied per step (e.g. 1Inch, Thorchain, etc) which means only the step will be reverted, not the whole transaction."
-msgstr "Essa configuração é aplicada por passo (por exemplo, 1Inch, Thorchain, etc), que significa que apenas o passo será revertido, não toda a transação."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:25
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:246
 msgid "Swap and Bridge"
-msgstr "Inverter e Ponte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:33
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:286
 msgid "Request ID"
-msgstr "Solicitar ID"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:64
 msgid "Not found"
-msgstr "Não encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:65
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:39
 msgid "Swap with request ID = {requestId} not found."
-msgstr "Trocar com o ID de requisição = {requestId} não encontrado."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:214
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
-msgstr "Você recebeu {amount} {token} em carteira {conciseAddress} na cadeia {chain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:230
 msgid "Transaction was not sent."
-msgstr "Transação não foi enviada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:232
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
-msgstr "{amount} {symbol} em {blockchain} permanece em sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:257
 msgid "Delete"
-msgstr "excluir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:278
 msgid "Try again"
-msgstr "Tente novamente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx:50
 msgid "View transaction"
-msgstr "Ver transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:47
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:31
 msgid "Connect"
-msgstr "Conectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:43
 msgid "Swap Successful"
-msgstr "Troca bem sucedida"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:71
 msgid "Transaction Failed"
-msgstr "Transação Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:86
 msgid "Done"
-msgstr "Concluído"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:98
 msgid "Diagnosis"
-msgstr "Diagnóstico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:105
 msgid "See Details"
-msgstr "Ver Detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:13
 msgid "Cancel Swap"
-msgstr "Cancelar Swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:14
 msgid "Are you sure you want to cancel this swap?"
-msgstr "Tem certeza que deseja cancelar este swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:22
 msgid "Yes, Cancel it"
-msgstr "Sim, Cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:26
 msgid "No, Continue"
-msgstr "Não, continuar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:13
 msgid "Delete Transaction"
-msgstr "Excluir Transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:14
 msgid "Are you sure you want to delete this swap?"
-msgstr "Tem certeza que deseja excluir esta troca?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:22
 msgid "Yes, Delete it"
-msgstr "Sim, exclua-o"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:27
 msgid "No, Cancel"
-msgstr "Não, cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:12
 msgid "Change Network"
-msgstr "Alterar rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:20
 msgid "Network Changed"
-msgstr "Rede alterada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
-msgstr "Selecione o Token"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:19
 msgid "Wallet Connected"
-msgstr "Carteira conectada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:20
 msgid "Your wallet is connected, you can use it to swap."
-msgstr "Sua carteira está conectada, você pode usá-la para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:31
 msgid "Failed to Connect"
-msgstr "Falha na conexão"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:33
 msgid "Your wallet is not connected. Please try again."
-msgstr "Sua carteira não está conectada. Por favor, tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:42
 msgid "Connecting to your wallet"
-msgstr "Conectando-se à sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:43
 msgid "Click connect in your wallet popup."
-msgstr "Clique em conectar no pop-up da sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:9
 msgid "Failed Network, Please retry your swap."
-msgstr "Falha na Rede, tente novamente sua alternância."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:11
 msgid "Please reset your liquidity sources."
-msgstr "Por favor, redefina suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:12
 msgid "You have limited the liquidity sources and this might result in Rango finding no routes. Please consider resetting your liquidity sources."
-msgstr "Você limitou as fontes de liquidez e isso pode resultar em que o Rango não encontre nenhuma rota. Por favor, considere redefinir suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:17
 msgid "No Routes Found."
-msgstr "Nenhuma rota encontrada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:18
 msgid "Reasons why Rango couldn't find a route: low liquidity on token, very low input amount or no routes available for the selected input/output token combination."
-msgstr "Motivos porque Rango não conseguiu encontrar uma rota: baixa liquidez no token, quantidade muito baixa de entrada ou nenhuma rota disponível para a combinação selecionada de entrada/saída do token."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:23
 msgid "Bridge Limit Error: Please increase your amount."
-msgstr "Erro no limite da ponte: Por favor, aumente o seu valor."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:26
 msgid "Bridge Limit Error: Please decrease your amount."
-msgstr "Erro no limite da ponte: Por favor, reduza seu montante."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:31
 msgid "High Price Impact"
-msgstr "Impacto de preço alto"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:32
 msgid "Price impact is too high!"
-msgstr "O impacto nos preços é muito alto!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:33
 msgid "The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap."
-msgstr "O impacto no preço é significativamente maior do que o valor permitido. Se você tem certeza, continue, caso contrário, altere o swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:36
 msgid "Confirm high price impact"
-msgstr "Confirmar alto impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:39
 msgid "Route updated and price impact is too high, try again later!"
-msgstr "A rota atualizada e o impacto nos preços é muito alto, tente novamente mais tarde!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:44
 msgid "USD Price Unknown"
-msgstr "Preço em USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:45
 msgid "USD Price Unknown, Cannot calculate Price Impact."
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto de preços."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:46
 msgid "USD Price Unknown, Cannot calculate Price Impact. The price impact may be higher than usual. Are you sure to continue the Swap?"
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto do preço. O impacto do preço pode ser maior do que o normal. Tem certeza que deseja continuar o Swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:49
 msgid "Confirm USD Price Unknown"
-msgstr "Confirmar preço de USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
 #: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
-msgstr "Trocar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:7
 msgid "Swap anyway"
-msgstr "Trocar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:8
 msgid "The route goes through Ethereum. Continue?"
-msgstr "A rota passa pelo Ethereum. Continuar?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:13
 msgid "Network Fee"
-msgstr "Taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:14
 msgid "Protocol Fee"
-msgstr "Taxa do Protocolo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:15
 msgid "Affiliate Fee"
-msgstr "Taxa de afiliado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:16
 msgid "Outbound Fee"
-msgstr "Taxa de Saída"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:17
 msgid "Rango Fee"
-msgstr "Taxa de Rango"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
 msgid "Smart Routing"
-msgstr "Roteamento inteligente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
-msgstr "Taxa mais baixa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:36
 msgid "Fastest Transfer"
-msgstr "Mais Rápido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:40
 msgid "Maximum Return"
-msgstr "Retorno Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:44
 msgid "Maximum Output"
-msgstr "Produção Máxima"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
 msgid "Route has been updated."
-msgstr "Rota foi atualizada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:12
 msgid "Output amount changed to {newOutputAmount} ({percentageChange}% change)."
-msgstr "Valor de saída alterado para {newOutputAmount} ( Alteração de{percentageChange}%)."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:20
 msgid "Route swappers has been updated."
-msgstr "Os trocadores de rota foram atualizados."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:22
 msgid "Route internal coins has been updated."
-msgstr "Moedas internas do itinerário foram atualizadas."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
 #: widget/embedded/src/pages/Routes.tsx:48
 msgid "Routes"
-msgstr "Rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:77
 msgid "From"
-msgstr "De"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:120
 msgid "To"
-msgstr "Para"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:47
 msgid "Light"
-msgstr "Fino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:56
 msgid "Dark"
-msgstr "Escuro"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:65
 msgid "Auto"
-msgstr "Automático"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:133
 msgid "Loading failed"
-msgstr "Falha no carregamento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:149
 msgid "Enabled bridges"
-msgstr "Pontes habilitados"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:167
 msgid "Enabled exchanges"
-msgstr "Trocas ativadas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:185
 #: widget/embedded/src/pages/LanguagePage.tsx:38
 msgid "Language"
-msgstr "IDIOMA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:198
 msgid "Infinite approval"
-msgstr "Aprovação infinita"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:208
 msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Ativar o modo de 'aprovação infinita' concede acesso irrestrito a contratos inteligentes de DEXes/Bridges, permitindo-lhes utilizar o valor do token aprovado, sem limitações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:228
 msgid "Theme"
-msgstr "Tema"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
-msgstr "Confirmar troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
-msgstr "Trocar de início"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
-msgstr "Você recebe"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:67
 msgid "History"
-msgstr "Histórico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:74
 msgid "Search Transaction"
-msgstr "Pesquisar transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
-msgstr "Idioma"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:151
 msgid "Exchanges"
-msgstr "Trocas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:112
 msgid "Bridges"
-msgstr "Pontes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Deselect all"
-msgstr "Desmarcar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Select all"
-msgstr "Selecionar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:121
 msgid "Search {sourceType}"
-msgstr "Pesquisar em {sourceType}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
-msgstr "Pesquisar Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:72
 msgid "Source"
-msgstr "fonte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:73
 msgid "Destination"
-msgstr "Destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:79
 msgid "Swap {type}"
-msgstr "Trocar {type}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:95
 msgid "Search Token"
-msgstr "Token de pesquisa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
-msgstr "Atualmente, você está no modo campanha com restrições sobre fontes de liquidez. Gostaria de mudar este modo e usar todas as fontes de liquidez disponíveis?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
-msgstr "O ID da requisição é necessário para exibir os detalhes do swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
 #: widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx:30
 msgid "Connect Wallets"
-msgstr "Conectar Carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:76
 msgid "Choose a wallet to connect."
-msgstr "Escolha uma carteira para se conectar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:25
 msgid "This week"
-msgstr "Esta semana"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:32
 msgid "This month"
-msgstr "Este Mês"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:39
 msgid "This year"
-msgstr "Esse ano"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:125
 msgid "Required: >= {min} {symbol}"
-msgstr "Obrigatório: >= {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:138
 msgid "Required: > {min} {symbol}"
-msgstr "Obrigatório: > {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:153
 msgid "Required: <= {max} {symbol}"
-msgstr "Obrigatório: <= {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:166
 msgid "Required: < {max} {symbol}"
-msgstr "Obrigatório: < {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:634
 msgid " for network fee"
-msgstr " para taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:637
 msgid " for swap"
-msgstr " para troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:640
 msgid " for input and network fee"
-msgstr " por taxa de entrada e de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:642
 msgid "Needs ≈ {requiredAmount} {symbol}{reason}, but you have {currentAmount} {symbol} in your {blockchain} wallet."
-msgstr "Precisa de {requiredAmount} {symbol}{reason}, mas você tem {currentAmount} {symbol} na sua carteira {blockchain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:702
 msgid "Waiting for connecting wallet"
-msgstr "Aguardando conexão da carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:706
 msgid "Waiting for other running tasks to be finished"
-msgstr "Aguardando o término de outras tarefas em execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:709
 msgid "Waiting for changing wallet network"
-msgstr "Aguardando mudança da rede de carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:6
 msgid "Sunday"
-msgstr "domingo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:7
 msgid "Monday"
-msgstr "Segunda-Feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:8
 msgid "Tuesday"
-msgstr "Terça-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:9
 msgid "Wednesday"
-msgstr "quarta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:10
 msgid "Thursday"
-msgstr "quinta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:11
 msgid "Friday"
-msgstr "Sexta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:12
 msgid "Saturday"
-msgstr "sábado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
-msgstr " Erro ao conectar ao servidor, por favor recarregue o app e tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/BottomLogo/BottomLogo.tsx:14
 msgid "Powered By"
-msgstr "Desenvolvido por"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/ChangeSlippageButton/ChangeSlippageButton.tsx:14
 msgid "Change Slippage"
-msgstr "Alterar Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx:63
@@ -1041,120 +1034,120 @@ msgstr ""
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:74
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:100
 msgid "Swap on {fromChain} via {swapper}"
-msgstr "Trocar em {fromChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:107
 msgid "Bridge to {toChain} via {swapper}"
-msgstr "Ponte para {toChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:28
 msgid "Swap Details"
-msgstr "Trocar detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:8
 msgid "Failed"
-msgstr "Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:10
 msgid "Complete"
-msgstr "Complete"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:12
 msgid "In progress"
-msgstr "Em Execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapToken.tsx:122
 msgid "Waiting for bridge transaction"
-msgstr "Aguardando a transação da bridge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:150
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:56
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:235
 msgid "Chain"
-msgstr "Corrente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:168
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:49
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:259
 msgid "Token"
-msgstr "Identificador"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:12
 msgid "Connected"
-msgstr "Conectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:13
 msgid "Disconnect"
-msgstr "Desconectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:18
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:19
 msgid "Install"
-msgstr "Instale"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:24
 msgid "Connecting..."
-msgstr "Conectandochar@@0"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:25
 msgid "Connecting"
-msgstr "Conectando"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:30
 msgid "Disconnected"
-msgstr "Desconectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:34
 msgid "you need to pass a correct state to Wallet."
-msgstr "você precisa passar um estado correto para o Wallet."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/HomePanel/HomePanel.tsx:123
 msgid "SWAP"
-msgstr "TROCA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
-msgstr "Saldo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:62
 msgid "Max"
-msgstr "Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={selectedSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:179
 msgid "swap from"
-msgstr "trocar de"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:198
 msgid "maximum amount of asset"
-msgstr "quantidade máxima de ativos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
-msgstr "trocar para"
+msgstr ""

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -53,13 +53,13 @@ msgstr "その他 +{count}"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
-msgid "Activate"
-msgstr "有効にする"
+msgid "Activate this tab"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:21
-msgid "Another tab is open and handles transactions. You can activate this tab."
-msgstr "別のタブはオープンでトランザクションを処理します。このタブを有効にすることができます。"
+msgid "Another tab is open and handles transactions."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
@@ -100,17 +100,17 @@ msgid "You need to connect a {blockchainName} wallet."
 msgstr "{blockchainName} ウォレットに接続する必要があります。"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:435
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
 msgstr "別のアドレスに送る"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:446
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
 msgstr "宛先アドレス"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:465
+#: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
 msgstr "アドレス {destination} はブロックチェーンアドレスパターンと一致しません。"
 
@@ -162,24 +162,24 @@ msgid "Cancel"
 msgstr "キャンセル"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:44
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
 msgstr "更新"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:60
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
 msgstr "通知"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:73
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:312
-#: widget/embedded/src/pages/SettingsPage.tsx:212
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
+#: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
 msgstr "設定"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:83
+#: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
 msgstr "取引履歴"
 
@@ -204,12 +204,13 @@ msgid "Swaps steps"
 msgstr "ステップを入れ替えます"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:25
+#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
 msgstr "再試行する"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:37
+#: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
+#: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
 msgstr "Reset"
 
@@ -219,71 +220,73 @@ msgid "There are no notifications."
 msgstr "通知はありません。"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:126
+#: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
 msgstr "スライドページエラー"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:127
+#: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
 msgstr "滑り止めの警告"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:231
+#: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
 msgstr "あなたの: {amount} {symbol}"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:252
+#: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
 msgstr "最小必要なスリップページは {minRequiredSlippage}です"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/Quote.tsx:325
+#: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
 msgstr "すべてのルートを見る"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:98
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
 msgstr "詳細情報を表示"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:108
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
 msgstr "ガス&料金の説明"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:121
-#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:88
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
+#: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
 msgstr "詳細"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:162
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
 msgstr "合計支払手数料"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:182
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
 msgstr "支払い不可能な手数料を非表示"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:183
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
 msgstr "未払い手数料を表示"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:193
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
 msgstr "説明"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:197
-msgid "The following fees are considered in the transaction output and\n"
+#: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
+msgid ""
+"The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
-msgstr "以下の手数料は取引の出力で考慮され、\n"
+msgstr ""
+"以下の手数料は取引の出力で考慮され、\n"
 "                余分なガスを支払う必要はありません。"
 
 #. js-lingui-explicit-id
@@ -297,14 +300,19 @@ msgid "Estimated output"
 msgstr "推定された出力"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteTrigger .tsx:77
+#: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
 msgstr "ビア:"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Quote/QuoteTrigger .tsx:160
+#: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
 msgstr "チェーン:"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/components/Quotes/Quotes.tsx:92
+msgid "Sort by"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
@@ -327,19 +335,19 @@ msgid "Price impact"
 msgstr "価格への影響"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:36
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
 msgstr "このルートについては、少なくとも {minRequiredSlippage} まで滑りやすくする必要があります。"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:60
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
 msgstr "このルートについては、少なくとも {minRequiredSlippage} への滑りを増やすことをお勧めします。"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:69
+#: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
 msgstr "注意、あなたの滑りは高いです。"
 
@@ -380,7 +388,7 @@ msgid "Slippage tolerance per swap"
 msgstr "スワップごとの滑り止め許容差"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/Slippage/Slippage.tsx:90
+#: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
 msgstr "カスタム"
 
@@ -534,7 +542,7 @@ msgid "Network Changed"
 msgstr "ネットワークを変更しました"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/components/TokenList/TokenList.tsx:257
+#: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
 msgstr "トークンを選択"
 
@@ -650,7 +658,7 @@ msgstr "不明なUSD価格を確認"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
-#: widget/embedded/src/pages/Home.tsx:155
+#: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
 msgstr "入れ替え"
 
@@ -690,29 +698,29 @@ msgid "Rango Fee"
 msgstr "Rango手数料"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:26
-msgid "Fastest Transfer"
-msgstr "最速送金"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:27
-msgid "Maximum Return"
-msgstr "最大返品数"
-
-#. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
+msgid "Smart Routing"
+msgstr "スマートルーティング"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
 msgstr "最低手数料"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:29
-msgid "Maximum Output"
-msgstr "最大出力"
+#: widget/embedded/src/constants/quote.ts:36
+msgid "Fastest Transfer"
+msgstr "最速送金"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/constants/quote.ts:30
-msgid "Smart Routing"
-msgstr "スマートルーティング"
+#: widget/embedded/src/constants/quote.ts:40
+msgid "Maximum Return"
+msgstr "最大返品数"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/constants/quote.ts:44
+msgid "Maximum Output"
+msgstr "最大出力"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
@@ -735,17 +743,84 @@ msgid "Route internal coins has been updated."
 msgstr "ルート内部コインが更新されました。"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:303
+#: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
+#: widget/embedded/src/pages/Routes.tsx:48
+msgid "Routes"
+msgstr "ルート"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Inputs/Inputs.tsx:77
+msgid "From"
+msgstr "差出人:"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Inputs/Inputs.tsx:120
+msgid "To"
+msgstr "終了日"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:47
+msgid "Light"
+msgstr "ライト"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:56
+msgid "Dark"
+msgstr "ダーク"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:65
+msgid "Auto"
+msgstr "自動"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:133
+msgid "Loading failed"
+msgstr "読み込みに失敗しました"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:149
+msgid "Enabled bridges"
+msgstr "有効なブリッジ"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:167
+msgid "Enabled exchanges"
+msgstr "有効な取引所"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:185
+#: widget/embedded/src/pages/LanguagePage.tsx:38
+msgid "Language"
+msgstr "言語"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:198
+msgid "Infinite approval"
+msgstr "永久承認"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:208
+msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
+msgstr "「Infinite承認」モードを有効にすると、DEX/Bridgesのスマートコントラクトへの無制限のアクセスが許可され、承認されたトークンの量を制限なく利用できます。"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/containers/Settings/Lists.tsx:228
+msgid "Theme"
+msgstr "テーマ"
+
+#. js-lingui-explicit-id
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
 msgstr "スワップの確認"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:333
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
 msgstr "スワップを開始"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/ConfirmSwapPage.tsx:359
+#: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
 msgstr "あなたは"
 
@@ -760,23 +835,7 @@ msgid "Search Transaction"
 msgstr "トランザクションを検索"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:172
-msgid "From"
-msgstr "差出人:"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/Home.tsx:213
-msgid "To"
-msgstr "終了日"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/LanguagePage.tsx:36
-#: widget/embedded/src/pages/SettingsPage.tsx:136
-msgid "Language"
-msgstr "言語"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/LanguagePage.tsx:43
+#: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
 msgstr "言語"
 
@@ -808,11 +867,6 @@ msgid "Search {sourceType}"
 msgstr "{sourceType} を検索"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/Routes.tsx:77
-msgid "Routes"
-msgstr "ルート"
-
-#. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
 msgstr "ブロックチェーンを検索"
@@ -838,39 +892,7 @@ msgid "Search Token"
 msgstr "トークンを検索"
 
 #. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:86
-msgid "Loading failed"
-msgstr "読み込みに失敗しました"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:102
-msgid "Enabled bridges"
-msgstr "有効なブリッジ"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:119
-msgid "Enabled exchanges"
-msgstr "有効な取引所"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:147
-#: widget/embedded/src/pages/ThemePage.tsx:70
-#: widget/embedded/src/pages/ThemePage.tsx:79
-msgid "Theme"
-msgstr "テーマ"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:159
-msgid "Infinite approval"
-msgstr "永久承認"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:169
-msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "「Infinite承認」モードを有効にすると、DEX/Bridgesのスマートコントラクトへの無制限のアクセスが許可され、承認されたトークンの量を制限なく利用できます。"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/SettingsPage.tsx:219
+#: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
 msgstr "現在、流動性情報源に制限があるキャンペーンモードです。 このモードを切り替えて、利用可能なすべての流動性源を使用しますか？"
 
@@ -878,21 +900,6 @@ msgstr "現在、流動性情報源に制限があるキャンペーンモード
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
 msgstr "スワップの詳細を表示するにはリクエスト ID が必要です。"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:34
-msgid "Light"
-msgstr "ライト"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:46
-msgid "Dark"
-msgstr "ダーク"
-
-#. js-lingui-explicit-id
-#: widget/embedded/src/pages/ThemePage.tsx:58
-msgid "Auto"
-msgstr "自動"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
@@ -1151,4 +1158,3 @@ msgstr "アセットの最大量"
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
 msgstr "スワップ先"
-

--- a/translations/nl.po
+++ b/translations/nl.po
@@ -1,22 +1,17 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-06 17:24+0330\n"
+"POT-Creation-Date: 2024-03-10 13:29+0330\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: pt\n"
-"Project-Id-Version: rango\n"
+"Language: nl\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-02-20 09:32\n"
+"PO-Revision-Date: \n"
 "Last-Translator: \n"
-"Language-Team: Portuguese\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: rango\n"
-"X-Crowdin-Project-ID: 622238\n"
-"X-Crowdin-Language: pt-PT\n"
-"X-Crowdin-File: en.po\n"
-"X-Crowdin-File-ID: 30\n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
@@ -24,7 +19,7 @@ msgstr ""
 #: widget/embedded/src/pages/HistoryPage.tsx:85
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:131
 msgid "No results found"
-msgstr "Nenhum resultado encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:38
@@ -32,24 +27,24 @@ msgstr "Nenhum resultado encontrado"
 #: widget/embedded/src/pages/HistoryPage.tsx:87
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:132
 msgid "Try using different keywords"
-msgstr "Tente usar palavras-chave diferentes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:66
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:46
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:40
 msgid "Select Blockchain"
-msgstr "Selecione a Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:66
 msgid "All"
-msgstr "TODOS"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:100
 msgid "More +{count}"
-msgstr "Mais +{count}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
@@ -64,221 +59,221 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
 msgid "Activate current tab"
-msgstr "Ativar a aba atual"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:22
 msgid "Currently, some transactions are running and being handled by other browser tab. If you activate this tab, all transactions that are already in the transaction sign step will expire."
-msgstr "No momento, algumas transações estão sendo executadas e sendo tratadas por outra aba do navegador. Se você ativar essa aba, todas as transações que já estão na etapa de sinal de transação irão expirar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:32
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:269
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:237
 msgid "Confirm"
-msgstr "Confirmar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:284
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:359
 msgid "Your {blockchainName} wallets"
-msgstr "Suas carteiras {blockchainName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:303
 msgid "Insufficient account balance"
-msgstr "Saldo de conta insuficiente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:312
 msgid "Proceed anyway"
-msgstr "Continuar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:368
 msgid "You need to connect a {blockchainName} wallet."
-msgstr "Você precisa conectar uma carteira {blockchainName}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
-msgstr "Enviar para outro endereço"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
-msgstr "Seu endereço de destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
-msgstr "O endereço {destination} não corresponde ao padrão do endereço da blockchain."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:168
 msgid "Add {chain} chain"
-msgstr "Adiciona cadeia {chain}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:217
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:250
 msgid "Add {blockchainDisplayName} Chain"
-msgstr "Adicionar Corrente {blockchainDisplayName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:222
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:254
 msgid "You should connect a {blockchainDisplayName} supported wallet or choose a different {blockchainDisplayName} address"
-msgstr "Você deve conectar uma carteira com suporte do {blockchainDisplayName} ou escolher um endereço {blockchainDisplayName} diferente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:272
 msgid "{blockchainDisplayName} Chain Added"
-msgstr "{blockchainDisplayName} Cadeia Adicionada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:276
 msgid "{blockchainDisplayName} is added to your wallet, you can use it to swap."
-msgstr "{blockchainDisplayName} foi adicionado à sua carteira, você pode usá-lo para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:286
 msgid "Request Rejected"
-msgstr "Pedido rejeitado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:287
 msgid "You've rejected adding {blockchainDisplayName} chain to your wallet."
-msgstr "Você rejeitou adicionar {blockchainDisplayName} corrente à sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:311
 msgid "Show more wallets"
-msgstr "Mostrar mais carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/CancelButton.tsx:14
 msgid "Cancel"
-msgstr "cancelar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
-msgstr "atualizar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
-msgstr "notificações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
 #: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
-msgstr "Confirgurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
-msgstr "Histórico de transações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/WalletButton.tsx:14
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:16
 #: widget/embedded/src/constants/messages.ts:5
 msgid "Connect Wallet"
-msgstr "Conectar Carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx:118
 #: widget/embedded/src/utils/date.ts:18
 #: widget/embedded/src/utils/time.ts:22
 msgid "Today"
-msgstr "hoje"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:375
 msgid "Swaps steps"
-msgstr "Etapas de troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
-msgstr "Repetir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
 #: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NotificationContent/NotificationNotFound.tsx:13
 msgid "There are no notifications."
-msgstr "Não há notificações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
-msgstr "Erro Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
-msgstr "Aviso Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
-msgstr "Sua: {amount} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
-msgstr "Mínimo de slippage necessário é {minRequiredSlippage}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
-msgstr "Ver todas as rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
-msgstr "Ver mais informações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
-msgstr "Explicação de Gás e Taxa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
-msgstr "detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
-msgstr "Taxa total a pagar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
-msgstr "Ocultar taxas não-pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
-msgstr "Mostrar tarifas não pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
-msgstr "Descrição:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
@@ -286,28 +281,26 @@ msgid ""
 "The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
 msgstr ""
-"As seguintes tarifas são consideradas no resultado da transação e\n"
-"                você não precisará pagar gás extra por elas."
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:25
 msgid "Swap input"
-msgstr "Swap input"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:44
 msgid "Estimated output"
-msgstr "Saída estimada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
-msgstr "Via:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
-msgstr "Correntas:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quotes/Quotes.tsx:92
@@ -317,720 +310,720 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
 msgid "Swapping"
-msgstr "Swapping"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:51
 msgid "Gas cost"
-msgstr "Custo de gás"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:59
 msgid "Receiving"
-msgstr "Recebimento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:67
 msgid "Price impact"
-msgstr "Impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Você precisa aumentar o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Recomendamos que você aumente o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
-msgstr "Cuidado, seu slippage está alto."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx:73
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:25
 msgid "Change"
-msgstr "Troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:41
 msgid "Change settings"
-msgstr "Alterar configurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:51
 msgid "High slippage"
-msgstr "Alto slide"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:52
 msgid "Low slippage"
-msgstr "Slippage Baixo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:56
 msgid " Caution, your slippage is high (={userSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={userSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:76
 msgid "Confirm anyway"
-msgstr "Confirmar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:35
 msgid "Slippage tolerance per swap"
-msgstr "Tolerância do slippage por swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
-msgstr "Personalizado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:11
 msgid "Your transaction will be reverted if the price changes unfavorably by more than this percentage"
-msgstr "Sua transação será revertida se o preço mudar desfavoravelmente, mais do que esta porcentagem"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:16
 msgid "Warning"
-msgstr "ATENÇÃO"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:17
 msgid "This setting is applied per step (e.g. 1Inch, Thorchain, etc) which means only the step will be reverted, not the whole transaction."
-msgstr "Essa configuração é aplicada por passo (por exemplo, 1Inch, Thorchain, etc), que significa que apenas o passo será revertido, não toda a transação."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:25
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:246
 msgid "Swap and Bridge"
-msgstr "Inverter e Ponte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:33
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:286
 msgid "Request ID"
-msgstr "Solicitar ID"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:64
 msgid "Not found"
-msgstr "Não encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:65
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:39
 msgid "Swap with request ID = {requestId} not found."
-msgstr "Trocar com o ID de requisição = {requestId} não encontrado."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:214
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
-msgstr "Você recebeu {amount} {token} em carteira {conciseAddress} na cadeia {chain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:230
 msgid "Transaction was not sent."
-msgstr "Transação não foi enviada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:232
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
-msgstr "{amount} {symbol} em {blockchain} permanece em sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:257
 msgid "Delete"
-msgstr "excluir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:278
 msgid "Try again"
-msgstr "Tente novamente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx:50
 msgid "View transaction"
-msgstr "Ver transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:47
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:31
 msgid "Connect"
-msgstr "Conectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:43
 msgid "Swap Successful"
-msgstr "Troca bem sucedida"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:71
 msgid "Transaction Failed"
-msgstr "Transação Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:86
 msgid "Done"
-msgstr "Concluído"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:98
 msgid "Diagnosis"
-msgstr "Diagnóstico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:105
 msgid "See Details"
-msgstr "Ver Detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:13
 msgid "Cancel Swap"
-msgstr "Cancelar Swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:14
 msgid "Are you sure you want to cancel this swap?"
-msgstr "Tem certeza que deseja cancelar este swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:22
 msgid "Yes, Cancel it"
-msgstr "Sim, Cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:26
 msgid "No, Continue"
-msgstr "Não, continuar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:13
 msgid "Delete Transaction"
-msgstr "Excluir Transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:14
 msgid "Are you sure you want to delete this swap?"
-msgstr "Tem certeza que deseja excluir esta troca?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:22
 msgid "Yes, Delete it"
-msgstr "Sim, exclua-o"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:27
 msgid "No, Cancel"
-msgstr "Não, cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:12
 msgid "Change Network"
-msgstr "Alterar rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:20
 msgid "Network Changed"
-msgstr "Rede alterada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
-msgstr "Selecione o Token"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:19
 msgid "Wallet Connected"
-msgstr "Carteira conectada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:20
 msgid "Your wallet is connected, you can use it to swap."
-msgstr "Sua carteira está conectada, você pode usá-la para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:31
 msgid "Failed to Connect"
-msgstr "Falha na conexão"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:33
 msgid "Your wallet is not connected. Please try again."
-msgstr "Sua carteira não está conectada. Por favor, tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:42
 msgid "Connecting to your wallet"
-msgstr "Conectando-se à sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:43
 msgid "Click connect in your wallet popup."
-msgstr "Clique em conectar no pop-up da sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:9
 msgid "Failed Network, Please retry your swap."
-msgstr "Falha na Rede, tente novamente sua alternância."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:11
 msgid "Please reset your liquidity sources."
-msgstr "Por favor, redefina suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:12
 msgid "You have limited the liquidity sources and this might result in Rango finding no routes. Please consider resetting your liquidity sources."
-msgstr "Você limitou as fontes de liquidez e isso pode resultar em que o Rango não encontre nenhuma rota. Por favor, considere redefinir suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:17
 msgid "No Routes Found."
-msgstr "Nenhuma rota encontrada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:18
 msgid "Reasons why Rango couldn't find a route: low liquidity on token, very low input amount or no routes available for the selected input/output token combination."
-msgstr "Motivos porque Rango não conseguiu encontrar uma rota: baixa liquidez no token, quantidade muito baixa de entrada ou nenhuma rota disponível para a combinação selecionada de entrada/saída do token."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:23
 msgid "Bridge Limit Error: Please increase your amount."
-msgstr "Erro no limite da ponte: Por favor, aumente o seu valor."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:26
 msgid "Bridge Limit Error: Please decrease your amount."
-msgstr "Erro no limite da ponte: Por favor, reduza seu montante."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:31
 msgid "High Price Impact"
-msgstr "Impacto de preço alto"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:32
 msgid "Price impact is too high!"
-msgstr "O impacto nos preços é muito alto!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:33
 msgid "The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap."
-msgstr "O impacto no preço é significativamente maior do que o valor permitido. Se você tem certeza, continue, caso contrário, altere o swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:36
 msgid "Confirm high price impact"
-msgstr "Confirmar alto impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:39
 msgid "Route updated and price impact is too high, try again later!"
-msgstr "A rota atualizada e o impacto nos preços é muito alto, tente novamente mais tarde!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:44
 msgid "USD Price Unknown"
-msgstr "Preço em USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:45
 msgid "USD Price Unknown, Cannot calculate Price Impact."
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto de preços."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:46
 msgid "USD Price Unknown, Cannot calculate Price Impact. The price impact may be higher than usual. Are you sure to continue the Swap?"
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto do preço. O impacto do preço pode ser maior do que o normal. Tem certeza que deseja continuar o Swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:49
 msgid "Confirm USD Price Unknown"
-msgstr "Confirmar preço de USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
 #: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
-msgstr "Trocar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:7
 msgid "Swap anyway"
-msgstr "Trocar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:8
 msgid "The route goes through Ethereum. Continue?"
-msgstr "A rota passa pelo Ethereum. Continuar?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:13
 msgid "Network Fee"
-msgstr "Taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:14
 msgid "Protocol Fee"
-msgstr "Taxa do Protocolo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:15
 msgid "Affiliate Fee"
-msgstr "Taxa de afiliado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:16
 msgid "Outbound Fee"
-msgstr "Taxa de Saída"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:17
 msgid "Rango Fee"
-msgstr "Taxa de Rango"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
 msgid "Smart Routing"
-msgstr "Roteamento inteligente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
-msgstr "Taxa mais baixa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:36
 msgid "Fastest Transfer"
-msgstr "Mais Rápido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:40
 msgid "Maximum Return"
-msgstr "Retorno Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:44
 msgid "Maximum Output"
-msgstr "Produção Máxima"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
 msgid "Route has been updated."
-msgstr "Rota foi atualizada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:12
 msgid "Output amount changed to {newOutputAmount} ({percentageChange}% change)."
-msgstr "Valor de saída alterado para {newOutputAmount} ( Alteração de{percentageChange}%)."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:20
 msgid "Route swappers has been updated."
-msgstr "Os trocadores de rota foram atualizados."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:22
 msgid "Route internal coins has been updated."
-msgstr "Moedas internas do itinerário foram atualizadas."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
 #: widget/embedded/src/pages/Routes.tsx:48
 msgid "Routes"
-msgstr "Rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:77
 msgid "From"
-msgstr "De"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:120
 msgid "To"
-msgstr "Para"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:47
 msgid "Light"
-msgstr "Fino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:56
 msgid "Dark"
-msgstr "Escuro"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:65
 msgid "Auto"
-msgstr "Automático"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:133
 msgid "Loading failed"
-msgstr "Falha no carregamento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:149
 msgid "Enabled bridges"
-msgstr "Pontes habilitados"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:167
 msgid "Enabled exchanges"
-msgstr "Trocas ativadas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:185
 #: widget/embedded/src/pages/LanguagePage.tsx:38
 msgid "Language"
-msgstr "IDIOMA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:198
 msgid "Infinite approval"
-msgstr "Aprovação infinita"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:208
 msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Ativar o modo de 'aprovação infinita' concede acesso irrestrito a contratos inteligentes de DEXes/Bridges, permitindo-lhes utilizar o valor do token aprovado, sem limitações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:228
 msgid "Theme"
-msgstr "Tema"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
-msgstr "Confirmar troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
-msgstr "Trocar de início"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
-msgstr "Você recebe"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:67
 msgid "History"
-msgstr "Histórico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:74
 msgid "Search Transaction"
-msgstr "Pesquisar transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
-msgstr "Idioma"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:151
 msgid "Exchanges"
-msgstr "Trocas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:112
 msgid "Bridges"
-msgstr "Pontes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Deselect all"
-msgstr "Desmarcar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Select all"
-msgstr "Selecionar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:121
 msgid "Search {sourceType}"
-msgstr "Pesquisar em {sourceType}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
-msgstr "Pesquisar Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:72
 msgid "Source"
-msgstr "fonte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:73
 msgid "Destination"
-msgstr "Destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:79
 msgid "Swap {type}"
-msgstr "Trocar {type}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:95
 msgid "Search Token"
-msgstr "Token de pesquisa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
-msgstr "Atualmente, você está no modo campanha com restrições sobre fontes de liquidez. Gostaria de mudar este modo e usar todas as fontes de liquidez disponíveis?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
-msgstr "O ID da requisição é necessário para exibir os detalhes do swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
 #: widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx:30
 msgid "Connect Wallets"
-msgstr "Conectar Carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:76
 msgid "Choose a wallet to connect."
-msgstr "Escolha uma carteira para se conectar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:25
 msgid "This week"
-msgstr "Esta semana"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:32
 msgid "This month"
-msgstr "Este Mês"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:39
 msgid "This year"
-msgstr "Esse ano"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:125
 msgid "Required: >= {min} {symbol}"
-msgstr "Obrigatório: >= {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:138
 msgid "Required: > {min} {symbol}"
-msgstr "Obrigatório: > {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:153
 msgid "Required: <= {max} {symbol}"
-msgstr "Obrigatório: <= {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:166
 msgid "Required: < {max} {symbol}"
-msgstr "Obrigatório: < {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:634
 msgid " for network fee"
-msgstr " para taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:637
 msgid " for swap"
-msgstr " para troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:640
 msgid " for input and network fee"
-msgstr " por taxa de entrada e de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:642
 msgid "Needs ≈ {requiredAmount} {symbol}{reason}, but you have {currentAmount} {symbol} in your {blockchain} wallet."
-msgstr "Precisa de {requiredAmount} {symbol}{reason}, mas você tem {currentAmount} {symbol} na sua carteira {blockchain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:702
 msgid "Waiting for connecting wallet"
-msgstr "Aguardando conexão da carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:706
 msgid "Waiting for other running tasks to be finished"
-msgstr "Aguardando o término de outras tarefas em execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:709
 msgid "Waiting for changing wallet network"
-msgstr "Aguardando mudança da rede de carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:6
 msgid "Sunday"
-msgstr "domingo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:7
 msgid "Monday"
-msgstr "Segunda-Feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:8
 msgid "Tuesday"
-msgstr "Terça-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:9
 msgid "Wednesday"
-msgstr "quarta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:10
 msgid "Thursday"
-msgstr "quinta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:11
 msgid "Friday"
-msgstr "Sexta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:12
 msgid "Saturday"
-msgstr "sábado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
-msgstr " Erro ao conectar ao servidor, por favor recarregue o app e tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/BottomLogo/BottomLogo.tsx:14
 msgid "Powered By"
-msgstr "Desenvolvido por"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/ChangeSlippageButton/ChangeSlippageButton.tsx:14
 msgid "Change Slippage"
-msgstr "Alterar Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx:63
@@ -1041,120 +1034,120 @@ msgstr ""
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:74
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:100
 msgid "Swap on {fromChain} via {swapper}"
-msgstr "Trocar em {fromChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:107
 msgid "Bridge to {toChain} via {swapper}"
-msgstr "Ponte para {toChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:28
 msgid "Swap Details"
-msgstr "Trocar detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:8
 msgid "Failed"
-msgstr "Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:10
 msgid "Complete"
-msgstr "Complete"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:12
 msgid "In progress"
-msgstr "Em Execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapToken.tsx:122
 msgid "Waiting for bridge transaction"
-msgstr "Aguardando a transação da bridge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:150
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:56
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:235
 msgid "Chain"
-msgstr "Corrente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:168
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:49
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:259
 msgid "Token"
-msgstr "Identificador"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:12
 msgid "Connected"
-msgstr "Conectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:13
 msgid "Disconnect"
-msgstr "Desconectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:18
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:19
 msgid "Install"
-msgstr "Instale"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:24
 msgid "Connecting..."
-msgstr "Conectandochar@@0"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:25
 msgid "Connecting"
-msgstr "Conectando"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:30
 msgid "Disconnected"
-msgstr "Desconectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:34
 msgid "you need to pass a correct state to Wallet."
-msgstr "você precisa passar um estado correto para o Wallet."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/HomePanel/HomePanel.tsx:123
 msgid "SWAP"
-msgstr "TROCA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
-msgstr "Saldo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:62
 msgid "Max"
-msgstr "Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={selectedSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:179
 msgid "swap from"
-msgstr "trocar de"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:198
 msgid "maximum amount of asset"
-msgstr "quantidade máxima de ativos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
-msgstr "trocar para"
+msgstr ""

--- a/translations/pl.po
+++ b/translations/pl.po
@@ -1,22 +1,17 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-06 17:24+0330\n"
+"POT-Creation-Date: 2024-03-10 13:29+0330\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: pt\n"
-"Project-Id-Version: rango\n"
+"Language: pl\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-02-20 09:32\n"
+"PO-Revision-Date: \n"
 "Last-Translator: \n"
-"Language-Team: Portuguese\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: rango\n"
-"X-Crowdin-Project-ID: 622238\n"
-"X-Crowdin-Language: pt-PT\n"
-"X-Crowdin-File: en.po\n"
-"X-Crowdin-File-ID: 30\n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
@@ -24,7 +19,7 @@ msgstr ""
 #: widget/embedded/src/pages/HistoryPage.tsx:85
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:131
 msgid "No results found"
-msgstr "Nenhum resultado encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:38
@@ -32,24 +27,24 @@ msgstr "Nenhum resultado encontrado"
 #: widget/embedded/src/pages/HistoryPage.tsx:87
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:132
 msgid "Try using different keywords"
-msgstr "Tente usar palavras-chave diferentes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:66
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:46
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:40
 msgid "Select Blockchain"
-msgstr "Selecione a Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:66
 msgid "All"
-msgstr "TODOS"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:100
 msgid "More +{count}"
-msgstr "Mais +{count}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
@@ -64,221 +59,221 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
 msgid "Activate current tab"
-msgstr "Ativar a aba atual"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:22
 msgid "Currently, some transactions are running and being handled by other browser tab. If you activate this tab, all transactions that are already in the transaction sign step will expire."
-msgstr "No momento, algumas transações estão sendo executadas e sendo tratadas por outra aba do navegador. Se você ativar essa aba, todas as transações que já estão na etapa de sinal de transação irão expirar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:32
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:269
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:237
 msgid "Confirm"
-msgstr "Confirmar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:284
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:359
 msgid "Your {blockchainName} wallets"
-msgstr "Suas carteiras {blockchainName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:303
 msgid "Insufficient account balance"
-msgstr "Saldo de conta insuficiente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:312
 msgid "Proceed anyway"
-msgstr "Continuar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:368
 msgid "You need to connect a {blockchainName} wallet."
-msgstr "Você precisa conectar uma carteira {blockchainName}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
-msgstr "Enviar para outro endereço"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
-msgstr "Seu endereço de destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
-msgstr "O endereço {destination} não corresponde ao padrão do endereço da blockchain."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:168
 msgid "Add {chain} chain"
-msgstr "Adiciona cadeia {chain}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:217
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:250
 msgid "Add {blockchainDisplayName} Chain"
-msgstr "Adicionar Corrente {blockchainDisplayName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:222
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:254
 msgid "You should connect a {blockchainDisplayName} supported wallet or choose a different {blockchainDisplayName} address"
-msgstr "Você deve conectar uma carteira com suporte do {blockchainDisplayName} ou escolher um endereço {blockchainDisplayName} diferente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:272
 msgid "{blockchainDisplayName} Chain Added"
-msgstr "{blockchainDisplayName} Cadeia Adicionada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:276
 msgid "{blockchainDisplayName} is added to your wallet, you can use it to swap."
-msgstr "{blockchainDisplayName} foi adicionado à sua carteira, você pode usá-lo para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:286
 msgid "Request Rejected"
-msgstr "Pedido rejeitado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:287
 msgid "You've rejected adding {blockchainDisplayName} chain to your wallet."
-msgstr "Você rejeitou adicionar {blockchainDisplayName} corrente à sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:311
 msgid "Show more wallets"
-msgstr "Mostrar mais carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/CancelButton.tsx:14
 msgid "Cancel"
-msgstr "cancelar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
-msgstr "atualizar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
-msgstr "notificações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
 #: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
-msgstr "Confirgurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
-msgstr "Histórico de transações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/WalletButton.tsx:14
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:16
 #: widget/embedded/src/constants/messages.ts:5
 msgid "Connect Wallet"
-msgstr "Conectar Carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx:118
 #: widget/embedded/src/utils/date.ts:18
 #: widget/embedded/src/utils/time.ts:22
 msgid "Today"
-msgstr "hoje"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:375
 msgid "Swaps steps"
-msgstr "Etapas de troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
-msgstr "Repetir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
 #: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NotificationContent/NotificationNotFound.tsx:13
 msgid "There are no notifications."
-msgstr "Não há notificações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
-msgstr "Erro Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
-msgstr "Aviso Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
-msgstr "Sua: {amount} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
-msgstr "Mínimo de slippage necessário é {minRequiredSlippage}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
-msgstr "Ver todas as rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
-msgstr "Ver mais informações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
-msgstr "Explicação de Gás e Taxa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
-msgstr "detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
-msgstr "Taxa total a pagar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
-msgstr "Ocultar taxas não-pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
-msgstr "Mostrar tarifas não pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
-msgstr "Descrição:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
@@ -286,28 +281,26 @@ msgid ""
 "The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
 msgstr ""
-"As seguintes tarifas são consideradas no resultado da transação e\n"
-"                você não precisará pagar gás extra por elas."
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:25
 msgid "Swap input"
-msgstr "Swap input"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:44
 msgid "Estimated output"
-msgstr "Saída estimada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
-msgstr "Via:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
-msgstr "Correntas:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quotes/Quotes.tsx:92
@@ -317,720 +310,720 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
 msgid "Swapping"
-msgstr "Swapping"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:51
 msgid "Gas cost"
-msgstr "Custo de gás"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:59
 msgid "Receiving"
-msgstr "Recebimento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:67
 msgid "Price impact"
-msgstr "Impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Você precisa aumentar o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Recomendamos que você aumente o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
-msgstr "Cuidado, seu slippage está alto."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx:73
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:25
 msgid "Change"
-msgstr "Troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:41
 msgid "Change settings"
-msgstr "Alterar configurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:51
 msgid "High slippage"
-msgstr "Alto slide"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:52
 msgid "Low slippage"
-msgstr "Slippage Baixo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:56
 msgid " Caution, your slippage is high (={userSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={userSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:76
 msgid "Confirm anyway"
-msgstr "Confirmar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:35
 msgid "Slippage tolerance per swap"
-msgstr "Tolerância do slippage por swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
-msgstr "Personalizado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:11
 msgid "Your transaction will be reverted if the price changes unfavorably by more than this percentage"
-msgstr "Sua transação será revertida se o preço mudar desfavoravelmente, mais do que esta porcentagem"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:16
 msgid "Warning"
-msgstr "ATENÇÃO"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:17
 msgid "This setting is applied per step (e.g. 1Inch, Thorchain, etc) which means only the step will be reverted, not the whole transaction."
-msgstr "Essa configuração é aplicada por passo (por exemplo, 1Inch, Thorchain, etc), que significa que apenas o passo será revertido, não toda a transação."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:25
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:246
 msgid "Swap and Bridge"
-msgstr "Inverter e Ponte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:33
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:286
 msgid "Request ID"
-msgstr "Solicitar ID"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:64
 msgid "Not found"
-msgstr "Não encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:65
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:39
 msgid "Swap with request ID = {requestId} not found."
-msgstr "Trocar com o ID de requisição = {requestId} não encontrado."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:214
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
-msgstr "Você recebeu {amount} {token} em carteira {conciseAddress} na cadeia {chain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:230
 msgid "Transaction was not sent."
-msgstr "Transação não foi enviada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:232
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
-msgstr "{amount} {symbol} em {blockchain} permanece em sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:257
 msgid "Delete"
-msgstr "excluir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:278
 msgid "Try again"
-msgstr "Tente novamente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx:50
 msgid "View transaction"
-msgstr "Ver transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:47
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:31
 msgid "Connect"
-msgstr "Conectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:43
 msgid "Swap Successful"
-msgstr "Troca bem sucedida"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:71
 msgid "Transaction Failed"
-msgstr "Transação Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:86
 msgid "Done"
-msgstr "Concluído"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:98
 msgid "Diagnosis"
-msgstr "Diagnóstico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:105
 msgid "See Details"
-msgstr "Ver Detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:13
 msgid "Cancel Swap"
-msgstr "Cancelar Swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:14
 msgid "Are you sure you want to cancel this swap?"
-msgstr "Tem certeza que deseja cancelar este swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:22
 msgid "Yes, Cancel it"
-msgstr "Sim, Cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:26
 msgid "No, Continue"
-msgstr "Não, continuar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:13
 msgid "Delete Transaction"
-msgstr "Excluir Transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:14
 msgid "Are you sure you want to delete this swap?"
-msgstr "Tem certeza que deseja excluir esta troca?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:22
 msgid "Yes, Delete it"
-msgstr "Sim, exclua-o"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:27
 msgid "No, Cancel"
-msgstr "Não, cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:12
 msgid "Change Network"
-msgstr "Alterar rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:20
 msgid "Network Changed"
-msgstr "Rede alterada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
-msgstr "Selecione o Token"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:19
 msgid "Wallet Connected"
-msgstr "Carteira conectada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:20
 msgid "Your wallet is connected, you can use it to swap."
-msgstr "Sua carteira está conectada, você pode usá-la para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:31
 msgid "Failed to Connect"
-msgstr "Falha na conexão"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:33
 msgid "Your wallet is not connected. Please try again."
-msgstr "Sua carteira não está conectada. Por favor, tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:42
 msgid "Connecting to your wallet"
-msgstr "Conectando-se à sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:43
 msgid "Click connect in your wallet popup."
-msgstr "Clique em conectar no pop-up da sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:9
 msgid "Failed Network, Please retry your swap."
-msgstr "Falha na Rede, tente novamente sua alternância."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:11
 msgid "Please reset your liquidity sources."
-msgstr "Por favor, redefina suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:12
 msgid "You have limited the liquidity sources and this might result in Rango finding no routes. Please consider resetting your liquidity sources."
-msgstr "Você limitou as fontes de liquidez e isso pode resultar em que o Rango não encontre nenhuma rota. Por favor, considere redefinir suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:17
 msgid "No Routes Found."
-msgstr "Nenhuma rota encontrada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:18
 msgid "Reasons why Rango couldn't find a route: low liquidity on token, very low input amount or no routes available for the selected input/output token combination."
-msgstr "Motivos porque Rango não conseguiu encontrar uma rota: baixa liquidez no token, quantidade muito baixa de entrada ou nenhuma rota disponível para a combinação selecionada de entrada/saída do token."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:23
 msgid "Bridge Limit Error: Please increase your amount."
-msgstr "Erro no limite da ponte: Por favor, aumente o seu valor."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:26
 msgid "Bridge Limit Error: Please decrease your amount."
-msgstr "Erro no limite da ponte: Por favor, reduza seu montante."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:31
 msgid "High Price Impact"
-msgstr "Impacto de preço alto"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:32
 msgid "Price impact is too high!"
-msgstr "O impacto nos preços é muito alto!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:33
 msgid "The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap."
-msgstr "O impacto no preço é significativamente maior do que o valor permitido. Se você tem certeza, continue, caso contrário, altere o swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:36
 msgid "Confirm high price impact"
-msgstr "Confirmar alto impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:39
 msgid "Route updated and price impact is too high, try again later!"
-msgstr "A rota atualizada e o impacto nos preços é muito alto, tente novamente mais tarde!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:44
 msgid "USD Price Unknown"
-msgstr "Preço em USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:45
 msgid "USD Price Unknown, Cannot calculate Price Impact."
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto de preços."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:46
 msgid "USD Price Unknown, Cannot calculate Price Impact. The price impact may be higher than usual. Are you sure to continue the Swap?"
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto do preço. O impacto do preço pode ser maior do que o normal. Tem certeza que deseja continuar o Swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:49
 msgid "Confirm USD Price Unknown"
-msgstr "Confirmar preço de USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
 #: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
-msgstr "Trocar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:7
 msgid "Swap anyway"
-msgstr "Trocar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:8
 msgid "The route goes through Ethereum. Continue?"
-msgstr "A rota passa pelo Ethereum. Continuar?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:13
 msgid "Network Fee"
-msgstr "Taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:14
 msgid "Protocol Fee"
-msgstr "Taxa do Protocolo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:15
 msgid "Affiliate Fee"
-msgstr "Taxa de afiliado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:16
 msgid "Outbound Fee"
-msgstr "Taxa de Saída"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:17
 msgid "Rango Fee"
-msgstr "Taxa de Rango"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
 msgid "Smart Routing"
-msgstr "Roteamento inteligente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
-msgstr "Taxa mais baixa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:36
 msgid "Fastest Transfer"
-msgstr "Mais Rápido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:40
 msgid "Maximum Return"
-msgstr "Retorno Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:44
 msgid "Maximum Output"
-msgstr "Produção Máxima"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
 msgid "Route has been updated."
-msgstr "Rota foi atualizada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:12
 msgid "Output amount changed to {newOutputAmount} ({percentageChange}% change)."
-msgstr "Valor de saída alterado para {newOutputAmount} ( Alteração de{percentageChange}%)."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:20
 msgid "Route swappers has been updated."
-msgstr "Os trocadores de rota foram atualizados."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:22
 msgid "Route internal coins has been updated."
-msgstr "Moedas internas do itinerário foram atualizadas."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
 #: widget/embedded/src/pages/Routes.tsx:48
 msgid "Routes"
-msgstr "Rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:77
 msgid "From"
-msgstr "De"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:120
 msgid "To"
-msgstr "Para"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:47
 msgid "Light"
-msgstr "Fino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:56
 msgid "Dark"
-msgstr "Escuro"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:65
 msgid "Auto"
-msgstr "Automático"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:133
 msgid "Loading failed"
-msgstr "Falha no carregamento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:149
 msgid "Enabled bridges"
-msgstr "Pontes habilitados"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:167
 msgid "Enabled exchanges"
-msgstr "Trocas ativadas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:185
 #: widget/embedded/src/pages/LanguagePage.tsx:38
 msgid "Language"
-msgstr "IDIOMA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:198
 msgid "Infinite approval"
-msgstr "Aprovação infinita"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:208
 msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Ativar o modo de 'aprovação infinita' concede acesso irrestrito a contratos inteligentes de DEXes/Bridges, permitindo-lhes utilizar o valor do token aprovado, sem limitações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:228
 msgid "Theme"
-msgstr "Tema"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
-msgstr "Confirmar troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
-msgstr "Trocar de início"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
-msgstr "Você recebe"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:67
 msgid "History"
-msgstr "Histórico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:74
 msgid "Search Transaction"
-msgstr "Pesquisar transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
-msgstr "Idioma"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:151
 msgid "Exchanges"
-msgstr "Trocas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:112
 msgid "Bridges"
-msgstr "Pontes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Deselect all"
-msgstr "Desmarcar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Select all"
-msgstr "Selecionar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:121
 msgid "Search {sourceType}"
-msgstr "Pesquisar em {sourceType}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
-msgstr "Pesquisar Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:72
 msgid "Source"
-msgstr "fonte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:73
 msgid "Destination"
-msgstr "Destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:79
 msgid "Swap {type}"
-msgstr "Trocar {type}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:95
 msgid "Search Token"
-msgstr "Token de pesquisa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
-msgstr "Atualmente, você está no modo campanha com restrições sobre fontes de liquidez. Gostaria de mudar este modo e usar todas as fontes de liquidez disponíveis?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
-msgstr "O ID da requisição é necessário para exibir os detalhes do swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
 #: widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx:30
 msgid "Connect Wallets"
-msgstr "Conectar Carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:76
 msgid "Choose a wallet to connect."
-msgstr "Escolha uma carteira para se conectar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:25
 msgid "This week"
-msgstr "Esta semana"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:32
 msgid "This month"
-msgstr "Este Mês"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:39
 msgid "This year"
-msgstr "Esse ano"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:125
 msgid "Required: >= {min} {symbol}"
-msgstr "Obrigatório: >= {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:138
 msgid "Required: > {min} {symbol}"
-msgstr "Obrigatório: > {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:153
 msgid "Required: <= {max} {symbol}"
-msgstr "Obrigatório: <= {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:166
 msgid "Required: < {max} {symbol}"
-msgstr "Obrigatório: < {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:634
 msgid " for network fee"
-msgstr " para taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:637
 msgid " for swap"
-msgstr " para troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:640
 msgid " for input and network fee"
-msgstr " por taxa de entrada e de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:642
 msgid "Needs ≈ {requiredAmount} {symbol}{reason}, but you have {currentAmount} {symbol} in your {blockchain} wallet."
-msgstr "Precisa de {requiredAmount} {symbol}{reason}, mas você tem {currentAmount} {symbol} na sua carteira {blockchain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:702
 msgid "Waiting for connecting wallet"
-msgstr "Aguardando conexão da carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:706
 msgid "Waiting for other running tasks to be finished"
-msgstr "Aguardando o término de outras tarefas em execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:709
 msgid "Waiting for changing wallet network"
-msgstr "Aguardando mudança da rede de carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:6
 msgid "Sunday"
-msgstr "domingo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:7
 msgid "Monday"
-msgstr "Segunda-Feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:8
 msgid "Tuesday"
-msgstr "Terça-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:9
 msgid "Wednesday"
-msgstr "quarta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:10
 msgid "Thursday"
-msgstr "quinta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:11
 msgid "Friday"
-msgstr "Sexta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:12
 msgid "Saturday"
-msgstr "sábado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
-msgstr " Erro ao conectar ao servidor, por favor recarregue o app e tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/BottomLogo/BottomLogo.tsx:14
 msgid "Powered By"
-msgstr "Desenvolvido por"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/ChangeSlippageButton/ChangeSlippageButton.tsx:14
 msgid "Change Slippage"
-msgstr "Alterar Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx:63
@@ -1041,120 +1034,120 @@ msgstr ""
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:74
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:100
 msgid "Swap on {fromChain} via {swapper}"
-msgstr "Trocar em {fromChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:107
 msgid "Bridge to {toChain} via {swapper}"
-msgstr "Ponte para {toChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:28
 msgid "Swap Details"
-msgstr "Trocar detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:8
 msgid "Failed"
-msgstr "Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:10
 msgid "Complete"
-msgstr "Complete"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:12
 msgid "In progress"
-msgstr "Em Execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapToken.tsx:122
 msgid "Waiting for bridge transaction"
-msgstr "Aguardando a transação da bridge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:150
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:56
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:235
 msgid "Chain"
-msgstr "Corrente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:168
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:49
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:259
 msgid "Token"
-msgstr "Identificador"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:12
 msgid "Connected"
-msgstr "Conectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:13
 msgid "Disconnect"
-msgstr "Desconectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:18
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:19
 msgid "Install"
-msgstr "Instale"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:24
 msgid "Connecting..."
-msgstr "Conectandochar@@0"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:25
 msgid "Connecting"
-msgstr "Conectando"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:30
 msgid "Disconnected"
-msgstr "Desconectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:34
 msgid "you need to pass a correct state to Wallet."
-msgstr "você precisa passar um estado correto para o Wallet."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/HomePanel/HomePanel.tsx:123
 msgid "SWAP"
-msgstr "TROCA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
-msgstr "Saldo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:62
 msgid "Max"
-msgstr "Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={selectedSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:179
 msgid "swap from"
-msgstr "trocar de"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:198
 msgid "maximum amount of asset"
-msgstr "quantidade máxima de ativos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
-msgstr "trocar para"
+msgstr ""

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -1,22 +1,17 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-06 17:24+0330\n"
+"POT-Creation-Date: 2024-03-10 11:57+0330\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: pt\n"
-"Project-Id-Version: rango\n"
+"Language: ru\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-02-20 09:32\n"
+"PO-Revision-Date: \n"
 "Last-Translator: \n"
-"Language-Team: Portuguese\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: rango\n"
-"X-Crowdin-Project-ID: 622238\n"
-"X-Crowdin-Language: pt-PT\n"
-"X-Crowdin-File: en.po\n"
-"X-Crowdin-File-ID: 30\n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
@@ -24,7 +19,7 @@ msgstr ""
 #: widget/embedded/src/pages/HistoryPage.tsx:85
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:131
 msgid "No results found"
-msgstr "Nenhum resultado encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:38
@@ -32,24 +27,24 @@ msgstr "Nenhum resultado encontrado"
 #: widget/embedded/src/pages/HistoryPage.tsx:87
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:132
 msgid "Try using different keywords"
-msgstr "Tente usar palavras-chave diferentes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:66
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:46
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:40
 msgid "Select Blockchain"
-msgstr "Selecione a Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:66
 msgid "All"
-msgstr "TODOS"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:100
 msgid "More +{count}"
-msgstr "Mais +{count}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
@@ -64,221 +59,221 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
 msgid "Activate current tab"
-msgstr "Ativar a aba atual"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:22
 msgid "Currently, some transactions are running and being handled by other browser tab. If you activate this tab, all transactions that are already in the transaction sign step will expire."
-msgstr "No momento, algumas transações estão sendo executadas e sendo tratadas por outra aba do navegador. Se você ativar essa aba, todas as transações que já estão na etapa de sinal de transação irão expirar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:32
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:269
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:237
 msgid "Confirm"
-msgstr "Confirmar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:284
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:359
 msgid "Your {blockchainName} wallets"
-msgstr "Suas carteiras {blockchainName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:303
 msgid "Insufficient account balance"
-msgstr "Saldo de conta insuficiente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:312
 msgid "Proceed anyway"
-msgstr "Continuar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:368
 msgid "You need to connect a {blockchainName} wallet."
-msgstr "Você precisa conectar uma carteira {blockchainName}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
-msgstr "Enviar para outro endereço"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
-msgstr "Seu endereço de destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
-msgstr "O endereço {destination} não corresponde ao padrão do endereço da blockchain."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:168
 msgid "Add {chain} chain"
-msgstr "Adiciona cadeia {chain}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:217
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:250
 msgid "Add {blockchainDisplayName} Chain"
-msgstr "Adicionar Corrente {blockchainDisplayName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:222
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:254
 msgid "You should connect a {blockchainDisplayName} supported wallet or choose a different {blockchainDisplayName} address"
-msgstr "Você deve conectar uma carteira com suporte do {blockchainDisplayName} ou escolher um endereço {blockchainDisplayName} diferente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:272
 msgid "{blockchainDisplayName} Chain Added"
-msgstr "{blockchainDisplayName} Cadeia Adicionada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:276
 msgid "{blockchainDisplayName} is added to your wallet, you can use it to swap."
-msgstr "{blockchainDisplayName} foi adicionado à sua carteira, você pode usá-lo para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:286
 msgid "Request Rejected"
-msgstr "Pedido rejeitado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:287
 msgid "You've rejected adding {blockchainDisplayName} chain to your wallet."
-msgstr "Você rejeitou adicionar {blockchainDisplayName} corrente à sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:311
 msgid "Show more wallets"
-msgstr "Mostrar mais carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/CancelButton.tsx:14
 msgid "Cancel"
-msgstr "cancelar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
-msgstr "atualizar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
-msgstr "notificações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
 #: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
-msgstr "Confirgurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
-msgstr "Histórico de transações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/WalletButton.tsx:14
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:16
 #: widget/embedded/src/constants/messages.ts:5
 msgid "Connect Wallet"
-msgstr "Conectar Carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx:118
 #: widget/embedded/src/utils/date.ts:18
 #: widget/embedded/src/utils/time.ts:22
 msgid "Today"
-msgstr "hoje"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:375
 msgid "Swaps steps"
-msgstr "Etapas de troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
-msgstr "Repetir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
 #: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NotificationContent/NotificationNotFound.tsx:13
 msgid "There are no notifications."
-msgstr "Não há notificações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
-msgstr "Erro Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
-msgstr "Aviso Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
-msgstr "Sua: {amount} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
-msgstr "Mínimo de slippage necessário é {minRequiredSlippage}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
-msgstr "Ver todas as rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
-msgstr "Ver mais informações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
-msgstr "Explicação de Gás e Taxa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
-msgstr "detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
-msgstr "Taxa total a pagar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
-msgstr "Ocultar taxas não-pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
-msgstr "Mostrar tarifas não pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
-msgstr "Descrição:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
@@ -286,28 +281,26 @@ msgid ""
 "The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
 msgstr ""
-"As seguintes tarifas são consideradas no resultado da transação e\n"
-"                você não precisará pagar gás extra por elas."
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:25
 msgid "Swap input"
-msgstr "Swap input"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:44
 msgid "Estimated output"
-msgstr "Saída estimada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
-msgstr "Via:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
-msgstr "Correntas:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quotes/Quotes.tsx:92
@@ -317,720 +310,720 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
 msgid "Swapping"
-msgstr "Swapping"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:51
 msgid "Gas cost"
-msgstr "Custo de gás"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:59
 msgid "Receiving"
-msgstr "Recebimento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:67
 msgid "Price impact"
-msgstr "Impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Você precisa aumentar o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Recomendamos que você aumente o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
-msgstr "Cuidado, seu slippage está alto."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx:73
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:25
 msgid "Change"
-msgstr "Troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:41
 msgid "Change settings"
-msgstr "Alterar configurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:51
 msgid "High slippage"
-msgstr "Alto slide"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:52
 msgid "Low slippage"
-msgstr "Slippage Baixo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:56
 msgid " Caution, your slippage is high (={userSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={userSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:76
 msgid "Confirm anyway"
-msgstr "Confirmar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:35
 msgid "Slippage tolerance per swap"
-msgstr "Tolerância do slippage por swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
-msgstr "Personalizado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:11
 msgid "Your transaction will be reverted if the price changes unfavorably by more than this percentage"
-msgstr "Sua transação será revertida se o preço mudar desfavoravelmente, mais do que esta porcentagem"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:16
 msgid "Warning"
-msgstr "ATENÇÃO"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:17
 msgid "This setting is applied per step (e.g. 1Inch, Thorchain, etc) which means only the step will be reverted, not the whole transaction."
-msgstr "Essa configuração é aplicada por passo (por exemplo, 1Inch, Thorchain, etc), que significa que apenas o passo será revertido, não toda a transação."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:25
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:246
 msgid "Swap and Bridge"
-msgstr "Inverter e Ponte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:33
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:286
 msgid "Request ID"
-msgstr "Solicitar ID"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:64
 msgid "Not found"
-msgstr "Não encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:65
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:39
 msgid "Swap with request ID = {requestId} not found."
-msgstr "Trocar com o ID de requisição = {requestId} não encontrado."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:214
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
-msgstr "Você recebeu {amount} {token} em carteira {conciseAddress} na cadeia {chain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:230
 msgid "Transaction was not sent."
-msgstr "Transação não foi enviada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:232
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
-msgstr "{amount} {symbol} em {blockchain} permanece em sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:257
 msgid "Delete"
-msgstr "excluir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:278
 msgid "Try again"
-msgstr "Tente novamente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx:50
 msgid "View transaction"
-msgstr "Ver transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:47
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:31
 msgid "Connect"
-msgstr "Conectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:43
 msgid "Swap Successful"
-msgstr "Troca bem sucedida"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:71
 msgid "Transaction Failed"
-msgstr "Transação Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:86
 msgid "Done"
-msgstr "Concluído"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:98
 msgid "Diagnosis"
-msgstr "Diagnóstico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:105
 msgid "See Details"
-msgstr "Ver Detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:13
 msgid "Cancel Swap"
-msgstr "Cancelar Swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:14
 msgid "Are you sure you want to cancel this swap?"
-msgstr "Tem certeza que deseja cancelar este swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:22
 msgid "Yes, Cancel it"
-msgstr "Sim, Cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:26
 msgid "No, Continue"
-msgstr "Não, continuar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:13
 msgid "Delete Transaction"
-msgstr "Excluir Transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:14
 msgid "Are you sure you want to delete this swap?"
-msgstr "Tem certeza que deseja excluir esta troca?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:22
 msgid "Yes, Delete it"
-msgstr "Sim, exclua-o"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:27
 msgid "No, Cancel"
-msgstr "Não, cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:12
 msgid "Change Network"
-msgstr "Alterar rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:20
 msgid "Network Changed"
-msgstr "Rede alterada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
-msgstr "Selecione o Token"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:19
 msgid "Wallet Connected"
-msgstr "Carteira conectada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:20
 msgid "Your wallet is connected, you can use it to swap."
-msgstr "Sua carteira está conectada, você pode usá-la para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:31
 msgid "Failed to Connect"
-msgstr "Falha na conexão"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:33
 msgid "Your wallet is not connected. Please try again."
-msgstr "Sua carteira não está conectada. Por favor, tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:42
 msgid "Connecting to your wallet"
-msgstr "Conectando-se à sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:43
 msgid "Click connect in your wallet popup."
-msgstr "Clique em conectar no pop-up da sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:9
 msgid "Failed Network, Please retry your swap."
-msgstr "Falha na Rede, tente novamente sua alternância."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:11
 msgid "Please reset your liquidity sources."
-msgstr "Por favor, redefina suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:12
 msgid "You have limited the liquidity sources and this might result in Rango finding no routes. Please consider resetting your liquidity sources."
-msgstr "Você limitou as fontes de liquidez e isso pode resultar em que o Rango não encontre nenhuma rota. Por favor, considere redefinir suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:17
 msgid "No Routes Found."
-msgstr "Nenhuma rota encontrada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:18
 msgid "Reasons why Rango couldn't find a route: low liquidity on token, very low input amount or no routes available for the selected input/output token combination."
-msgstr "Motivos porque Rango não conseguiu encontrar uma rota: baixa liquidez no token, quantidade muito baixa de entrada ou nenhuma rota disponível para a combinação selecionada de entrada/saída do token."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:23
 msgid "Bridge Limit Error: Please increase your amount."
-msgstr "Erro no limite da ponte: Por favor, aumente o seu valor."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:26
 msgid "Bridge Limit Error: Please decrease your amount."
-msgstr "Erro no limite da ponte: Por favor, reduza seu montante."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:31
 msgid "High Price Impact"
-msgstr "Impacto de preço alto"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:32
 msgid "Price impact is too high!"
-msgstr "O impacto nos preços é muito alto!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:33
 msgid "The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap."
-msgstr "O impacto no preço é significativamente maior do que o valor permitido. Se você tem certeza, continue, caso contrário, altere o swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:36
 msgid "Confirm high price impact"
-msgstr "Confirmar alto impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:39
 msgid "Route updated and price impact is too high, try again later!"
-msgstr "A rota atualizada e o impacto nos preços é muito alto, tente novamente mais tarde!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:44
 msgid "USD Price Unknown"
-msgstr "Preço em USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:45
 msgid "USD Price Unknown, Cannot calculate Price Impact."
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto de preços."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:46
 msgid "USD Price Unknown, Cannot calculate Price Impact. The price impact may be higher than usual. Are you sure to continue the Swap?"
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto do preço. O impacto do preço pode ser maior do que o normal. Tem certeza que deseja continuar o Swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:49
 msgid "Confirm USD Price Unknown"
-msgstr "Confirmar preço de USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
 #: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
-msgstr "Trocar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:7
 msgid "Swap anyway"
-msgstr "Trocar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:8
 msgid "The route goes through Ethereum. Continue?"
-msgstr "A rota passa pelo Ethereum. Continuar?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:13
 msgid "Network Fee"
-msgstr "Taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:14
 msgid "Protocol Fee"
-msgstr "Taxa do Protocolo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:15
 msgid "Affiliate Fee"
-msgstr "Taxa de afiliado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:16
 msgid "Outbound Fee"
-msgstr "Taxa de Saída"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:17
 msgid "Rango Fee"
-msgstr "Taxa de Rango"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
 msgid "Smart Routing"
-msgstr "Roteamento inteligente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
-msgstr "Taxa mais baixa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:36
 msgid "Fastest Transfer"
-msgstr "Mais Rápido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:40
 msgid "Maximum Return"
-msgstr "Retorno Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:44
 msgid "Maximum Output"
-msgstr "Produção Máxima"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
 msgid "Route has been updated."
-msgstr "Rota foi atualizada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:12
 msgid "Output amount changed to {newOutputAmount} ({percentageChange}% change)."
-msgstr "Valor de saída alterado para {newOutputAmount} ( Alteração de{percentageChange}%)."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:20
 msgid "Route swappers has been updated."
-msgstr "Os trocadores de rota foram atualizados."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:22
 msgid "Route internal coins has been updated."
-msgstr "Moedas internas do itinerário foram atualizadas."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
 #: widget/embedded/src/pages/Routes.tsx:48
 msgid "Routes"
-msgstr "Rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:77
 msgid "From"
-msgstr "De"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:120
 msgid "To"
-msgstr "Para"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:47
 msgid "Light"
-msgstr "Fino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:56
 msgid "Dark"
-msgstr "Escuro"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:65
 msgid "Auto"
-msgstr "Automático"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:133
 msgid "Loading failed"
-msgstr "Falha no carregamento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:149
 msgid "Enabled bridges"
-msgstr "Pontes habilitados"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:167
 msgid "Enabled exchanges"
-msgstr "Trocas ativadas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:185
 #: widget/embedded/src/pages/LanguagePage.tsx:38
 msgid "Language"
-msgstr "IDIOMA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:198
 msgid "Infinite approval"
-msgstr "Aprovação infinita"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:208
 msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Ativar o modo de 'aprovação infinita' concede acesso irrestrito a contratos inteligentes de DEXes/Bridges, permitindo-lhes utilizar o valor do token aprovado, sem limitações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:228
 msgid "Theme"
-msgstr "Tema"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
-msgstr "Confirmar troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
-msgstr "Trocar de início"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
-msgstr "Você recebe"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:67
 msgid "History"
-msgstr "Histórico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:74
 msgid "Search Transaction"
-msgstr "Pesquisar transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
-msgstr "Idioma"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:151
 msgid "Exchanges"
-msgstr "Trocas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:112
 msgid "Bridges"
-msgstr "Pontes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Deselect all"
-msgstr "Desmarcar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Select all"
-msgstr "Selecionar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:121
 msgid "Search {sourceType}"
-msgstr "Pesquisar em {sourceType}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
-msgstr "Pesquisar Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:72
 msgid "Source"
-msgstr "fonte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:73
 msgid "Destination"
-msgstr "Destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:79
 msgid "Swap {type}"
-msgstr "Trocar {type}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:95
 msgid "Search Token"
-msgstr "Token de pesquisa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
-msgstr "Atualmente, você está no modo campanha com restrições sobre fontes de liquidez. Gostaria de mudar este modo e usar todas as fontes de liquidez disponíveis?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
-msgstr "O ID da requisição é necessário para exibir os detalhes do swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
 #: widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx:30
 msgid "Connect Wallets"
-msgstr "Conectar Carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:76
 msgid "Choose a wallet to connect."
-msgstr "Escolha uma carteira para se conectar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:25
 msgid "This week"
-msgstr "Esta semana"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:32
 msgid "This month"
-msgstr "Este Mês"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:39
 msgid "This year"
-msgstr "Esse ano"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:125
 msgid "Required: >= {min} {symbol}"
-msgstr "Obrigatório: >= {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:138
 msgid "Required: > {min} {symbol}"
-msgstr "Obrigatório: > {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:153
 msgid "Required: <= {max} {symbol}"
-msgstr "Obrigatório: <= {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:166
 msgid "Required: < {max} {symbol}"
-msgstr "Obrigatório: < {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:634
 msgid " for network fee"
-msgstr " para taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:637
 msgid " for swap"
-msgstr " para troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:640
 msgid " for input and network fee"
-msgstr " por taxa de entrada e de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:642
 msgid "Needs ≈ {requiredAmount} {symbol}{reason}, but you have {currentAmount} {symbol} in your {blockchain} wallet."
-msgstr "Precisa de {requiredAmount} {symbol}{reason}, mas você tem {currentAmount} {symbol} na sua carteira {blockchain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:702
 msgid "Waiting for connecting wallet"
-msgstr "Aguardando conexão da carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:706
 msgid "Waiting for other running tasks to be finished"
-msgstr "Aguardando o término de outras tarefas em execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:709
 msgid "Waiting for changing wallet network"
-msgstr "Aguardando mudança da rede de carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:6
 msgid "Sunday"
-msgstr "domingo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:7
 msgid "Monday"
-msgstr "Segunda-Feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:8
 msgid "Tuesday"
-msgstr "Terça-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:9
 msgid "Wednesday"
-msgstr "quarta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:10
 msgid "Thursday"
-msgstr "quinta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:11
 msgid "Friday"
-msgstr "Sexta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:12
 msgid "Saturday"
-msgstr "sábado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
-msgstr " Erro ao conectar ao servidor, por favor recarregue o app e tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/BottomLogo/BottomLogo.tsx:14
 msgid "Powered By"
-msgstr "Desenvolvido por"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/ChangeSlippageButton/ChangeSlippageButton.tsx:14
 msgid "Change Slippage"
-msgstr "Alterar Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx:63
@@ -1041,120 +1034,120 @@ msgstr ""
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:74
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:100
 msgid "Swap on {fromChain} via {swapper}"
-msgstr "Trocar em {fromChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:107
 msgid "Bridge to {toChain} via {swapper}"
-msgstr "Ponte para {toChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:28
 msgid "Swap Details"
-msgstr "Trocar detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:8
 msgid "Failed"
-msgstr "Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:10
 msgid "Complete"
-msgstr "Complete"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:12
 msgid "In progress"
-msgstr "Em Execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapToken.tsx:122
 msgid "Waiting for bridge transaction"
-msgstr "Aguardando a transação da bridge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:150
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:56
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:235
 msgid "Chain"
-msgstr "Corrente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:168
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:49
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:259
 msgid "Token"
-msgstr "Identificador"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:12
 msgid "Connected"
-msgstr "Conectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:13
 msgid "Disconnect"
-msgstr "Desconectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:18
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:19
 msgid "Install"
-msgstr "Instale"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:24
 msgid "Connecting..."
-msgstr "Conectandochar@@0"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:25
 msgid "Connecting"
-msgstr "Conectando"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:30
 msgid "Disconnected"
-msgstr "Desconectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:34
 msgid "you need to pass a correct state to Wallet."
-msgstr "você precisa passar um estado correto para o Wallet."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/HomePanel/HomePanel.tsx:123
 msgid "SWAP"
-msgstr "TROCA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
-msgstr "Saldo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:62
 msgid "Max"
-msgstr "Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={selectedSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:179
 msgid "swap from"
-msgstr "trocar de"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:198
 msgid "maximum amount of asset"
-msgstr "quantidade máxima de ativos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
-msgstr "trocar para"
+msgstr ""

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -1,22 +1,11 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-06 17:24+0330\n"
+"POT-Creation-Date: 2024-03-10 23:38+0330\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: pt\n"
-"Project-Id-Version: rango\n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-02-20 09:32\n"
-"Last-Translator: \n"
-"Language-Team: Portuguese\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: rango\n"
-"X-Crowdin-Project-ID: 622238\n"
-"X-Crowdin-Language: pt-PT\n"
-"X-Crowdin-File: en.po\n"
-"X-Crowdin-File-ID: 30\n"
+"Language: sv\n"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
@@ -24,7 +13,7 @@ msgstr ""
 #: widget/embedded/src/pages/HistoryPage.tsx:85
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:131
 msgid "No results found"
-msgstr "Nenhum resultado encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:38
@@ -32,24 +21,24 @@ msgstr "Nenhum resultado encontrado"
 #: widget/embedded/src/pages/HistoryPage.tsx:87
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:132
 msgid "Try using different keywords"
-msgstr "Tente usar palavras-chave diferentes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:66
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:46
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:40
 msgid "Select Blockchain"
-msgstr "Selecione a Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:66
 msgid "All"
-msgstr "TODOS"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:100
 msgid "More +{count}"
-msgstr "Mais +{count}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
@@ -64,221 +53,221 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
 msgid "Activate current tab"
-msgstr "Ativar a aba atual"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:22
 msgid "Currently, some transactions are running and being handled by other browser tab. If you activate this tab, all transactions that are already in the transaction sign step will expire."
-msgstr "No momento, algumas transações estão sendo executadas e sendo tratadas por outra aba do navegador. Se você ativar essa aba, todas as transações que já estão na etapa de sinal de transação irão expirar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:32
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:269
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:237
 msgid "Confirm"
-msgstr "Confirmar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:284
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:359
 msgid "Your {blockchainName} wallets"
-msgstr "Suas carteiras {blockchainName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:303
 msgid "Insufficient account balance"
-msgstr "Saldo de conta insuficiente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:312
 msgid "Proceed anyway"
-msgstr "Continuar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:368
 msgid "You need to connect a {blockchainName} wallet."
-msgstr "Você precisa conectar uma carteira {blockchainName}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
-msgstr "Enviar para outro endereço"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
-msgstr "Seu endereço de destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
-msgstr "O endereço {destination} não corresponde ao padrão do endereço da blockchain."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:168
 msgid "Add {chain} chain"
-msgstr "Adiciona cadeia {chain}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:217
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:250
 msgid "Add {blockchainDisplayName} Chain"
-msgstr "Adicionar Corrente {blockchainDisplayName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:222
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:254
 msgid "You should connect a {blockchainDisplayName} supported wallet or choose a different {blockchainDisplayName} address"
-msgstr "Você deve conectar uma carteira com suporte do {blockchainDisplayName} ou escolher um endereço {blockchainDisplayName} diferente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:272
 msgid "{blockchainDisplayName} Chain Added"
-msgstr "{blockchainDisplayName} Cadeia Adicionada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:276
 msgid "{blockchainDisplayName} is added to your wallet, you can use it to swap."
-msgstr "{blockchainDisplayName} foi adicionado à sua carteira, você pode usá-lo para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:286
 msgid "Request Rejected"
-msgstr "Pedido rejeitado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:287
 msgid "You've rejected adding {blockchainDisplayName} chain to your wallet."
-msgstr "Você rejeitou adicionar {blockchainDisplayName} corrente à sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:311
 msgid "Show more wallets"
-msgstr "Mostrar mais carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/CancelButton.tsx:14
 msgid "Cancel"
-msgstr "cancelar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
-msgstr "atualizar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
-msgstr "notificações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
 #: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
-msgstr "Confirgurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
-msgstr "Histórico de transações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/WalletButton.tsx:14
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:16
 #: widget/embedded/src/constants/messages.ts:5
 msgid "Connect Wallet"
-msgstr "Conectar Carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx:118
 #: widget/embedded/src/utils/date.ts:18
 #: widget/embedded/src/utils/time.ts:22
 msgid "Today"
-msgstr "hoje"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:375
 msgid "Swaps steps"
-msgstr "Etapas de troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
-msgstr "Repetir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
 #: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NotificationContent/NotificationNotFound.tsx:13
 msgid "There are no notifications."
-msgstr "Não há notificações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
-msgstr "Erro Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
-msgstr "Aviso Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
-msgstr "Sua: {amount} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
-msgstr "Mínimo de slippage necessário é {minRequiredSlippage}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
-msgstr "Ver todas as rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
-msgstr "Ver mais informações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
-msgstr "Explicação de Gás e Taxa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
-msgstr "detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
-msgstr "Taxa total a pagar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
-msgstr "Ocultar taxas não-pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
-msgstr "Mostrar tarifas não pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
-msgstr "Descrição:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
@@ -286,28 +275,26 @@ msgid ""
 "The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
 msgstr ""
-"As seguintes tarifas são consideradas no resultado da transação e\n"
-"                você não precisará pagar gás extra por elas."
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:25
 msgid "Swap input"
-msgstr "Swap input"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:44
 msgid "Estimated output"
-msgstr "Saída estimada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
-msgstr "Via:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
-msgstr "Correntas:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quotes/Quotes.tsx:92
@@ -317,720 +304,720 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
 msgid "Swapping"
-msgstr "Swapping"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:51
 msgid "Gas cost"
-msgstr "Custo de gás"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:59
 msgid "Receiving"
-msgstr "Recebimento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:67
 msgid "Price impact"
-msgstr "Impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Você precisa aumentar o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Recomendamos que você aumente o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
-msgstr "Cuidado, seu slippage está alto."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx:73
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:25
 msgid "Change"
-msgstr "Troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:41
 msgid "Change settings"
-msgstr "Alterar configurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:51
 msgid "High slippage"
-msgstr "Alto slide"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:52
 msgid "Low slippage"
-msgstr "Slippage Baixo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:56
 msgid " Caution, your slippage is high (={userSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={userSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:76
 msgid "Confirm anyway"
-msgstr "Confirmar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:35
 msgid "Slippage tolerance per swap"
-msgstr "Tolerância do slippage por swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
-msgstr "Personalizado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:11
 msgid "Your transaction will be reverted if the price changes unfavorably by more than this percentage"
-msgstr "Sua transação será revertida se o preço mudar desfavoravelmente, mais do que esta porcentagem"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:16
 msgid "Warning"
-msgstr "ATENÇÃO"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:17
 msgid "This setting is applied per step (e.g. 1Inch, Thorchain, etc) which means only the step will be reverted, not the whole transaction."
-msgstr "Essa configuração é aplicada por passo (por exemplo, 1Inch, Thorchain, etc), que significa que apenas o passo será revertido, não toda a transação."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:25
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:246
 msgid "Swap and Bridge"
-msgstr "Inverter e Ponte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:33
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:286
 msgid "Request ID"
-msgstr "Solicitar ID"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:64
 msgid "Not found"
-msgstr "Não encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:65
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:39
 msgid "Swap with request ID = {requestId} not found."
-msgstr "Trocar com o ID de requisição = {requestId} não encontrado."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:214
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
-msgstr "Você recebeu {amount} {token} em carteira {conciseAddress} na cadeia {chain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:230
 msgid "Transaction was not sent."
-msgstr "Transação não foi enviada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:232
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
-msgstr "{amount} {symbol} em {blockchain} permanece em sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:257
 msgid "Delete"
-msgstr "excluir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:278
 msgid "Try again"
-msgstr "Tente novamente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx:50
 msgid "View transaction"
-msgstr "Ver transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:47
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:31
 msgid "Connect"
-msgstr "Conectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:43
 msgid "Swap Successful"
-msgstr "Troca bem sucedida"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:71
 msgid "Transaction Failed"
-msgstr "Transação Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:86
 msgid "Done"
-msgstr "Concluído"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:98
 msgid "Diagnosis"
-msgstr "Diagnóstico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:105
 msgid "See Details"
-msgstr "Ver Detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:13
 msgid "Cancel Swap"
-msgstr "Cancelar Swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:14
 msgid "Are you sure you want to cancel this swap?"
-msgstr "Tem certeza que deseja cancelar este swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:22
 msgid "Yes, Cancel it"
-msgstr "Sim, Cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:26
 msgid "No, Continue"
-msgstr "Não, continuar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:13
 msgid "Delete Transaction"
-msgstr "Excluir Transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:14
 msgid "Are you sure you want to delete this swap?"
-msgstr "Tem certeza que deseja excluir esta troca?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:22
 msgid "Yes, Delete it"
-msgstr "Sim, exclua-o"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:27
 msgid "No, Cancel"
-msgstr "Não, cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:12
 msgid "Change Network"
-msgstr "Alterar rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:20
 msgid "Network Changed"
-msgstr "Rede alterada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
-msgstr "Selecione o Token"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:19
 msgid "Wallet Connected"
-msgstr "Carteira conectada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:20
 msgid "Your wallet is connected, you can use it to swap."
-msgstr "Sua carteira está conectada, você pode usá-la para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:31
 msgid "Failed to Connect"
-msgstr "Falha na conexão"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:33
 msgid "Your wallet is not connected. Please try again."
-msgstr "Sua carteira não está conectada. Por favor, tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:42
 msgid "Connecting to your wallet"
-msgstr "Conectando-se à sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:43
 msgid "Click connect in your wallet popup."
-msgstr "Clique em conectar no pop-up da sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:9
 msgid "Failed Network, Please retry your swap."
-msgstr "Falha na Rede, tente novamente sua alternância."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:11
 msgid "Please reset your liquidity sources."
-msgstr "Por favor, redefina suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:12
 msgid "You have limited the liquidity sources and this might result in Rango finding no routes. Please consider resetting your liquidity sources."
-msgstr "Você limitou as fontes de liquidez e isso pode resultar em que o Rango não encontre nenhuma rota. Por favor, considere redefinir suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:17
 msgid "No Routes Found."
-msgstr "Nenhuma rota encontrada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:18
 msgid "Reasons why Rango couldn't find a route: low liquidity on token, very low input amount or no routes available for the selected input/output token combination."
-msgstr "Motivos porque Rango não conseguiu encontrar uma rota: baixa liquidez no token, quantidade muito baixa de entrada ou nenhuma rota disponível para a combinação selecionada de entrada/saída do token."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:23
 msgid "Bridge Limit Error: Please increase your amount."
-msgstr "Erro no limite da ponte: Por favor, aumente o seu valor."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:26
 msgid "Bridge Limit Error: Please decrease your amount."
-msgstr "Erro no limite da ponte: Por favor, reduza seu montante."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:31
 msgid "High Price Impact"
-msgstr "Impacto de preço alto"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:32
 msgid "Price impact is too high!"
-msgstr "O impacto nos preços é muito alto!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:33
 msgid "The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap."
-msgstr "O impacto no preço é significativamente maior do que o valor permitido. Se você tem certeza, continue, caso contrário, altere o swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:36
 msgid "Confirm high price impact"
-msgstr "Confirmar alto impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:39
 msgid "Route updated and price impact is too high, try again later!"
-msgstr "A rota atualizada e o impacto nos preços é muito alto, tente novamente mais tarde!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:44
 msgid "USD Price Unknown"
-msgstr "Preço em USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:45
 msgid "USD Price Unknown, Cannot calculate Price Impact."
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto de preços."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:46
 msgid "USD Price Unknown, Cannot calculate Price Impact. The price impact may be higher than usual. Are you sure to continue the Swap?"
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto do preço. O impacto do preço pode ser maior do que o normal. Tem certeza que deseja continuar o Swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:49
 msgid "Confirm USD Price Unknown"
-msgstr "Confirmar preço de USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
 #: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
-msgstr "Trocar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:7
 msgid "Swap anyway"
-msgstr "Trocar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:8
 msgid "The route goes through Ethereum. Continue?"
-msgstr "A rota passa pelo Ethereum. Continuar?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:13
 msgid "Network Fee"
-msgstr "Taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:14
 msgid "Protocol Fee"
-msgstr "Taxa do Protocolo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:15
 msgid "Affiliate Fee"
-msgstr "Taxa de afiliado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:16
 msgid "Outbound Fee"
-msgstr "Taxa de Saída"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:17
 msgid "Rango Fee"
-msgstr "Taxa de Rango"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
 msgid "Smart Routing"
-msgstr "Roteamento inteligente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
-msgstr "Taxa mais baixa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:36
 msgid "Fastest Transfer"
-msgstr "Mais Rápido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:40
 msgid "Maximum Return"
-msgstr "Retorno Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:44
 msgid "Maximum Output"
-msgstr "Produção Máxima"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
 msgid "Route has been updated."
-msgstr "Rota foi atualizada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:12
 msgid "Output amount changed to {newOutputAmount} ({percentageChange}% change)."
-msgstr "Valor de saída alterado para {newOutputAmount} ( Alteração de{percentageChange}%)."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:20
 msgid "Route swappers has been updated."
-msgstr "Os trocadores de rota foram atualizados."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:22
 msgid "Route internal coins has been updated."
-msgstr "Moedas internas do itinerário foram atualizadas."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
 #: widget/embedded/src/pages/Routes.tsx:48
 msgid "Routes"
-msgstr "Rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:77
 msgid "From"
-msgstr "De"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:120
 msgid "To"
-msgstr "Para"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:47
 msgid "Light"
-msgstr "Fino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:56
 msgid "Dark"
-msgstr "Escuro"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:65
 msgid "Auto"
-msgstr "Automático"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:133
 msgid "Loading failed"
-msgstr "Falha no carregamento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:149
 msgid "Enabled bridges"
-msgstr "Pontes habilitados"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:167
 msgid "Enabled exchanges"
-msgstr "Trocas ativadas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:185
 #: widget/embedded/src/pages/LanguagePage.tsx:38
 msgid "Language"
-msgstr "IDIOMA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:198
 msgid "Infinite approval"
-msgstr "Aprovação infinita"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:208
 msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Ativar o modo de 'aprovação infinita' concede acesso irrestrito a contratos inteligentes de DEXes/Bridges, permitindo-lhes utilizar o valor do token aprovado, sem limitações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:228
 msgid "Theme"
-msgstr "Tema"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
-msgstr "Confirmar troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
-msgstr "Trocar de início"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
-msgstr "Você recebe"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:67
 msgid "History"
-msgstr "Histórico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:74
 msgid "Search Transaction"
-msgstr "Pesquisar transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
-msgstr "Idioma"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:151
 msgid "Exchanges"
-msgstr "Trocas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:112
 msgid "Bridges"
-msgstr "Pontes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Deselect all"
-msgstr "Desmarcar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Select all"
-msgstr "Selecionar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:121
 msgid "Search {sourceType}"
-msgstr "Pesquisar em {sourceType}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
-msgstr "Pesquisar Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:72
 msgid "Source"
-msgstr "fonte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:73
 msgid "Destination"
-msgstr "Destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:79
 msgid "Swap {type}"
-msgstr "Trocar {type}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:95
 msgid "Search Token"
-msgstr "Token de pesquisa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
-msgstr "Atualmente, você está no modo campanha com restrições sobre fontes de liquidez. Gostaria de mudar este modo e usar todas as fontes de liquidez disponíveis?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
-msgstr "O ID da requisição é necessário para exibir os detalhes do swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
 #: widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx:30
 msgid "Connect Wallets"
-msgstr "Conectar Carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:76
 msgid "Choose a wallet to connect."
-msgstr "Escolha uma carteira para se conectar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:25
 msgid "This week"
-msgstr "Esta semana"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:32
 msgid "This month"
-msgstr "Este Mês"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:39
 msgid "This year"
-msgstr "Esse ano"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:125
 msgid "Required: >= {min} {symbol}"
-msgstr "Obrigatório: >= {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:138
 msgid "Required: > {min} {symbol}"
-msgstr "Obrigatório: > {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:153
 msgid "Required: <= {max} {symbol}"
-msgstr "Obrigatório: <= {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:166
 msgid "Required: < {max} {symbol}"
-msgstr "Obrigatório: < {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:634
 msgid " for network fee"
-msgstr " para taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:637
 msgid " for swap"
-msgstr " para troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:640
 msgid " for input and network fee"
-msgstr " por taxa de entrada e de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:642
 msgid "Needs ≈ {requiredAmount} {symbol}{reason}, but you have {currentAmount} {symbol} in your {blockchain} wallet."
-msgstr "Precisa de {requiredAmount} {symbol}{reason}, mas você tem {currentAmount} {symbol} na sua carteira {blockchain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:702
 msgid "Waiting for connecting wallet"
-msgstr "Aguardando conexão da carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:706
 msgid "Waiting for other running tasks to be finished"
-msgstr "Aguardando o término de outras tarefas em execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:709
 msgid "Waiting for changing wallet network"
-msgstr "Aguardando mudança da rede de carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:6
 msgid "Sunday"
-msgstr "domingo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:7
 msgid "Monday"
-msgstr "Segunda-Feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:8
 msgid "Tuesday"
-msgstr "Terça-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:9
 msgid "Wednesday"
-msgstr "quarta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:10
 msgid "Thursday"
-msgstr "quinta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:11
 msgid "Friday"
-msgstr "Sexta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:12
 msgid "Saturday"
-msgstr "sábado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
-msgstr " Erro ao conectar ao servidor, por favor recarregue o app e tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/BottomLogo/BottomLogo.tsx:14
 msgid "Powered By"
-msgstr "Desenvolvido por"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/ChangeSlippageButton/ChangeSlippageButton.tsx:14
 msgid "Change Slippage"
-msgstr "Alterar Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx:63
@@ -1041,120 +1028,120 @@ msgstr ""
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:74
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:100
 msgid "Swap on {fromChain} via {swapper}"
-msgstr "Trocar em {fromChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:107
 msgid "Bridge to {toChain} via {swapper}"
-msgstr "Ponte para {toChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:28
 msgid "Swap Details"
-msgstr "Trocar detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:8
 msgid "Failed"
-msgstr "Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:10
 msgid "Complete"
-msgstr "Complete"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:12
 msgid "In progress"
-msgstr "Em Execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapToken.tsx:122
 msgid "Waiting for bridge transaction"
-msgstr "Aguardando a transação da bridge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:150
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:56
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:235
 msgid "Chain"
-msgstr "Corrente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:168
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:49
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:259
 msgid "Token"
-msgstr "Identificador"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:12
 msgid "Connected"
-msgstr "Conectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:13
 msgid "Disconnect"
-msgstr "Desconectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:18
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:19
 msgid "Install"
-msgstr "Instale"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:24
 msgid "Connecting..."
-msgstr "Conectandochar@@0"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:25
 msgid "Connecting"
-msgstr "Conectando"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:30
 msgid "Disconnected"
-msgstr "Desconectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:34
 msgid "you need to pass a correct state to Wallet."
-msgstr "você precisa passar um estado correto para o Wallet."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/HomePanel/HomePanel.tsx:123
 msgid "SWAP"
-msgstr "TROCA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
-msgstr "Saldo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:62
 msgid "Max"
-msgstr "Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={selectedSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:179
 msgid "swap from"
-msgstr "trocar de"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:198
 msgid "maximum amount of asset"
-msgstr "quantidade máxima de ativos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
-msgstr "trocar para"
+msgstr ""

--- a/translations/uk.po
+++ b/translations/uk.po
@@ -1,22 +1,17 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-06 17:24+0330\n"
+"POT-Creation-Date: 2024-03-10 11:57+0330\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: pt\n"
-"Project-Id-Version: rango\n"
+"Language: uk\n"
+"Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-02-20 09:32\n"
+"PO-Revision-Date: \n"
 "Last-Translator: \n"
-"Language-Team: Portuguese\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: rango\n"
-"X-Crowdin-Project-ID: 622238\n"
-"X-Crowdin-Language: pt-PT\n"
-"X-Crowdin-File: en.po\n"
-"X-Crowdin-File-ID: 30\n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
@@ -24,7 +19,7 @@ msgstr ""
 #: widget/embedded/src/pages/HistoryPage.tsx:85
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:131
 msgid "No results found"
-msgstr "Nenhum resultado encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:38
@@ -32,24 +27,24 @@ msgstr "Nenhum resultado encontrado"
 #: widget/embedded/src/pages/HistoryPage.tsx:87
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:132
 msgid "Try using different keywords"
-msgstr "Tente usar palavras-chave diferentes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:66
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:46
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:40
 msgid "Select Blockchain"
-msgstr "Selecione a Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:66
 msgid "All"
-msgstr "TODOS"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:100
 msgid "More +{count}"
-msgstr "Mais +{count}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
@@ -64,221 +59,221 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
 msgid "Activate current tab"
-msgstr "Ativar a aba atual"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:22
 msgid "Currently, some transactions are running and being handled by other browser tab. If you activate this tab, all transactions that are already in the transaction sign step will expire."
-msgstr "No momento, algumas transações estão sendo executadas e sendo tratadas por outra aba do navegador. Se você ativar essa aba, todas as transações que já estão na etapa de sinal de transação irão expirar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:32
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:269
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:237
 msgid "Confirm"
-msgstr "Confirmar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:284
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:359
 msgid "Your {blockchainName} wallets"
-msgstr "Suas carteiras {blockchainName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:303
 msgid "Insufficient account balance"
-msgstr "Saldo de conta insuficiente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:312
 msgid "Proceed anyway"
-msgstr "Continuar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:368
 msgid "You need to connect a {blockchainName} wallet."
-msgstr "Você precisa conectar uma carteira {blockchainName}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
-msgstr "Enviar para outro endereço"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
-msgstr "Seu endereço de destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
-msgstr "O endereço {destination} não corresponde ao padrão do endereço da blockchain."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:168
 msgid "Add {chain} chain"
-msgstr "Adiciona cadeia {chain}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:217
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:250
 msgid "Add {blockchainDisplayName} Chain"
-msgstr "Adicionar Corrente {blockchainDisplayName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:222
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:254
 msgid "You should connect a {blockchainDisplayName} supported wallet or choose a different {blockchainDisplayName} address"
-msgstr "Você deve conectar uma carteira com suporte do {blockchainDisplayName} ou escolher um endereço {blockchainDisplayName} diferente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:272
 msgid "{blockchainDisplayName} Chain Added"
-msgstr "{blockchainDisplayName} Cadeia Adicionada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:276
 msgid "{blockchainDisplayName} is added to your wallet, you can use it to swap."
-msgstr "{blockchainDisplayName} foi adicionado à sua carteira, você pode usá-lo para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:286
 msgid "Request Rejected"
-msgstr "Pedido rejeitado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:287
 msgid "You've rejected adding {blockchainDisplayName} chain to your wallet."
-msgstr "Você rejeitou adicionar {blockchainDisplayName} corrente à sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:311
 msgid "Show more wallets"
-msgstr "Mostrar mais carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/CancelButton.tsx:14
 msgid "Cancel"
-msgstr "cancelar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
-msgstr "atualizar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
-msgstr "notificações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
 #: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
-msgstr "Confirgurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
-msgstr "Histórico de transações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/WalletButton.tsx:14
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:16
 #: widget/embedded/src/constants/messages.ts:5
 msgid "Connect Wallet"
-msgstr "Conectar Carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx:118
 #: widget/embedded/src/utils/date.ts:18
 #: widget/embedded/src/utils/time.ts:22
 msgid "Today"
-msgstr "hoje"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:375
 msgid "Swaps steps"
-msgstr "Etapas de troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
-msgstr "Repetir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
 #: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NotificationContent/NotificationNotFound.tsx:13
 msgid "There are no notifications."
-msgstr "Não há notificações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
-msgstr "Erro Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
-msgstr "Aviso Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
-msgstr "Sua: {amount} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
-msgstr "Mínimo de slippage necessário é {minRequiredSlippage}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
-msgstr "Ver todas as rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
-msgstr "Ver mais informações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
-msgstr "Explicação de Gás e Taxa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
-msgstr "detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
-msgstr "Taxa total a pagar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
-msgstr "Ocultar taxas não-pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
-msgstr "Mostrar tarifas não pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
-msgstr "Descrição:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
@@ -286,28 +281,26 @@ msgid ""
 "The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
 msgstr ""
-"As seguintes tarifas são consideradas no resultado da transação e\n"
-"                você não precisará pagar gás extra por elas."
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:25
 msgid "Swap input"
-msgstr "Swap input"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:44
 msgid "Estimated output"
-msgstr "Saída estimada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
-msgstr "Via:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
-msgstr "Correntas:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quotes/Quotes.tsx:92
@@ -317,720 +310,720 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
 msgid "Swapping"
-msgstr "Swapping"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:51
 msgid "Gas cost"
-msgstr "Custo de gás"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:59
 msgid "Receiving"
-msgstr "Recebimento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:67
 msgid "Price impact"
-msgstr "Impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Você precisa aumentar o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Recomendamos que você aumente o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
-msgstr "Cuidado, seu slippage está alto."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx:73
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:25
 msgid "Change"
-msgstr "Troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:41
 msgid "Change settings"
-msgstr "Alterar configurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:51
 msgid "High slippage"
-msgstr "Alto slide"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:52
 msgid "Low slippage"
-msgstr "Slippage Baixo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:56
 msgid " Caution, your slippage is high (={userSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={userSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:76
 msgid "Confirm anyway"
-msgstr "Confirmar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:35
 msgid "Slippage tolerance per swap"
-msgstr "Tolerância do slippage por swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
-msgstr "Personalizado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:11
 msgid "Your transaction will be reverted if the price changes unfavorably by more than this percentage"
-msgstr "Sua transação será revertida se o preço mudar desfavoravelmente, mais do que esta porcentagem"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:16
 msgid "Warning"
-msgstr "ATENÇÃO"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:17
 msgid "This setting is applied per step (e.g. 1Inch, Thorchain, etc) which means only the step will be reverted, not the whole transaction."
-msgstr "Essa configuração é aplicada por passo (por exemplo, 1Inch, Thorchain, etc), que significa que apenas o passo será revertido, não toda a transação."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:25
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:246
 msgid "Swap and Bridge"
-msgstr "Inverter e Ponte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:33
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:286
 msgid "Request ID"
-msgstr "Solicitar ID"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:64
 msgid "Not found"
-msgstr "Não encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:65
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:39
 msgid "Swap with request ID = {requestId} not found."
-msgstr "Trocar com o ID de requisição = {requestId} não encontrado."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:214
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
-msgstr "Você recebeu {amount} {token} em carteira {conciseAddress} na cadeia {chain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:230
 msgid "Transaction was not sent."
-msgstr "Transação não foi enviada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:232
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
-msgstr "{amount} {symbol} em {blockchain} permanece em sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:257
 msgid "Delete"
-msgstr "excluir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:278
 msgid "Try again"
-msgstr "Tente novamente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx:50
 msgid "View transaction"
-msgstr "Ver transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:47
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:31
 msgid "Connect"
-msgstr "Conectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:43
 msgid "Swap Successful"
-msgstr "Troca bem sucedida"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:71
 msgid "Transaction Failed"
-msgstr "Transação Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:86
 msgid "Done"
-msgstr "Concluído"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:98
 msgid "Diagnosis"
-msgstr "Diagnóstico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:105
 msgid "See Details"
-msgstr "Ver Detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:13
 msgid "Cancel Swap"
-msgstr "Cancelar Swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:14
 msgid "Are you sure you want to cancel this swap?"
-msgstr "Tem certeza que deseja cancelar este swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:22
 msgid "Yes, Cancel it"
-msgstr "Sim, Cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:26
 msgid "No, Continue"
-msgstr "Não, continuar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:13
 msgid "Delete Transaction"
-msgstr "Excluir Transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:14
 msgid "Are you sure you want to delete this swap?"
-msgstr "Tem certeza que deseja excluir esta troca?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:22
 msgid "Yes, Delete it"
-msgstr "Sim, exclua-o"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:27
 msgid "No, Cancel"
-msgstr "Não, cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:12
 msgid "Change Network"
-msgstr "Alterar rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:20
 msgid "Network Changed"
-msgstr "Rede alterada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
-msgstr "Selecione o Token"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:19
 msgid "Wallet Connected"
-msgstr "Carteira conectada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:20
 msgid "Your wallet is connected, you can use it to swap."
-msgstr "Sua carteira está conectada, você pode usá-la para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:31
 msgid "Failed to Connect"
-msgstr "Falha na conexão"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:33
 msgid "Your wallet is not connected. Please try again."
-msgstr "Sua carteira não está conectada. Por favor, tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:42
 msgid "Connecting to your wallet"
-msgstr "Conectando-se à sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:43
 msgid "Click connect in your wallet popup."
-msgstr "Clique em conectar no pop-up da sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:9
 msgid "Failed Network, Please retry your swap."
-msgstr "Falha na Rede, tente novamente sua alternância."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:11
 msgid "Please reset your liquidity sources."
-msgstr "Por favor, redefina suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:12
 msgid "You have limited the liquidity sources and this might result in Rango finding no routes. Please consider resetting your liquidity sources."
-msgstr "Você limitou as fontes de liquidez e isso pode resultar em que o Rango não encontre nenhuma rota. Por favor, considere redefinir suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:17
 msgid "No Routes Found."
-msgstr "Nenhuma rota encontrada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:18
 msgid "Reasons why Rango couldn't find a route: low liquidity on token, very low input amount or no routes available for the selected input/output token combination."
-msgstr "Motivos porque Rango não conseguiu encontrar uma rota: baixa liquidez no token, quantidade muito baixa de entrada ou nenhuma rota disponível para a combinação selecionada de entrada/saída do token."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:23
 msgid "Bridge Limit Error: Please increase your amount."
-msgstr "Erro no limite da ponte: Por favor, aumente o seu valor."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:26
 msgid "Bridge Limit Error: Please decrease your amount."
-msgstr "Erro no limite da ponte: Por favor, reduza seu montante."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:31
 msgid "High Price Impact"
-msgstr "Impacto de preço alto"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:32
 msgid "Price impact is too high!"
-msgstr "O impacto nos preços é muito alto!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:33
 msgid "The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap."
-msgstr "O impacto no preço é significativamente maior do que o valor permitido. Se você tem certeza, continue, caso contrário, altere o swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:36
 msgid "Confirm high price impact"
-msgstr "Confirmar alto impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:39
 msgid "Route updated and price impact is too high, try again later!"
-msgstr "A rota atualizada e o impacto nos preços é muito alto, tente novamente mais tarde!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:44
 msgid "USD Price Unknown"
-msgstr "Preço em USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:45
 msgid "USD Price Unknown, Cannot calculate Price Impact."
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto de preços."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:46
 msgid "USD Price Unknown, Cannot calculate Price Impact. The price impact may be higher than usual. Are you sure to continue the Swap?"
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto do preço. O impacto do preço pode ser maior do que o normal. Tem certeza que deseja continuar o Swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:49
 msgid "Confirm USD Price Unknown"
-msgstr "Confirmar preço de USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
 #: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
-msgstr "Trocar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:7
 msgid "Swap anyway"
-msgstr "Trocar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:8
 msgid "The route goes through Ethereum. Continue?"
-msgstr "A rota passa pelo Ethereum. Continuar?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:13
 msgid "Network Fee"
-msgstr "Taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:14
 msgid "Protocol Fee"
-msgstr "Taxa do Protocolo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:15
 msgid "Affiliate Fee"
-msgstr "Taxa de afiliado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:16
 msgid "Outbound Fee"
-msgstr "Taxa de Saída"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:17
 msgid "Rango Fee"
-msgstr "Taxa de Rango"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
 msgid "Smart Routing"
-msgstr "Roteamento inteligente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
-msgstr "Taxa mais baixa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:36
 msgid "Fastest Transfer"
-msgstr "Mais Rápido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:40
 msgid "Maximum Return"
-msgstr "Retorno Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:44
 msgid "Maximum Output"
-msgstr "Produção Máxima"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
 msgid "Route has been updated."
-msgstr "Rota foi atualizada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:12
 msgid "Output amount changed to {newOutputAmount} ({percentageChange}% change)."
-msgstr "Valor de saída alterado para {newOutputAmount} ( Alteração de{percentageChange}%)."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:20
 msgid "Route swappers has been updated."
-msgstr "Os trocadores de rota foram atualizados."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:22
 msgid "Route internal coins has been updated."
-msgstr "Moedas internas do itinerário foram atualizadas."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
 #: widget/embedded/src/pages/Routes.tsx:48
 msgid "Routes"
-msgstr "Rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:77
 msgid "From"
-msgstr "De"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:120
 msgid "To"
-msgstr "Para"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:47
 msgid "Light"
-msgstr "Fino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:56
 msgid "Dark"
-msgstr "Escuro"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:65
 msgid "Auto"
-msgstr "Automático"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:133
 msgid "Loading failed"
-msgstr "Falha no carregamento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:149
 msgid "Enabled bridges"
-msgstr "Pontes habilitados"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:167
 msgid "Enabled exchanges"
-msgstr "Trocas ativadas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:185
 #: widget/embedded/src/pages/LanguagePage.tsx:38
 msgid "Language"
-msgstr "IDIOMA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:198
 msgid "Infinite approval"
-msgstr "Aprovação infinita"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:208
 msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Ativar o modo de 'aprovação infinita' concede acesso irrestrito a contratos inteligentes de DEXes/Bridges, permitindo-lhes utilizar o valor do token aprovado, sem limitações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:228
 msgid "Theme"
-msgstr "Tema"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
-msgstr "Confirmar troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
-msgstr "Trocar de início"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
-msgstr "Você recebe"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:67
 msgid "History"
-msgstr "Histórico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:74
 msgid "Search Transaction"
-msgstr "Pesquisar transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
-msgstr "Idioma"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:151
 msgid "Exchanges"
-msgstr "Trocas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:112
 msgid "Bridges"
-msgstr "Pontes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Deselect all"
-msgstr "Desmarcar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Select all"
-msgstr "Selecionar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:121
 msgid "Search {sourceType}"
-msgstr "Pesquisar em {sourceType}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
-msgstr "Pesquisar Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:72
 msgid "Source"
-msgstr "fonte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:73
 msgid "Destination"
-msgstr "Destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:79
 msgid "Swap {type}"
-msgstr "Trocar {type}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:95
 msgid "Search Token"
-msgstr "Token de pesquisa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
-msgstr "Atualmente, você está no modo campanha com restrições sobre fontes de liquidez. Gostaria de mudar este modo e usar todas as fontes de liquidez disponíveis?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
-msgstr "O ID da requisição é necessário para exibir os detalhes do swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
 #: widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx:30
 msgid "Connect Wallets"
-msgstr "Conectar Carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:76
 msgid "Choose a wallet to connect."
-msgstr "Escolha uma carteira para se conectar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:25
 msgid "This week"
-msgstr "Esta semana"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:32
 msgid "This month"
-msgstr "Este Mês"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:39
 msgid "This year"
-msgstr "Esse ano"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:125
 msgid "Required: >= {min} {symbol}"
-msgstr "Obrigatório: >= {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:138
 msgid "Required: > {min} {symbol}"
-msgstr "Obrigatório: > {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:153
 msgid "Required: <= {max} {symbol}"
-msgstr "Obrigatório: <= {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:166
 msgid "Required: < {max} {symbol}"
-msgstr "Obrigatório: < {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:634
 msgid " for network fee"
-msgstr " para taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:637
 msgid " for swap"
-msgstr " para troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:640
 msgid " for input and network fee"
-msgstr " por taxa de entrada e de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:642
 msgid "Needs ≈ {requiredAmount} {symbol}{reason}, but you have {currentAmount} {symbol} in your {blockchain} wallet."
-msgstr "Precisa de {requiredAmount} {symbol}{reason}, mas você tem {currentAmount} {symbol} na sua carteira {blockchain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:702
 msgid "Waiting for connecting wallet"
-msgstr "Aguardando conexão da carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:706
 msgid "Waiting for other running tasks to be finished"
-msgstr "Aguardando o término de outras tarefas em execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:709
 msgid "Waiting for changing wallet network"
-msgstr "Aguardando mudança da rede de carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:6
 msgid "Sunday"
-msgstr "domingo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:7
 msgid "Monday"
-msgstr "Segunda-Feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:8
 msgid "Tuesday"
-msgstr "Terça-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:9
 msgid "Wednesday"
-msgstr "quarta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:10
 msgid "Thursday"
-msgstr "quinta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:11
 msgid "Friday"
-msgstr "Sexta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:12
 msgid "Saturday"
-msgstr "sábado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
-msgstr " Erro ao conectar ao servidor, por favor recarregue o app e tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/BottomLogo/BottomLogo.tsx:14
 msgid "Powered By"
-msgstr "Desenvolvido por"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/ChangeSlippageButton/ChangeSlippageButton.tsx:14
 msgid "Change Slippage"
-msgstr "Alterar Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx:63
@@ -1041,120 +1034,120 @@ msgstr ""
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:74
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:100
 msgid "Swap on {fromChain} via {swapper}"
-msgstr "Trocar em {fromChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:107
 msgid "Bridge to {toChain} via {swapper}"
-msgstr "Ponte para {toChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:28
 msgid "Swap Details"
-msgstr "Trocar detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:8
 msgid "Failed"
-msgstr "Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:10
 msgid "Complete"
-msgstr "Complete"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:12
 msgid "In progress"
-msgstr "Em Execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapToken.tsx:122
 msgid "Waiting for bridge transaction"
-msgstr "Aguardando a transação da bridge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:150
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:56
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:235
 msgid "Chain"
-msgstr "Corrente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:168
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:49
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:259
 msgid "Token"
-msgstr "Identificador"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:12
 msgid "Connected"
-msgstr "Conectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:13
 msgid "Disconnect"
-msgstr "Desconectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:18
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:19
 msgid "Install"
-msgstr "Instale"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:24
 msgid "Connecting..."
-msgstr "Conectandochar@@0"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:25
 msgid "Connecting"
-msgstr "Conectando"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:30
 msgid "Disconnected"
-msgstr "Desconectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:34
 msgid "you need to pass a correct state to Wallet."
-msgstr "você precisa passar um estado correto para o Wallet."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/HomePanel/HomePanel.tsx:123
 msgid "SWAP"
-msgstr "TROCA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
-msgstr "Saldo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:62
 msgid "Max"
-msgstr "Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={selectedSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:179
 msgid "swap from"
-msgstr "trocar de"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:198
 msgid "maximum amount of asset"
-msgstr "quantidade máxima de ativos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
-msgstr "trocar para"
+msgstr ""

--- a/translations/zh.po
+++ b/translations/zh.po
@@ -1,22 +1,11 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2023-11-06 17:24+0330\n"
+"POT-Creation-Date: 2024-03-10 23:38+0330\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: pt\n"
-"Project-Id-Version: rango\n"
-"Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2024-02-20 09:32\n"
-"Last-Translator: \n"
-"Language-Team: Portuguese\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Crowdin-Project: rango\n"
-"X-Crowdin-Project-ID: 622238\n"
-"X-Crowdin-Language: pt-PT\n"
-"X-Crowdin-File: en.po\n"
-"X-Crowdin-File-ID: 30\n"
+"Language: zh\n"
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:37
@@ -24,7 +13,7 @@ msgstr ""
 #: widget/embedded/src/pages/HistoryPage.tsx:85
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:131
 msgid "No results found"
-msgstr "Nenhum resultado encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:38
@@ -32,24 +21,24 @@ msgstr "Nenhum resultado encontrado"
 #: widget/embedded/src/pages/HistoryPage.tsx:87
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:132
 msgid "Try using different keywords"
-msgstr "Tente usar palavras-chave diferentes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainList/BlockchainList.tsx:66
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:46
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:40
 msgid "Select Blockchain"
-msgstr "Selecione a Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:66
 msgid "All"
-msgstr "TODOS"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx:100
 msgid "More +{count}"
-msgstr "Mais +{count}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx:16
@@ -64,221 +53,221 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:20
 msgid "Activate current tab"
-msgstr "Ativar a aba atual"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:22
 msgid "Currently, some transactions are running and being handled by other browser tab. If you activate this tab, all transactions that are already in the transaction sign step will expire."
-msgstr "No momento, algumas transações estão sendo executadas e sendo tratadas por outra aba do navegador. Se você ativar essa aba, todas as transações que já estão na etapa de sinal de transação irão expirar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx:32
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:269
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:237
 msgid "Confirm"
-msgstr "Confirmar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:284
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:359
 msgid "Your {blockchainName} wallets"
-msgstr "Suas carteiras {blockchainName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:303
 msgid "Insufficient account balance"
-msgstr "Saldo de conta insuficiente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:312
 msgid "Proceed anyway"
-msgstr "Continuar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:368
 msgid "You need to connect a {blockchainName} wallet."
-msgstr "Você precisa conectar uma carteira {blockchainName}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:425
 msgid "Send to a different address"
-msgstr "Enviar para outro endereço"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:442
 msgid "Your destination address"
-msgstr "Seu endereço de destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx:461
 msgid "Address {destination} doesn't match the blockchain address pattern."
-msgstr "O endereço {destination} não corresponde ao padrão do endereço da blockchain."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:168
 msgid "Add {chain} chain"
-msgstr "Adiciona cadeia {chain}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:217
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:250
 msgid "Add {blockchainDisplayName} Chain"
-msgstr "Adicionar Corrente {blockchainDisplayName}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:222
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:254
 msgid "You should connect a {blockchainDisplayName} supported wallet or choose a different {blockchainDisplayName} address"
-msgstr "Você deve conectar uma carteira com suporte do {blockchainDisplayName} ou escolher um endereço {blockchainDisplayName} diferente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:272
 msgid "{blockchainDisplayName} Chain Added"
-msgstr "{blockchainDisplayName} Cadeia Adicionada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:276
 msgid "{blockchainDisplayName} is added to your wallet, you can use it to swap."
-msgstr "{blockchainDisplayName} foi adicionado à sua carteira, você pode usá-lo para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:286
 msgid "Request Rejected"
-msgstr "Pedido rejeitado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:287
 msgid "You've rejected adding {blockchainDisplayName} chain to your wallet."
-msgstr "Você rejeitou adicionar {blockchainDisplayName} corrente à sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx:311
 msgid "Show more wallets"
-msgstr "Mostrar mais carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/CancelButton.tsx:14
 msgid "Cancel"
-msgstr "cancelar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:45
 msgid "Refresh"
-msgstr "atualizar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:61
 msgid "Notifications"
-msgstr "notificações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:74
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:311
 #: widget/embedded/src/pages/SettingsPage.tsx:38
 msgid "Settings"
-msgstr "Confirgurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx:84
 msgid "Transactions History"
-msgstr "Histórico de transações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HeaderButtons/WalletButton.tsx:14
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:16
 #: widget/embedded/src/constants/messages.ts:5
 msgid "Connect Wallet"
-msgstr "Conectar Carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx:118
 #: widget/embedded/src/utils/date.ts:18
 #: widget/embedded/src/utils/time.ts:22
 msgid "Today"
-msgstr "hoje"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.tsx:20
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:375
 msgid "Swaps steps"
-msgstr "Etapas de troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:28
 msgid "Retry"
-msgstr "Repetir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NoResult/NoResult.helpers.ts:40
 #: widget/embedded/src/pages/SettingsPage.tsx:51
 msgid "Reset"
-msgstr "Reset"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/NotificationContent/NotificationNotFound.tsx:13
 msgid "There are no notifications."
-msgstr "Não há notificações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:138
 msgid "Slippage Error"
-msgstr "Erro Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:139
 msgid "Slippage Warning"
-msgstr "Aviso Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:243
 msgid "Yours: {amount} {symbol}"
-msgstr "Sua: {amount} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:264
 msgid "Minimum required slippage is {minRequiredSlippage}"
-msgstr "Mínimo de slippage necessário é {minRequiredSlippage}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/Quote.tsx:363
 msgid "See All Routes"
-msgstr "Ver todas as rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:81
 msgid "View more info"
-msgstr "Ver mais informações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:91
 msgid "Gas & Fee Explanation"
-msgstr "Explicação de Gás e Taxa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:104
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:102
 msgid "Details"
-msgstr "detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:145
 msgid "Total Payable Fee"
-msgstr "Taxa total a pagar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:165
 msgid "Hide non-payable fees"
-msgstr "Ocultar taxas não-pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:166
 msgid "Show non-payable fees"
-msgstr "Mostrar tarifas não pagáveis"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:176
 msgid "Description"
-msgstr "Descrição:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteCostDetails.tsx:180
@@ -286,28 +275,26 @@ msgid ""
 "The following fees are considered in the transaction output and\n"
 "                you won’t need to pay extra gas for them."
 msgstr ""
-"As seguintes tarifas são consideradas no resultado da transação e\n"
-"                você não precisará pagar gás extra por elas."
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:25
 msgid "Swap input"
-msgstr "Swap input"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteSummary.tsx:44
 msgid "Estimated output"
-msgstr "Saída estimada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:64
 msgid "Via:"
-msgstr "Via:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quote/QuoteTrigger.tsx:147
 msgid "Chains:"
-msgstr "Correntas:"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Quotes/Quotes.tsx:92
@@ -317,720 +304,720 @@ msgstr ""
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:43
 msgid "Swapping"
-msgstr "Swapping"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:51
 msgid "Gas cost"
-msgstr "Custo de gás"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:59
 msgid "Receiving"
-msgstr "Recebimento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx:67
 msgid "Price impact"
-msgstr "Impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:35
 msgid "You need to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Você precisa aumentar o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:59
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:60
 #: widget/ui/src/containers/Warnings/MinRequiredSlippage.tsx:22
 msgid "We recommend you to increase slippage to at least {minRequiredSlippage} for this route."
-msgstr "Recomendamos que você aumente o slippage para pelo menos {minRequiredSlippage} para esta rota."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts:68
 msgid "Caution, your slippage is high."
-msgstr "Cuidado, seu slippage está alto."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx:73
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:25
 msgid "Change"
-msgstr "Troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:41
 msgid "Change settings"
-msgstr "Alterar configurações"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:51
 msgid "High slippage"
-msgstr "Alto slide"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:52
 msgid "Low slippage"
-msgstr "Slippage Baixo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:56
 msgid " Caution, your slippage is high (={userSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={userSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx:76
 msgid "Confirm anyway"
-msgstr "Confirmar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:35
 msgid "Slippage tolerance per swap"
-msgstr "Tolerância do slippage por swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/Slippage.tsx:88
 msgid "Custom"
-msgstr "Personalizado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:11
 msgid "Your transaction will be reverted if the price changes unfavorably by more than this percentage"
-msgstr "Sua transação será revertida se o preço mudar desfavoravelmente, mais do que esta porcentagem"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:16
 msgid "Warning"
-msgstr "ATENÇÃO"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/Slippage/SlippageTooltipContent.tsx:17
 msgid "This setting is applied per step (e.g. 1Inch, Thorchain, etc) which means only the step will be reverted, not the whole transaction."
-msgstr "Essa configuração é aplicada por passo (por exemplo, 1Inch, Thorchain, etc), que significa que apenas o passo será revertido, não toda a transação."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:25
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:246
 msgid "Swap and Bridge"
-msgstr "Inverter e Ponte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:33
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:286
 msgid "Request ID"
-msgstr "Solicitar ID"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:64
 msgid "Not found"
-msgstr "Não encontrado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.Placeholder.tsx:65
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:39
 msgid "Swap with request ID = {requestId} not found."
-msgstr "Trocar com o ID de requisição = {requestId} não encontrado."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:214
 msgid "You have received {amount} {token} in {conciseAddress} wallet on {chain} chain."
-msgstr "Você recebeu {amount} {token} em carteira {conciseAddress} na cadeia {chain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:230
 msgid "Transaction was not sent."
-msgstr "Transação não foi enviada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:232
 msgid "{amount} {symbol} on {blockchain} remain in your wallet"
-msgstr "{amount} {symbol} em {blockchain} permanece em sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:257
 msgid "Delete"
-msgstr "excluir"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetails/SwapDetails.tsx:278
 msgid "Try again"
-msgstr "Tente novamente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx:50
 msgid "View transaction"
-msgstr "Ver transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx:47
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:31
 msgid "Connect"
-msgstr "Conectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:43
 msgid "Swap Successful"
-msgstr "Troca bem sucedida"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:71
 msgid "Transaction Failed"
-msgstr "Transação Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:86
 msgid "Done"
-msgstr "Concluído"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:98
 msgid "Diagnosis"
-msgstr "Diagnóstico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx:105
 msgid "See Details"
-msgstr "Ver Detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:13
 msgid "Cancel Swap"
-msgstr "Cancelar Swap"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:14
 msgid "Are you sure you want to cancel this swap?"
-msgstr "Tem certeza que deseja cancelar este swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:22
 msgid "Yes, Cancel it"
-msgstr "Sim, Cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx:26
 msgid "No, Continue"
-msgstr "Não, continuar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:13
 msgid "Delete Transaction"
-msgstr "Excluir Transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:14
 msgid "Are you sure you want to delete this swap?"
-msgstr "Tem certeza que deseja excluir esta troca?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:22
 msgid "Yes, Delete it"
-msgstr "Sim, exclua-o"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx:27
 msgid "No, Cancel"
-msgstr "Não, cancele"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:12
 msgid "Change Network"
-msgstr "Alterar rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx:20
 msgid "Network Changed"
-msgstr "Rede alterada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/TokenList/TokenList.tsx:258
 msgid "Select Token"
-msgstr "Selecione o Token"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:19
 msgid "Wallet Connected"
-msgstr "Carteira conectada"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:20
 msgid "Your wallet is connected, you can use it to swap."
-msgstr "Sua carteira está conectada, você pode usá-la para trocar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:31
 msgid "Failed to Connect"
-msgstr "Falha na conexão"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:33
 msgid "Your wallet is not connected. Please try again."
-msgstr "Sua carteira não está conectada. Por favor, tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:42
 msgid "Connecting to your wallet"
-msgstr "Conectando-se à sua carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/components/WalletModal/WalletModalContent.tsx:43
 msgid "Click connect in your wallet popup."
-msgstr "Clique em conectar no pop-up da sua carteira."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:9
 msgid "Failed Network, Please retry your swap."
-msgstr "Falha na Rede, tente novamente sua alternância."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:11
 msgid "Please reset your liquidity sources."
-msgstr "Por favor, redefina suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:12
 msgid "You have limited the liquidity sources and this might result in Rango finding no routes. Please consider resetting your liquidity sources."
-msgstr "Você limitou as fontes de liquidez e isso pode resultar em que o Rango não encontre nenhuma rota. Por favor, considere redefinir suas fontes de liquidez."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:17
 msgid "No Routes Found."
-msgstr "Nenhuma rota encontrada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:18
 msgid "Reasons why Rango couldn't find a route: low liquidity on token, very low input amount or no routes available for the selected input/output token combination."
-msgstr "Motivos porque Rango não conseguiu encontrar uma rota: baixa liquidez no token, quantidade muito baixa de entrada ou nenhuma rota disponível para a combinação selecionada de entrada/saída do token."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:23
 msgid "Bridge Limit Error: Please increase your amount."
-msgstr "Erro no limite da ponte: Por favor, aumente o seu valor."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:26
 msgid "Bridge Limit Error: Please decrease your amount."
-msgstr "Erro no limite da ponte: Por favor, reduza seu montante."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:31
 msgid "High Price Impact"
-msgstr "Impacto de preço alto"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:32
 msgid "Price impact is too high!"
-msgstr "O impacto nos preços é muito alto!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:33
 msgid "The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap."
-msgstr "O impacto no preço é significativamente maior do que o valor permitido. Se você tem certeza, continue, caso contrário, altere o swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:36
 msgid "Confirm high price impact"
-msgstr "Confirmar alto impacto nos preços"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:39
 msgid "Route updated and price impact is too high, try again later!"
-msgstr "A rota atualizada e o impacto nos preços é muito alto, tente novamente mais tarde!"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:44
 msgid "USD Price Unknown"
-msgstr "Preço em USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:45
 msgid "USD Price Unknown, Cannot calculate Price Impact."
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto de preços."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:46
 msgid "USD Price Unknown, Cannot calculate Price Impact. The price impact may be higher than usual. Are you sure to continue the Swap?"
-msgstr "Preço em USD desconhecido, não é possível calcular o impacto do preço. O impacto do preço pode ser maior do que o normal. Tem certeza que deseja continuar o Swap?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/errors.ts:49
 msgid "Confirm USD Price Unknown"
-msgstr "Confirmar preço de USD desconhecido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:6
 #: widget/embedded/src/pages/Home.tsx:156
 msgid "Swap"
-msgstr "Trocar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:7
 msgid "Swap anyway"
-msgstr "Trocar mesmo assim"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/messages.ts:8
 msgid "The route goes through Ethereum. Continue?"
-msgstr "A rota passa pelo Ethereum. Continuar?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:13
 msgid "Network Fee"
-msgstr "Taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:14
 msgid "Protocol Fee"
-msgstr "Taxa do Protocolo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:15
 msgid "Affiliate Fee"
-msgstr "Taxa de afiliado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:16
 msgid "Outbound Fee"
-msgstr "Taxa de Saída"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:17
 msgid "Rango Fee"
-msgstr "Taxa de Rango"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:28
 msgid "Smart Routing"
-msgstr "Roteamento inteligente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:32
 msgid "Lowest Fee"
-msgstr "Taxa mais baixa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:36
 msgid "Fastest Transfer"
-msgstr "Mais Rápido"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:40
 msgid "Maximum Return"
-msgstr "Retorno Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/quote.ts:44
 msgid "Maximum Output"
-msgstr "Produção Máxima"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:10
 msgid "Route has been updated."
-msgstr "Rota foi atualizada."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:12
 msgid "Output amount changed to {newOutputAmount} ({percentageChange}% change)."
-msgstr "Valor de saída alterado para {newOutputAmount} ( Alteração de{percentageChange}%)."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:20
 msgid "Route swappers has been updated."
-msgstr "Os trocadores de rota foram atualizados."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/constants/warnings.ts:22
 msgid "Route internal coins has been updated."
-msgstr "Moedas internas do itinerário foram atualizadas."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx:53
 #: widget/embedded/src/pages/Routes.tsx:48
 msgid "Routes"
-msgstr "Rotas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:77
 msgid "From"
-msgstr "De"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Inputs/Inputs.tsx:120
 msgid "To"
-msgstr "Para"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:47
 msgid "Light"
-msgstr "Fino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:56
 msgid "Dark"
-msgstr "Escuro"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:65
 msgid "Auto"
-msgstr "Automático"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:133
 msgid "Loading failed"
-msgstr "Falha no carregamento"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:149
 msgid "Enabled bridges"
-msgstr "Pontes habilitados"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:167
 msgid "Enabled exchanges"
-msgstr "Trocas ativadas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:185
 #: widget/embedded/src/pages/LanguagePage.tsx:38
 msgid "Language"
-msgstr "IDIOMA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:198
 msgid "Infinite approval"
-msgstr "Aprovação infinita"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:208
 msgid "Enabling the 'Infinite approval' mode grants unrestricted access to smart contracts of DEXes/Bridges, allowing them to utilize the approved token amount without limitations."
-msgstr "Ativar o modo de 'aprovação infinita' concede acesso irrestrito a contratos inteligentes de DEXes/Bridges, permitindo-lhes utilizar o valor do token aprovado, sem limitações."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/containers/Settings/Lists.tsx:228
 msgid "Theme"
-msgstr "Tema"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:302
 msgid "Confirm Swap"
-msgstr "Confirmar troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:332
 msgid "Start Swap"
-msgstr "Trocar de início"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/ConfirmSwapPage.tsx:358
 msgid "You get"
-msgstr "Você recebe"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:67
 msgid "History"
-msgstr "Histórico"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/HistoryPage.tsx:74
 msgid "Search Transaction"
-msgstr "Pesquisar transação"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LanguagePage.tsx:51
 msgid "language"
-msgstr "Idioma"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:151
 msgid "Exchanges"
-msgstr "Trocas"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:41
 #: widget/ui/src/components/LiquiditySourceList/LiquiditySourceList.tsx:112
 msgid "Bridges"
-msgstr "Pontes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Deselect all"
-msgstr "Desmarcar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:109
 msgid "Select all"
-msgstr "Selecionar todos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/LiquiditySourcePage.tsx:121
 msgid "Search {sourceType}"
-msgstr "Pesquisar em {sourceType}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectBlockchainPage.tsx:58
 msgid "Search Blockchain"
-msgstr "Pesquisar Blockchain"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:72
 msgid "Source"
-msgstr "fonte"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:73
 msgid "Destination"
-msgstr "Destino"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:79
 msgid "Swap {type}"
-msgstr "Trocar {type}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SelectSwapItemsPage.tsx:95
 msgid "Search Token"
-msgstr "Token de pesquisa"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SettingsPage.tsx:45
 msgid "Currently, you're in campaign mode with restrictions on liquidity sources. Would you like to switch out of this mode and make use of all available liquidity sources?"
-msgstr "Atualmente, você está no modo campanha com restrições sobre fontes de liquidez. Gostaria de mudar este modo e usar todas as fontes de liquidez disponíveis?"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/SwapDetailsPage.tsx:27
 msgid "The request ID is necessary to display the swap details."
-msgstr "O ID da requisição é necessário para exibir os detalhes do swap."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:72
 #: widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx:30
 msgid "Connect Wallets"
-msgstr "Conectar Carteiras"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/pages/WalletsPage.tsx:76
 msgid "Choose a wallet to connect."
-msgstr "Escolha uma carteira para se conectar."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:25
 msgid "This week"
-msgstr "Esta semana"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:32
 msgid "This month"
-msgstr "Este Mês"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/date.ts:39
 msgid "This year"
-msgstr "Esse ano"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:125
 msgid "Required: >= {min} {symbol}"
-msgstr "Obrigatório: >= {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:138
 msgid "Required: > {min} {symbol}"
-msgstr "Obrigatório: > {min} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:153
 msgid "Required: <= {max} {symbol}"
-msgstr "Obrigatório: <= {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:166
 msgid "Required: < {max} {symbol}"
-msgstr "Obrigatório: < {max} {symbol}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:634
 msgid " for network fee"
-msgstr " para taxa de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:637
 msgid " for swap"
-msgstr " para troca"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:640
 msgid " for input and network fee"
-msgstr " por taxa de entrada e de rede"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:642
 msgid "Needs ≈ {requiredAmount} {symbol}{reason}, but you have {currentAmount} {symbol} in your {blockchain} wallet."
-msgstr "Precisa de {requiredAmount} {symbol}{reason}, mas você tem {currentAmount} {symbol} na sua carteira {blockchain}."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:702
 msgid "Waiting for connecting wallet"
-msgstr "Aguardando conexão da carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:706
 msgid "Waiting for other running tasks to be finished"
-msgstr "Aguardando o término de outras tarefas em execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/swap.ts:709
 msgid "Waiting for changing wallet network"
-msgstr "Aguardando mudança da rede de carteira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:6
 msgid "Sunday"
-msgstr "domingo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:7
 msgid "Monday"
-msgstr "Segunda-Feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:8
 msgid "Tuesday"
-msgstr "Terça-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:9
 msgid "Wednesday"
-msgstr "quarta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:10
 msgid "Thursday"
-msgstr "quinta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:11
 msgid "Friday"
-msgstr "Sexta-feira"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/embedded/src/utils/time.ts:12
 msgid "Saturday"
-msgstr "sábado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Alert/LoadingFailedAlert.tsx:13
 msgid " Error connecting server, please reload the app and try again."
-msgstr " Erro ao conectar ao servidor, por favor recarregue o app e tente novamente."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/BottomLogo/BottomLogo.tsx:14
 msgid "Powered By"
-msgstr "Desenvolvido por"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/ChangeSlippageButton/ChangeSlippageButton.tsx:14
 msgid "Change Slippage"
-msgstr "Alterar Slippage"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx:63
@@ -1041,120 +1028,120 @@ msgstr ""
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:74
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:100
 msgid "Swap on {fromChain} via {swapper}"
-msgstr "Trocar em {fromChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/StepDetails/StepDetails.tsx:107
 msgid "Bridge to {toChain} via {swapper}"
-msgstr "Ponte para {toChain} via {swapper}"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapDetailsPlaceholder/SwapDetailsPlaceholder.tsx:28
 msgid "Swap Details"
-msgstr "Trocar detalhes"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:8
 msgid "Failed"
-msgstr "Falhou"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:10
 msgid "Complete"
-msgstr "Complete"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapListItem.helpers.ts:12
 msgid "In progress"
-msgstr "Em Execução"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/SwapListItem/SwapToken.tsx:122
 msgid "Waiting for bridge transaction"
-msgstr "Aguardando a transação da bridge"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:150
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:56
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:235
 msgid "Chain"
-msgstr "Corrente"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/TokenPreview/TokenPreview.tsx:168
 #: widget/ui/src/containers/SwapInput/TokenSection.tsx:49
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:259
 msgid "Token"
-msgstr "Identificador"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:12
 msgid "Connected"
-msgstr "Conectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:13
 msgid "Disconnect"
-msgstr "Desconectar"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:18
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:19
 msgid "Install"
-msgstr "Instale"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:24
 msgid "Connecting..."
-msgstr "Conectandochar@@0"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:25
 msgid "Connecting"
-msgstr "Conectando"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:30
 msgid "Disconnected"
-msgstr "Desconectado"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/components/Wallet/Wallet.helpers.ts:34
 msgid "you need to pass a correct state to Wallet."
-msgstr "você precisa passar um estado correto para o Wallet."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/HomePanel/HomePanel.tsx:123
 msgid "SWAP"
-msgstr "TROCA"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:55
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:194
 msgid "Balance"
-msgstr "Saldo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/SwapInput/SwapInput.tsx:62
 msgid "Max"
-msgstr "Máximo"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/Warnings/HighSlippageWarning.tsx:22
 msgid " Caution, your slippage is high (={selectedSlippage}). Your trade may be front run."
-msgstr " Cuidado, sua página de slippage está alta ={selectedSlippage}). Sua operação pode ser iniciada primeiro."
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:179
 msgid "swap from"
-msgstr "trocar de"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:198
 msgid "maximum amount of asset"
-msgstr "quantidade máxima de ativos"
+msgstr ""
 
 #. js-lingui-explicit-id
 #: widget/ui/src/containers/TokenInfo/TokenInfo.tsx:181
 msgid "swap to"
-msgstr "trocar para"
+msgstr ""

--- a/widget/embedded/src/constants/languages.ts
+++ b/widget/embedded/src/constants/languages.ts
@@ -1,6 +1,22 @@
 import type { FlagPropTypes, Language } from '@rango-dev/ui';
 
-import { English, French, Japanese, Portuguese, Spanish } from '@rango-dev/ui';
+import {
+  Chinese,
+  English,
+  Finland,
+  French,
+  German,
+  Greece,
+  Italian,
+  Japanese,
+  Netherlands,
+  Poland,
+  Portuguese,
+  Russian,
+  Spanish,
+  Swedish,
+  Ukrainian,
+} from '@rango-dev/ui';
 
 export type LanguageItem = {
   title: string;
@@ -15,6 +31,16 @@ export const LANGUAGES: LanguageItem[] = [
   { title: 'French', label: 'Français', local: 'fr', SVGFlag: French },
   { title: 'Japanese', label: '日本語', local: 'ja', SVGFlag: Japanese },
   { title: 'Portuguese', label: 'Português', local: 'pt', SVGFlag: Portuguese },
+  { title: 'Chinese', label: '中国人', local: 'zh', SVGFlag: Chinese },
+  { title: 'Russian', label: 'Русский', local: 'ru', SVGFlag: Russian },
+  { title: 'German', label: 'Deutsch', local: 'de', SVGFlag: German },
+  { title: 'Ukrainian', label: 'Україні', local: 'uk', SVGFlag: Ukrainian },
+  { title: 'Swedish', label: 'svenska', local: 'sv', SVGFlag: Swedish },
+  { title: 'Finnish', label: 'Suomalainen', local: 'fi', SVGFlag: Finland },
+  { title: 'Dutch', label: 'Nederlands', local: 'nl', SVGFlag: Netherlands },
+  { title: 'Greek', label: 'Grieks', local: 'el', SVGFlag: Greece },
+  { title: 'Italian', label: 'Italiana', local: 'it', SVGFlag: Italian },
+  { title: 'Polish', label: 'Polski', local: 'pl', SVGFlag: Poland },
 ];
 
 export const DEFAULT_LANGUAGE = 'en';

--- a/widget/embedded/src/pages/LanguagePage.tsx
+++ b/widget/embedded/src/pages/LanguagePage.tsx
@@ -1,5 +1,7 @@
 import { i18n } from '@lingui/core';
 import {
+  Alert,
+  Divider,
   List,
   ListItemButton,
   Radio,
@@ -36,6 +38,12 @@ export function LanguagePage() {
         title: i18n.t('Language'),
       }}>
       <PageContainer>
+        <Alert
+          type="warning"
+          variant="alarm"
+          title="Important Notice: Machine translations are in use"
+        />
+        <Divider size={'8'} />
         <RadioRoot value={activeLanguage}>
           <List
             type={

--- a/widget/playground/src/constants/languages.ts
+++ b/widget/playground/src/constants/languages.ts
@@ -1,4 +1,20 @@
-import { English, French, Japanese, Portuguese, Spanish } from '@rango-dev/ui';
+import {
+  Chinese,
+  English,
+  Finland,
+  French,
+  German,
+  Greece,
+  Italian,
+  Japanese,
+  Netherlands,
+  Poland,
+  Portuguese,
+  Russian,
+  Spanish,
+  Swedish,
+  Ukrainian,
+} from '@rango-dev/ui';
 
 export const LANGUAGES = [
   { name: 'English', value: 'en', Icon: English },
@@ -6,4 +22,14 @@ export const LANGUAGES = [
   { name: 'French', value: 'fr', Icon: French },
   { name: 'Japanese', value: 'ja', Icon: Japanese },
   { name: 'Portuguese', value: 'pt', Icon: Portuguese },
+  { name: 'Chinese', value: 'zh', Icon: Chinese },
+  { name: 'Russian', value: 'ru', Icon: Russian },
+  { name: 'German', value: 'de', Icon: German },
+  { name: 'Ukrainian', value: 'uk', Icon: Ukrainian },
+  { name: 'Swedish', value: 'sv', Icon: Swedish },
+  { name: 'Finnish', value: 'fi', Icon: Finland },
+  { name: 'Dutch', value: 'nl', Icon: Netherlands },
+  { name: 'Greek', value: 'el', Icon: Greece },
+  { name: 'Italian', value: 'it', Icon: Italian },
+  { name: 'Polish', value: 'pl', Icon: Poland },
 ];

--- a/widget/ui/src/components/Flags/Bengali.tsx
+++ b/widget/ui/src/components/Flags/Bengali.tsx
@@ -1,0 +1,25 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Bengali(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#496e2d" d="M0 0h512v512H0z" />
+        <circle cx={200.3} cy={256} r={111.3} fill="#d80027" />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Chinese.tsx
+++ b/widget/ui/src/components/Flags/Chinese.tsx
@@ -1,0 +1,28 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Chinese(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#d80027" d="M0 0h512v512H0z" />
+        <path
+          fill="#ffda44"
+          d="m140.1 155.8 22.1 68h71.5l-57.8 42.1 22.1 68-57.9-42-57.9 42 22.2-68-57.9-42.1H118zm163.4 240.7-16.9-20.8-25 9.7 14.5-22.5-16.9-20.9 25.9 6.9 14.6-22.5 1.4 26.8 26 6.9-25.1 9.6zm33.6-61 8-25.6-21.9-15.5 26.8-.4 7.9-25.6 8.7 25.4 26.8-.3-21.5 16 8.6 25.4-21.9-15.5zm45.3-147.6L370.6 212l19.2 18.7-26.5-3.8-11.8 24-4.6-26.4-26.6-3.8 23.8-12.5-4.6-26.5 19.2 18.7zm-78.2-73-2 26.7 24.9 10.1-26.1 6.4-1.9 26.8-14.1-22.8-26.1 6.4 17.3-20.5-14.2-22.7 24.9 10.1z"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Finland.tsx
+++ b/widget/ui/src/components/Flags/Finland.tsx
@@ -1,0 +1,31 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Finland(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path
+          fill="#eee"
+          d="M0 0h133.6l35.3 16.7L200.3 0H512v222.6l-22.6 31.7 22.6 35.1V512H200.3l-32-19.8-34.7 19.8H0V289.4l22.1-33.3L0 222.6z"
+        />
+        <path
+          fill="#0052b4"
+          d="M133.6 0v222.6H0v66.8h133.6V512h66.7V289.4H512v-66.8H200.3V0h-66.7z"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/German.tsx
+++ b/widget/ui/src/components/Flags/German.tsx
@@ -1,0 +1,26 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function German(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#ffda44" d="m0 345 256.7-25.5L512 345v167H0z" />
+        <path fill="#d80027" d="m0 167 255-23 257 23v178H0z" />
+        <path fill="#333" d="M0 0h512v167H0z" />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Greece.tsx
+++ b/widget/ui/src/components/Flags/Greece.tsx
@@ -1,0 +1,31 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Greece(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path
+          fill="#0052b4"
+          d="M0 0h99l29 32 28-32h356v57l-32 28 32 29v57l-32 28 32 29v57l-32 28 32 28v57l-32 29 32 28v57H0v-57l32-28-32-29v-56l32-29-32-28V171l32-29-32-28Z"
+        />
+        <path
+          fill="#eee"
+          d="M99 0v114H0v57h99v114H0v57h512v-57H156V171h100v-57H156V0Zm157 57v57h256V57Zm0 114v57h256v-57ZM0 398v57h512v-57z"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Hindi.tsx
+++ b/widget/ui/src/components/Flags/Hindi.tsx
@@ -1,0 +1,29 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Hindi(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#eee" d="m0 160 256-32 256 32v192l-256 32L0 352z" />
+        <path fill="#ff9811" d="M0 0h512v160H0Z" />
+        <path fill="#6da544" d="M0 352h512v160H0Z" />
+        <circle cx={256} cy={256} r={72} fill="#0052b4" />
+        <circle cx={256} cy={256} r={48} fill="#eee" />
+        <circle cx={256} cy={256} r={24} fill="#0052b4" />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Indonesian.tsx
+++ b/widget/ui/src/components/Flags/Indonesian.tsx
@@ -1,0 +1,25 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Indonesian(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#eee" d="m0 256 249.6-41.3L512 256v256H0z" />
+        <path fill="#a2001d" d="M0 0h512v256H0z" />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Italian.tsx
+++ b/widget/ui/src/components/Flags/Italian.tsx
@@ -1,0 +1,26 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Italian(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#eee" d="M167 0h178l25.9 252.3L345 512H167l-29.8-253.4z" />
+        <path fill="#6da544" d="M0 0h167v512H0z" />
+        <path fill="#d80027" d="M345 0h167v512H345z" />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Malay.tsx
+++ b/widget/ui/src/components/Flags/Malay.tsx
@@ -1,0 +1,29 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Malay(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path
+          fill="#ffda44"
+          d="m0 167 253.8-19.3L512 167v178l-254.9 32.3L0 345z"
+        />
+        <path fill="#d80027" d="M0 0h512v167H0z" />
+        <path fill="#338af3" d="M0 345h512v167H0z" />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Netherlands.tsx
+++ b/widget/ui/src/components/Flags/Netherlands.tsx
@@ -1,0 +1,29 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Netherlands(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path
+          fill="#eee"
+          d="m0 167 253.8-19.3L512 167v178l-254.9 32.3L0 345z"
+        />
+        <path fill="#a2001d" d="M0 0h512v167H0z" />
+        <path fill="#0052b4" d="M0 345h512v167H0z" />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Poland.tsx
+++ b/widget/ui/src/components/Flags/Poland.tsx
@@ -1,0 +1,25 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Poland(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#d80027" d="m0 256 256.4-44.3L512 256v256H0z" />
+        <path fill="#eee" d="M0 0h512v256H0z" />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Russian.tsx
+++ b/widget/ui/src/components/Flags/Russian.tsx
@@ -1,0 +1,26 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Russian(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#0052b4" d="M512 170v172l-256 32L0 342V170l256-32z" />
+        <path fill="#eee" d="M512 0v170H0V0Z" />
+        <path fill="#d80027" d="M512 342v170H0V342Z" />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Swedish.tsx
+++ b/widget/ui/src/components/Flags/Swedish.tsx
@@ -1,0 +1,31 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Swedish(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path
+          fill="#0052b4"
+          d="M0 0h133.6l35.3 16.7L200.3 0H512v222.6l-22.6 31.7 22.6 35.1V512H200.3l-32-19.8-34.7 19.8H0V289.4l22.1-33.3L0 222.6z"
+        />
+        <path
+          fill="#ffda44"
+          d="M133.6 0v222.6H0v66.8h133.6V512h66.7V289.4H512v-66.8H200.3V0z"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Thai.tsx
+++ b/widget/ui/src/components/Flags/Thai.tsx
@@ -1,0 +1,32 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Thai(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path
+          fill="#d80027"
+          d="M0 0h512v89l-79.2 163.7L512 423v89H0v-89l82.7-169.6L0 89z"
+        />
+        <path
+          fill="#eee"
+          d="M0 89h512v78l-42.6 91.2L512 345v78H0v-78l40-92.5L0 167z"
+        />
+        <path fill="#0052b4" d="M0 167h512v178H0z" />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Turkish.tsx
+++ b/widget/ui/src/components/Flags/Turkish.tsx
@@ -1,0 +1,28 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Turkish(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#d80027" d="M0 0h512v512H0z" />
+        <g fill="#eee">
+          <path d="m245.5 209.2 21 29 34-11.1-21 29 21 28.9-34-11.1-21 29V267l-34-11.1 34-11z" />
+          <path d="M188.2 328.3a72.3 72.3 0 1 1 34.4-136 89 89 0 1 0 0 127.3 72 72 0 0 1-34.4 8.7z" />
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Ukrainian.tsx
+++ b/widget/ui/src/components/Flags/Ukrainian.tsx
@@ -1,0 +1,25 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Ukrainian(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#ffda44" d="m0 256 258-39.4L512 256v256H0z" />
+        <path fill="#338af3" d="M0 0h512v256H0z" />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/Vietnamese.tsx
+++ b/widget/ui/src/components/Flags/Vietnamese.tsx
@@ -1,0 +1,28 @@
+import type { FlagPropTypes } from './Flags.types';
+
+import React from 'react';
+
+import { DEFAULT_SIZE } from './Flags.constants';
+
+export default function Vietnamese(props: FlagPropTypes) {
+  const { size = DEFAULT_SIZE } = props;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512">
+      <mask id="a">
+        <circle cx={256} cy={256} r={256} fill="#fff" />
+      </mask>
+      <g mask="url(#a)">
+        <path fill="#d80027" d="M0 0h512v512H0z" />
+        <path
+          fill="#ffda44"
+          d="m256 133.6 27.6 85H373L300.7 271l27.6 85-72.3-52.5-72.3 52.6 27.6-85-72.3-52.6h89.4z"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/widget/ui/src/components/Flags/index.ts
+++ b/widget/ui/src/components/Flags/index.ts
@@ -1,9 +1,49 @@
+import Bengali from './Bengali';
+import Chinese from './Chinese';
 import English from './English';
+import Finland from './Finland';
 import French from './French';
+import German from './German';
+import Greece from './Greece';
+import Hindi from './Hindi';
+import Indonesian from './Indonesian';
+import Italian from './Italian';
 import Japanese from './Japanese';
+import Malay from './Malay';
+import Netherlands from './Netherlands';
+import Poland from './Poland';
 import Portuguese from './Portuguese';
+import Russian from './Russian';
 import Spanish from './Spanish';
+import Swedish from './Swedish';
+import Thai from './Thai';
+import Turkish from './Turkish';
+import Ukrainian from './Ukrainian';
+import Vietnamese from './Vietnamese';
 
 export type { FlagPropTypes } from './Flags.types';
 
-export { English, Spanish, Japanese, French, Portuguese };
+export {
+  English,
+  Spanish,
+  Japanese,
+  French,
+  Portuguese,
+  Hindi,
+  Chinese,
+  Bengali,
+  Russian,
+  Indonesian,
+  German,
+  Malay,
+  Swedish,
+  Thai,
+  Turkish,
+  Ukrainian,
+  Vietnamese,
+  Finland,
+  Netherlands,
+  Greece,
+  Italian,
+  Poland,
+};

--- a/widget/ui/src/components/I18nManager/I18nManager.tsx
+++ b/widget/ui/src/components/I18nManager/I18nManager.tsx
@@ -11,11 +11,21 @@ import React, { useEffect, useReducer } from 'react';
  *  "translations/*": ["../../translations/*"]
  *}
  */
+import { messages as deMessages } from '../../../../../translations/de';
+import { messages as elMessages } from '../../../../../translations/el';
 import { messages as enMessages } from '../../../../../translations/en';
 import { messages as esMessages } from '../../../../../translations/es';
+import { messages as fiMessages } from '../../../../../translations/fi';
 import { messages as frMessages } from '../../../../../translations/fr';
+import { messages as itMessages } from '../../../../../translations/it';
 import { messages as jaMessages } from '../../../../../translations/ja';
+import { messages as nlMessages } from '../../../../../translations/nl';
+import { messages as plMessages } from '../../../../../translations/pl';
 import { messages as ptMessages } from '../../../../../translations/pt';
+import { messages as ruMessages } from '../../../../../translations/ru';
+import { messages as svMessages } from '../../../../../translations/sv';
+import { messages as ukMessages } from '../../../../../translations/uk';
+import { messages as zhMessages } from '../../../../../translations/zh';
 
 const messages = {
   en: enMessages,
@@ -23,6 +33,16 @@ const messages = {
   ja: jaMessages,
   fr: frMessages,
   pt: ptMessages,
+  zh: zhMessages,
+  ru: ruMessages,
+  de: deMessages,
+  uk: ukMessages,
+  sv: svMessages,
+  fi: fiMessages,
+  nl: nlMessages,
+  el: elMessages,
+  it: itMessages,
+  pl: plMessages,
 };
 
 i18n.load(messages);


### PR DESCRIPTION
# Summary

add more languages to widget

Fixes # (issue)

- [x] A warning on top of language list to let user know we are using machine translations.
- [x] chinese (Mandarin)
- [x] Russian
- [x] German
- [x] Vietnamese
- [x] Swedish
- [x] Finnish
- [x] Dutch
- [x] Greek
- [x] Italian
- [x] Polish

Note: Not supported
Marathi, Telugu, Tamil, Nigerian Pidgin, Hindi, Bengali, Indonesian, Turkish, Vietnamese, Malay, Thai

# Checklist:

- [x] I have performed a self-review of my code
