### PR TITLE
fix: get theme from config when singleTheme is true

### DIFF
--- a/widget/embedded/src/store/slices/settings.ts
+++ b/widget/embedded/src/store/slices/settings.ts
@@ -153,14 +153,16 @@ export const createSettingsSlice: StateCreator<
       language,
     })),
   updateSettings: (nextConfig: WidgetConfig) => {
-    const { features } = nextConfig;
+    const { features, theme } = nextConfig;
 
     const isThemeHidden = isFeatureHidden('theme', features);
     const isLanguageHidden = isFeatureHidden('language', features);
     const isLiquidityHidden = isFeatureHidden('liquiditySource', features);
+    const singleTheme = theme?.singleTheme;
 
     set({
       ...(isThemeHidden && { theme: nextConfig.theme?.mode || 'auto' }),
+      ...(singleTheme && { theme: nextConfig.theme?.mode || 'light' }),
       ...(isLanguageHidden && {
         language: nextConfig.language || DEFAULT_LANGUAGE,
       }),


### PR DESCRIPTION
# Summary
When the previous setting of widget mode is dark or light, and single theme is true, the theme didn't change.

Fixes # (issue)


# Checklist:

- [x] I have performed a self-review of my code
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
