### PR TITLE
fix: close completeModal when requestId is changed

### DIFF
--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -109,6 +109,8 @@ export function SwapDetails(props: SwapDetailsProps) {
       if (swap.status === 'success' || swap.status === 'failed') {
         setShowCompletedModal(swap.status);
         setAsRead(swap.requestId);
+      } else if (showCompletedModal) {
+        setShowCompletedModal(null);
       }
     }
   }, [swap.status, swap.requestId]);


### PR DESCRIPTION
# Summary
There was an issue in dapp that we didn't close complete modals when clicked on notification items.


# How did you test this change?
Linking by alpha branch of dapp


# Checklist:

- [x] I have performed a self-review of my code
