### PR TITLE
fix: apply minor improvements to the widget

### DIFF
--- a/widget/embedded/src/components/QuoteSkeleton/QuoteSkeleton.styles.ts
+++ b/widget/embedded/src/components/QuoteSkeleton/QuoteSkeleton.styles.ts
@@ -8,11 +8,19 @@ export const Container = styled('div', {
   backgroundColor: '$$color',
   borderBottomLeftRadius: '$xm',
   borderBottomRightRadius: '$xm',
-  padding: '$15 ',
+  padding: '$15',
   variants: {
     rounded: {
       true: {
         borderRadius: '$xm',
+      },
+    },
+    expanded: {
+      true: {
+        paddingBottom: '3px',
+      },
+      false: {
+        paddingBottom: '$12',
       },
     },
   },

--- a/widget/embedded/src/components/QuoteSkeleton/QuoteSkeleton.tsx
+++ b/widget/embedded/src/components/QuoteSkeleton/QuoteSkeleton.tsx
@@ -11,7 +11,7 @@ export function QuoteSkeleton(props: PropTypes) {
   const { type, expanded, tagHidden = false } = props;
 
   return (
-    <Container rounded={type !== 'basic'}>
+    <Container expanded={expanded} rounded={type !== 'basic'}>
       <QuoteSummarySkeleton type={type} tagHidden={tagHidden} />
       <Chains>
         <Skeleton height={15} variant="rounded" />
@@ -19,7 +19,7 @@ export function QuoteSkeleton(props: PropTypes) {
 
       {expanded && (
         <Steps>
-          <Divider size={20} />
+          <Divider size={24} />
           <StepSkeleton />
           <StepSkeleton />
           <StepSkeleton separator={false} />

--- a/widget/embedded/src/components/QuoteSkeleton/QuoteSummarySkeleton.styles.ts
+++ b/widget/embedded/src/components/QuoteSkeleton/QuoteSummarySkeleton.styles.ts
@@ -9,7 +9,7 @@ export const BasicSummary = styled('div', {
 });
 
 export const Output = styled('div', {
-  padding: '$12 $0 $20 $0',
+  padding: '14px $0 $20 $0',
   display: 'flex',
   flexDirection: 'column',
 });
@@ -27,7 +27,7 @@ export const QuoteSummary = styled('div', {
 });
 
 export const QuoteSummarySeparator = styled('div', {
-  height: '$28',
+  height: '$24',
   marginLeft: '13px',
   borderLeft: '1px solid $neutral700',
 });

--- a/widget/embedded/src/components/QuoteSkeleton/QuoteSummarySkeleton.tsx
+++ b/widget/embedded/src/components/QuoteSkeleton/QuoteSummarySkeleton.tsx
@@ -41,11 +41,11 @@ export function QuoteSummarySkeleton(props: PropTypes) {
       {!tagHidden && (
         <>
           <FlexContent>
-            <Skeleton width={65} height={14} variant="rounded" />
+            <Skeleton width={65} height={20} variant="rounded" />
             <Divider size={4} direction="horizontal" />
-            <Skeleton width={65} height={14} variant="rounded" />
+            <Skeleton width={65} height={20} variant="rounded" />
             <Divider size={4} direction="horizontal" />
-            <Skeleton width={65} height={14} variant="rounded" />
+            <Skeleton width={65} height={20} variant="rounded" />
           </FlexContent>
           <Line />
           {!showAllRoutesSkeleton && <Divider size={4} />}
@@ -60,7 +60,7 @@ export function QuoteSummarySkeleton(props: PropTypes) {
           <Skeleton width={60} height={10} variant="rounded" />
         </FlexContent>
         {showAllRoutesSkeleton && (
-          <Skeleton width={100} height={22} variant="rounded" />
+          <Skeleton width={85} height={24} variant="rounded" />
         )}
       </div>
 
@@ -88,6 +88,7 @@ export function QuoteSummarySkeleton(props: PropTypes) {
             <QuoteSummarySeparator />
             {quotePreview}
           </SwapPreview>
+          <Divider size={12} />
         </>
       )}
     </div>

--- a/widget/embedded/src/components/QuoteSkeleton/StepSkeleton.styles.ts
+++ b/widget/embedded/src/components/QuoteSkeleton/StepSkeleton.styles.ts
@@ -11,6 +11,13 @@ export const StepTokens = styled('div', {
   paddingBottom: '$10',
   display: 'flex',
   alignItems: 'center',
+  variants: {
+    extraSpace: {
+      true: {
+        paddingBottom: '$40',
+      },
+    },
+  },
 });
 
 export const StepTokenInfo = styled('div', {

--- a/widget/embedded/src/components/QuoteSkeleton/StepSkeleton.tsx
+++ b/widget/embedded/src/components/QuoteSkeleton/StepSkeleton.tsx
@@ -23,7 +23,7 @@ export function StepSkeleton(props: PropTypes) {
       </StepTitle>
       <StepContent>
         <StepSeparator hideSeparator={!separator} />
-        <StepTokens>
+        <StepTokens extraSpace={separator}>
           <StepTokenInfo>
             <ChainToken size="small" loading chainImage="" tokenImage="" />
             <Divider direction="horizontal" size={8} />

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx
@@ -97,7 +97,7 @@ export function HighValueLossWarningModal(props: Props) {
       />
 
       <Flex>
-        <Divider size={20} />
+        <Divider size="4" />
         <Typography size="small" variant="title">
           {i18n.t('Details')}
         </Typography>

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts
@@ -66,6 +66,7 @@ export function makeAlerts(
     }
     if (warning.type === QuoteWarningType.HIGH_SLIPPAGE) {
       alertInfo.title = i18n.t('Caution, your slippage is high.');
+      alertInfo.action = 'change-settings';
     }
     return alertInfo;
   }

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.styles.ts
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.styles.ts
@@ -8,7 +8,7 @@ export const Flex = styled('div', {
   display: 'flex',
   flexDirection: 'column',
   alignItems: 'flex-start',
-  gap: 10,
+  gap: '$5',
   width: '100%',
 });
 

--- a/widget/embedded/src/components/Quotes/Quotes.tsx
+++ b/widget/embedded/src/components/Quotes/Quotes.tsx
@@ -67,6 +67,18 @@ export function Quotes(props: PropTypes) {
 
   return (
     <>
+      {hasSort && (
+        <>
+          <StrategyContent>
+            <Typography size="xmedium" variant="title">
+              {i18n.t('Sort by')}
+            </Typography>
+            <SelectStrategy container={getContainer()} />
+          </StrategyContent>
+          <Divider size="10" />
+        </>
+      )}
+
       {loading &&
         Array.from({ length: ITEM_SKELETON_COUNT }, (_, index) => (
           <React.Fragment key={index}>
@@ -85,17 +97,6 @@ export function Quotes(props: PropTypes) {
 
       {!loading && (
         <>
-          {hasSort && (
-            <>
-              <StrategyContent>
-                <Typography size="xmedium" variant="title">
-                  {i18n.t('Sort by')}
-                </Typography>
-                <SelectStrategy container={getContainer()} />
-              </StrategyContent>
-              <Divider size="10" />
-            </>
-          )}
           {hasQuotes
             ? sortQuotes.map((quote, index) => {
                 const quoteWarning = getQuoteWarning(quote);

--- a/widget/embedded/src/constants/errors.ts
+++ b/widget/embedded/src/constants/errors.ts
@@ -31,7 +31,7 @@ export const errorMessages = () => {
       impactTitle: i18n.t('High Price Impact'),
       title: i18n.t('Price impact is too high!'),
       description: i18n.t(
-        'The price impact is significantly higher than the allowed amount. If you are sure, continue, otherwise, change the swap.'
+        'The price impact is significantly higher than the allowed amount.'
       ),
       confirmMessage: i18n.t('Confirm high price impact'),
     },

--- a/widget/embedded/src/containers/Inputs/Inputs.tsx
+++ b/widget/embedded/src/containers/Inputs/Inputs.tsx
@@ -14,6 +14,7 @@ import {
   USD_VALUE_MAX_DECIMALS,
   USD_VALUE_MIN_DECIMALS,
 } from '../../constants/routing';
+import { useAppStore } from '../../store/AppStore';
 import { useQuoteStore } from '../../store/quote';
 import { useWalletsStore } from '../../store/wallets';
 import { getContainer } from '../../utils/common';
@@ -39,6 +40,9 @@ export function Inputs(props: PropTypes) {
     selectedQuote,
   } = useQuoteStore();
   const { connectedWallets, getBalanceFor } = useWalletsStore();
+  const {
+    config: { variant },
+  } = useAppStore();
 
   const fromTokenBalance = fromToken ? getBalanceFor(fromToken) : null;
 
@@ -116,7 +120,9 @@ export function Inputs(props: PropTypes) {
         <SwitchFromAndToButton />
       </FromContainer>
       <SwapInput
-        sharpBottomStyle={!!selectedQuote || fetchingQuote}
+        sharpBottomStyle={
+          variant === 'default' && (!!selectedQuote || fetchingQuote)
+        }
         label={i18n.t('To')}
         mode="To"
         fetchingQuote={fetchingQuote}

--- a/widget/embedded/src/pages/ConfirmSwapPage.tsx
+++ b/widget/embedded/src/pages/ConfirmSwapPage.tsx
@@ -383,7 +383,8 @@ export function ConfirmSwapPage() {
         <QuoteInfo
           quote={selectedQuote}
           type="swap-preview"
-          expanded={true}
+          expanded
+          tagHidden
           error={confirmSwapResult.error}
           loading={fetchingConfirmationQuote}
           warning={confirmSwapResult.warnings?.quote ?? null}

--- a/widget/embedded/src/utils/swap.ts
+++ b/widget/embedded/src/utils/swap.ts
@@ -750,11 +750,7 @@ export function getLastConvertedTokenInFailedSwap(
 }
 
 export function shouldRetrySwap(pendingSwap: PendingSwap) {
-  return (
-    pendingSwap.status === 'failed' &&
-    !!pendingSwap.finishTime &&
-    new Date().getTime() - parseInt(pendingSwap.finishTime) < 4 * 3600 * 1000
-  );
+  return pendingSwap.status === 'failed';
 }
 
 export function confirmSwapDisabled(


### PR DESCRIPTION
# Summary

some minor improvements on the widget

Fixes # (issue)

- [x] The height of the quote skeleton doesn't align with the quote component, resulting in a minor layout shift 
![image1](https://github.com/rango-exchange/rango-client/assets/120931880/d1fe7f92-6852-4556-9656-a7dba7fae518)
- [x] Display sorting strategy for quotes upon loading 
![image2](https://github.com/rango-exchange/rango-client/assets/120931880/314cbdbc-7c45-42fc-bb5c-649e0c8f2554)
- [x] In expanded mode, the swap input component's bottom corners should have rounded edges
![image3](https://github.com/rango-exchange/rango-client/assets/120931880/05e22a62-fe0c-4c70-b9ae-25bdc46201b5)
- [x] In expanded mode, the quote modals overflow due to the smaller height of the swap-box
![image4](https://github.com/rango-exchange/rango-client/assets/120931880/7b8d0806-ac59-437b-b714-90e9c252a08b)
- [x] Remove the time restriction for the "try again" functionality

# Checklist:

- [x] I have performed a self-review of my code
