### PR TITLE
Hotfix/add ability to exclude packages in deploy

### DIFF
--- a/scripts/deploy/command.mjs
+++ b/scripts/deploy/command.mjs
@@ -6,11 +6,14 @@ import { build } from '../publish/build.mjs';
 import { logAsSection } from '../publish/utils.mjs';
 import { deployProjectsToVercel } from './utils.mjs';
 
+const EXCLUDED_PACKAGES = ['@rango-dev/widget-iframe'];
+
 // TODO: Working directory should be empty.
 async function run() {
   // Detect last release and what packages has changed since then.
   const packages = await workspacePackages();
   const privatePackages = packages.filter((pkg) => {
+    if (EXCLUDED_PACKAGES.includes(pkg.name)) return false;
     return pkg.private;
   });
 


### PR DESCRIPTION
# Summary

Adding ability to exclude some packages when we are deploying. this is useful for `iframe`, because it's being release in a separate flow.
