### PR TITLE
feat: attach config passed to widget to window

### DIFF
--- a/widget/embedded/global-env.d.ts
+++ b/widget/embedded/global-env.d.ts
@@ -1,0 +1,12 @@
+import type { WidgetConfig } from './src';
+
+export {};
+
+declare global {
+  interface Window {
+    __rango: {
+      config: WidgetConfig;
+      dappConfig: WidgetConfig;
+    };
+  }
+}

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -34,6 +34,8 @@ function Main(props: PropsWithChildren<PropTypes>) {
   const { updateConfig, updateSettings, fetch: fetchMeta } = useAppStore();
   const blockchains = useAppStore().blockchains();
   const tokens = useAppStore().tokens();
+  const config = useAppStore().config;
+
   const walletOptions: ProvidersOptions = {
     walletConnectProjectId: props.config?.walletConnectProjectId,
   };
@@ -50,6 +52,10 @@ function Main(props: PropsWithChildren<PropTypes>) {
     if (props.config) {
       updateConfig(props.config);
       updateSettings(props.config);
+      window['__rango'] = {
+        config,
+        dappConfig: props.config,
+      };
     }
   }, [props.config]);
 

--- a/widget/embedded/tsconfig.json
+++ b/widget/embedded/tsconfig.json
@@ -1,7 +1,12 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "extends": "../../tsconfig.lib.json",
-  "include": ["src", "types"],
+  "include": [
+    "src",
+    "types",
+    "../../global-wallets-env.d.ts",
+    "./global-env.d.ts"
+  ],
   "compilerOptions": {
     "module": "esnext",
     "outDir": "dist",


### PR DESCRIPTION
# Summary

attach `config` passed to widget to window

e.g.:
window.__rango.config

# How did you test this change?

The config is available in the console.

# Checklist:

- [x] I have performed a self-review of my code
