### PR TITLE
feat: add selectable chain connect modal

### DIFF
--- a/wallets/shared/src/rango.ts
+++ b/wallets/shared/src/rango.ts
@@ -81,6 +81,15 @@ export enum WalletTypes {
   MY_TON_WALLET = 'mytonwallet',
 }
 
+export enum ChainTypes {
+  SOLANA = 'SOLANA',
+  EVM = 'EVM',
+  COSMOS = 'COSMOS',
+  UTXO = 'UTXO',
+  STARKNET = 'STARKNET',
+  TRON = 'TRON',
+}
+
 export enum Networks {
   BTC = 'BTC',
   BSC = 'BSC',
@@ -143,6 +152,16 @@ export enum Networks {
   // Using instead of null
   Unknown = 'Unkown',
 }
+
+export const WALLET_SUPPORTED_CHAIN_TYPES: {
+  walletType: WalletTypes;
+  chainTypes: ChainTypes[];
+}[] = [
+  {
+    walletType: WalletTypes.PHANTOM,
+    chainTypes: [ChainTypes.SOLANA, ChainTypes.EVM, ChainTypes.UTXO],
+  },
+];
 
 export const XDEFI_WALLET_SUPPORTED_NATIVE_CHAINS: string[] = [
   Networks.BTC,

--- a/widget/embedded/src/components/WalletChainsModal/WalletChainsModal.styles.ts
+++ b/widget/embedded/src/components/WalletChainsModal/WalletChainsModal.styles.ts
@@ -1,0 +1,7 @@
+import { styled } from '@rango-dev/ui';
+
+export const ChainTypesList = styled('ul', {
+  padding: 0,
+  paddingTop: '$4',
+  paddingBottom: '$4',
+});

--- a/widget/embedded/src/components/WalletChainsModal/WalletChainsModal.tsx
+++ b/widget/embedded/src/components/WalletChainsModal/WalletChainsModal.tsx
@@ -1,0 +1,114 @@
+import type { PropTypes } from './WalletChainsModal.types';
+
+import { i18n } from '@lingui/core';
+import {
+  Button,
+  Checkbox,
+  Image,
+  ListItemButton,
+  MessageBox,
+} from '@rango-dev/ui';
+import {
+  ChainTypes,
+  WALLET_SUPPORTED_CHAIN_TYPES,
+} from '@rango-dev/wallets-shared';
+import React, { useState } from 'react';
+
+import { WIDGET_UI_ID } from '../../constants';
+import { WatermarkedModal } from '../common/WatermarkedModal';
+import { WalletImageContainer } from '../HeaderButtons/HeaderButtons.styles';
+import {
+  LogoContainer,
+  Spinner,
+} from '../WalletModal/WalletModalContent.styles';
+
+import { ChainTypesList } from './WalletChainsModal.styles';
+
+const chainTypeItems = [
+  { title: 'Solana', value: ChainTypes.SOLANA },
+  { title: 'EVM', value: ChainTypes.EVM },
+  { title: 'Cosmos', value: ChainTypes.COSMOS },
+  { title: 'UTXO', value: ChainTypes.UTXO },
+  { title: 'Starknet', value: ChainTypes.STARKNET },
+  { title: 'Tron', value: ChainTypes.TRON },
+];
+
+export const WalletChainsModal = (props: PropTypes) => {
+  const {
+    open,
+    onClose,
+    onConfirm,
+    selectedWalletType,
+    selectedWalletImage,
+    requiredChainType,
+  } = props;
+  const [selectedChainTypes, setSelectedChainTypes] = useState<ChainTypes[]>(
+    requiredChainType ? [requiredChainType] : []
+  );
+
+  const selectedWalletSupportedChainTypes = WALLET_SUPPORTED_CHAIN_TYPES.find(
+    (walletSupportedChainTypes) =>
+      walletSupportedChainTypes.walletType === selectedWalletType
+  )?.chainTypes;
+
+  const selectedWalletChainTypeItems = !!selectedWalletSupportedChainTypes
+    ? chainTypeItems.filter((chainTypeItem) =>
+        selectedWalletSupportedChainTypes.includes(chainTypeItem.value)
+      )
+    : chainTypeItems;
+
+  const handleChainTypeClick = (value: ChainTypes) =>
+    setSelectedChainTypes((selectedChainTypes) =>
+      selectedChainTypes.includes(value)
+        ? selectedChainTypes.filter((chainType) => chainType !== value)
+        : selectedChainTypes.concat(value)
+    );
+
+  return (
+    <WatermarkedModal
+      open={open}
+      onClose={onClose}
+      container={
+        document.getElementById(WIDGET_UI_ID.SWAP_BOX_ID) || document.body
+      }>
+      <MessageBox
+        type="info"
+        title={i18n.t('Select chain types')}
+        description={i18n.t(
+          `This wallet supports multiple chains. Select which chain you'd like to connect to.`
+        )}
+        icon={
+          <LogoContainer>
+            <WalletImageContainer>
+              <Image src={selectedWalletImage} size={45} />
+            </WalletImageContainer>
+            <Spinner />
+          </LogoContainer>
+        }
+      />
+      <ChainTypesList>
+        {selectedWalletChainTypeItems.map((chainTypeItem) => (
+          <ListItemButton
+            key={chainTypeItem.value}
+            id={chainTypeItem.value}
+            title={chainTypeItem.title}
+            hasDivider
+            style={{ height: 60 }}
+            onClick={() => handleChainTypeClick(chainTypeItem.value)}
+            end={
+              <Checkbox
+                checked={selectedChainTypes.includes(chainTypeItem.value)}
+              />
+            }
+          />
+        ))}
+      </ChainTypesList>
+      <Button
+        type="primary"
+        disabled={!selectedChainTypes.length}
+        onClick={() => onConfirm(selectedChainTypes)}>
+        {i18n.t('Confirm')}
+      </Button>
+    </WatermarkedModal>
+  );
+};

--- a/widget/embedded/src/components/WalletChainsModal/WalletChainsModal.types.ts
+++ b/widget/embedded/src/components/WalletChainsModal/WalletChainsModal.types.ts
@@ -1,0 +1,10 @@
+import type { ChainTypes } from '@rango-dev/wallets-shared';
+
+export interface PropTypes {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (chainTypes: ChainTypes[]) => void;
+  selectedWalletType: string;
+  selectedWalletImage: string;
+  requiredChainType?: null | ChainTypes;
+}

--- a/widget/embedded/src/components/WalletChainsModal/index.ts
+++ b/widget/embedded/src/components/WalletChainsModal/index.ts
@@ -1,0 +1,1 @@
+export { WalletChainsModal } from './WalletChainsModal';

--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -20,6 +20,7 @@ import type { BlockchainMeta, Token, WalletDetail } from 'rango-sdk';
 import { WalletState as WalletStatus } from '@rango-dev/ui';
 import { readAccountAddress } from '@rango-dev/wallets-react';
 import {
+  ChainTypes,
   detectInstallLink,
   getCosmosExperimentalChainInfo,
   isEvmAddress,
@@ -221,6 +222,37 @@ export function getRequiredChains(quote: SelectedQuote | null) {
     }
   });
   return wallets;
+}
+
+export function getRequiredChainType(
+  blockchains: BlockchainMeta[],
+  chain: string
+) {
+  const selectedBlockchain = blockchains.find(
+    (blockchain) => blockchain.name === chain
+  );
+
+  if (!selectedBlockchain) {
+    return null;
+  }
+
+  switch (selectedBlockchain.type) {
+    case 'EVM':
+      return ChainTypes.EVM;
+    case 'STARKNET':
+      return ChainTypes.STARKNET;
+    case 'TRANSFER':
+      return ChainTypes.UTXO;
+    case 'TRON':
+      return ChainTypes.TRON;
+    case 'COSMOS':
+      return ChainTypes.COSMOS;
+    case 'SOLANA':
+      return ChainTypes.SOLANA;
+
+    default:
+      return null;
+  }
 }
 
 type Blockchain = { name: string; accounts: ConnectedWallet[] };


### PR DESCRIPTION
# Summary

Added selectable chain connect modal.

Fixes # rf-1373


# How did you test this change?

When you try to connect phantom wallet, a modal should be displayed to select desired chains to connect.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
