### PR TITLE
fix: fix the connection problem that happens when another wallet takes over the requested one

### DIFF
--- a/wallets/provider-argentx/src/index.ts
+++ b/wallets/provider-argentx/src/index.ts
@@ -52,10 +52,10 @@ export const subscribe: Subscribe = ({ instance, state, updateAccounts }) => {
       }
     }
   };
-  instance?.on('accountsChanged', handleAccountsChanged);
+  instance?.on?.('accountsChanged', handleAccountsChanged);
 
   return () => {
-    instance?.off('accountsChanged', handleAccountsChanged);
+    instance?.off?.('accountsChanged', handleAccountsChanged);
   };
 };
 

--- a/wallets/provider-braavos/src/index.ts
+++ b/wallets/provider-braavos/src/index.ts
@@ -39,9 +39,9 @@ export const subscribe: Subscribe = ({ instance, state, updateAccounts }) => {
       }
     }
   };
-  instance?.on('accountsChanged', handleAccountsChanged);
+  instance?.on?.('accountsChanged', handleAccountsChanged);
   return () => {
-    instance?.off('accountsChanged', handleAccountsChanged);
+    instance?.off?.('accountsChanged', handleAccountsChanged);
   };
 };
 

--- a/wallets/provider-brave/src/index.ts
+++ b/wallets/provider-brave/src/index.ts
@@ -121,18 +121,18 @@ export const subscribe: Subscribe = ({
     updateAccounts([account]);
   };
 
-  evm_instance?.on('accountsChanged', handleEvmAccountsChanged);
+  evm_instance?.on?.('accountsChanged', handleEvmAccountsChanged);
 
-  evm_instance?.on('chainChanged', handleEvmChainChanged);
+  evm_instance?.on?.('chainChanged', handleEvmChainChanged);
 
-  sol_instance?.on('accountChanged', handleSolanaAccountsChanged);
+  sol_instance?.on?.('accountChanged', handleSolanaAccountsChanged);
 
   return () => {
-    evm_instance?.off('accountsChanged', handleEvmAccountsChanged);
+    evm_instance?.off?.('accountsChanged', handleEvmAccountsChanged);
 
-    evm_instance?.off('chainChanged', handleEvmChainChanged);
+    evm_instance?.off?.('chainChanged', handleEvmChainChanged);
 
-    sol_instance?.off('accountChanged', handleSolanaAccountsChanged);
+    sol_instance?.off?.('accountChanged', handleSolanaAccountsChanged);
   };
 };
 

--- a/wallets/provider-clover/src/index.ts
+++ b/wallets/provider-clover/src/index.ts
@@ -58,7 +58,7 @@ export const subscribe: Subscribe = ({
 }) => {
   const ethInstance = chooseInstance(instance, meta, Networks.ETHEREUM);
   const solanaInstance = chooseInstance(instance, meta, Networks.SOLANA);
-  ethInstance?.on('accountsChanged', async (addresses: string[]) => {
+  ethInstance?.on?.('accountsChanged', async (addresses: string[]) => {
     if (state.connected) {
       if (ethInstance) {
         const eth_chainId = meta

--- a/wallets/provider-coin98/src/index.ts
+++ b/wallets/provider-coin98/src/index.ts
@@ -77,10 +77,10 @@ export const subscribe: Subscribe = ({
     updateChainId(chainId);
     connect(network);
   };
-  eth?.on('chainChanged', handleChainChanged);
+  eth?.on?.('chainChanged', handleChainChanged);
 
   return () => {
-    eth?.off('chainChanged', handleChainChanged);
+    eth?.off?.('chainChanged', handleChainChanged);
   };
 };
 

--- a/wallets/provider-coinbase/src/index.ts
+++ b/wallets/provider-coinbase/src/index.ts
@@ -93,14 +93,14 @@ export const subscribe: Subscribe = (options) => {
       connect(network);
     }
   };
-  ethInstance?.on('accountsChanged', handleEvmAccountsChanged);
+  ethInstance?.on?.('accountsChanged', handleEvmAccountsChanged);
 
-  solanaInstance?.on('accountChanged', handleSolanaAccountChanged);
+  solanaInstance?.on?.('accountChanged', handleSolanaAccountChanged);
 
   return () => {
-    ethInstance?.off('accountsChanged', handleEvmAccountsChanged);
+    ethInstance?.off?.('accountsChanged', handleEvmAccountsChanged);
 
-    solanaInstance?.off('accountChanged', handleSolanaAccountChanged);
+    solanaInstance?.off?.('accountChanged', handleSolanaAccountChanged);
   };
 };
 export const switchNetwork: SwitchNetwork = switchNetworkForEvm;

--- a/wallets/provider-cosmostation/src/index.ts
+++ b/wallets/provider-cosmostation/src/index.ts
@@ -101,7 +101,7 @@ export const subscribe: Subscribe = ({
     connect();
   };
 
-  window.cosmostation.cosmos.on('accountChanged', handleCosmosAccountChanged);
+  window.cosmostation.cosmos.on?.('accountChanged', handleCosmosAccountChanged);
 
   return () => {
     if (cleanupEvm) {

--- a/wallets/provider-exodus/src/index.ts
+++ b/wallets/provider-exodus/src/index.ts
@@ -62,7 +62,7 @@ export const subscribe: Subscribe = (options) => {
     Networks.SOLANA
   );
   const { connect, updateAccounts, state, updateChainId, meta } = options;
-  ethInstance?.on('accountsChanged', (addresses: string[]) => {
+  ethInstance?.on?.('accountsChanged', (addresses: string[]) => {
     const eth_chainId = meta
       .filter(isEvmBlockchain)
       .find((blockchain) => blockchain.name === Networks.ETHEREUM)?.chainId;
@@ -74,7 +74,7 @@ export const subscribe: Subscribe = (options) => {
     }
   });
 
-  solanaInstance?.on('accountChanged', async (publicKey: string) => {
+  solanaInstance?.on?.('accountChanged', async (publicKey: string) => {
     if (state.network != Networks.SOLANA) {
       updateChainId(meta.filter(isSolanaBlockchain)[0].chainId);
     }

--- a/wallets/provider-frontier/src/index.ts
+++ b/wallets/provider-frontier/src/index.ts
@@ -88,14 +88,14 @@ export const subscribe: Subscribe = (options) => {
       connect(network);
     }
   };
-  ethInstance?.on('accountsChanged', handleEvmAccountsChanged);
+  ethInstance?.on?.('accountsChanged', handleEvmAccountsChanged);
 
-  solanaInstance?.on('accountChanged', handleSolanaAccountsChanged);
+  solanaInstance?.on?.('accountChanged', handleSolanaAccountsChanged);
 
   return () => {
-    ethInstance?.off('accountsChanged', handleEvmAccountsChanged);
+    ethInstance?.off?.('accountsChanged', handleEvmAccountsChanged);
 
-    solanaInstance?.off('accountChanged', handleSolanaAccountsChanged);
+    solanaInstance?.off?.('accountChanged', handleSolanaAccountsChanged);
   };
 };
 export const switchNetwork: SwitchNetwork = async (options) => {

--- a/wallets/provider-okx/src/index.ts
+++ b/wallets/provider-okx/src/index.ts
@@ -63,10 +63,10 @@ export const subscribe: Subscribe = ({ instance, updateAccounts, meta }) => {
     const [{ accounts, chainId }] = await getSolanaAccounts(instance);
     updateAccounts(accounts, chainId);
   };
-  ethInstance?.on('accountsChanged', handleEvmAccountsChanged);
+  ethInstance?.on?.('accountsChanged', handleEvmAccountsChanged);
 
   return () => {
-    ethInstance?.off('accountsChanged', handleEvmAccountsChanged);
+    ethInstance?.off?.('accountsChanged', handleEvmAccountsChanged);
   };
 };
 

--- a/wallets/provider-phantom/src/index.ts
+++ b/wallets/provider-phantom/src/index.ts
@@ -36,10 +36,10 @@ export const subscribe: Subscribe = ({ instance, updateAccounts, connect }) => {
       connect(network);
     }
   };
-  instance?.on('accountChanged', handleAccountsChanged);
+  instance?.on?.('accountChanged', handleAccountsChanged);
 
   return () => {
-    instance?.off('accountChanged', handleAccountsChanged);
+    instance?.off?.('accountChanged', handleAccountsChanged);
   };
 };
 

--- a/wallets/provider-xdefi/src/index.ts
+++ b/wallets/provider-xdefi/src/index.ts
@@ -107,10 +107,10 @@ export const subscribe: Subscribe = ({
     connect(network);
   };
   const eth = chooseInstance(instance, meta, Networks.ETHEREUM);
-  eth?.on('chainChanged', handleChainChanged);
+  eth?.on?.('chainChanged', handleChainChanged);
 
   return () => {
-    eth?.off('chainChanged', handleChainChanged);
+    eth?.off?.('chainChanged', handleChainChanged);
   };
 };
 

--- a/wallets/shared/src/providers.ts
+++ b/wallets/shared/src/providers.ts
@@ -52,13 +52,13 @@ export const subscribeToEvm: Subscribe = ({
     updateChainId(chainId);
   };
 
-  instance?.on('accountsChanged', handleAccountsChanged);
+  instance?.on?.('accountsChanged', handleAccountsChanged);
 
-  instance?.on('chainChanged', handleChainChanged);
+  instance?.on?.('chainChanged', handleChainChanged);
 
   const cleanup = () => {
-    instance?.off('accountsChanged', handleAccountsChanged);
-    instance?.off('chainChanged', handleChainChanged);
+    instance?.off?.('accountsChanged', handleAccountsChanged);
+    instance?.off?.('chainChanged', handleChainChanged);
   };
 
   return cleanup;


### PR DESCRIPTION
# Summary

When a user tries to connect to a particular wallet and it gets overridden by another wallet, and the instance lacks the `on` or `off` methods, it results in an error or app malfunction: 
![image1](https://github.com/rango-exchange/rango-client/assets/120931880/4df5c575-42ae-448d-b80d-249f817b0002)


Fixes # (issue)

We resolve this by conditionally invoking `on` and `off` methods.

# How did you test this change?

You can test this by enabling both the 'Core' and 'Metamask' wallets, then attempting to connect to the 'Metamask' wallet. The overridden wallet, 'Core' in this scenario, should connect successfully.

# Checklist:

- [x] I have performed a self-review of my code
