### PR TITLE
fix: remove redundant punctuation from settings page

### DIFF
--- a/widget/embedded/src/containers/Settings/Lists.tsx
+++ b/widget/embedded/src/containers/Settings/Lists.tsx
@@ -199,7 +199,7 @@ export function SettingsLists() {
           {currentLanguage}
         </Typography>
         <Divider direction="horizontal" size={8} />
-        <ChevronRightIcon color="gray" />,
+        <ChevronRightIcon color="gray" />
       </>
     ),
     onClick: () => navigate(navigationRoutes.languages),


### PR DESCRIPTION
# Summary
Removed redundant punctuation from settings page


# Checklist:

- [x] I have performed a self-review of my code

