### PR TITLE
fix: fix tron-link wallet connecting error

### DIFF
--- a/wallets/provider-tron-link/src/index.ts
+++ b/wallets/provider-tron-link/src/index.ts
@@ -37,9 +37,7 @@ export const connect: Connect = async ({ instance }) => {
       throw new Error(r.message);
     }
   }
-  const address = instance.tronWeb.address.fromHex(
-    (await instance.tronWeb.trx.getAccount()).address.toString()
-  );
+  const address = instance.tronWeb.defaultAddress.base58;
   // TODO check connected network
   return { accounts: address ? [address] : [], chainId: Networks.TRON };
 };


### PR DESCRIPTION
# Summary

Resolved following error when connecting to tron-link wallet: 

"Error: Cannot read properties of undefined (reading 'toString')"

Fixes # RF-1378


# How did you test this change?

You can test this by connecting to Tron Link.


# Checklist:

- [x] I have performed a self-review of my code
