### PR TITLE
fix: fix token selector infinite loader

### DIFF
--- a/widget/embedded/src/components/TokenList/TokenList.tsx
+++ b/widget/embedded/src/components/TokenList/TokenList.tsx
@@ -110,7 +110,7 @@ export function TokenList(props: PropTypes) {
 
   useEffect(() => {
     setTokens(list.slice(0, PAGE_SIZE));
-  }, [list]);
+  }, [list.length]);
 
   const renderList = () => {
     if (!tokens.length && !!searchedFor) {


### PR DESCRIPTION
# Summary

Sometimes, the infinite loader in the token selector, which loads more pages when the list reaches its end, doesn't work.

# How did you test this change?

This bug occurs when the widget fetches wallet balances and you scroll through a long list in the token selector. Or when you scroll through a long token list, causing it to load at least one more page, and switch between browser tabs, with the current tab becoming hidden, then returning to the same tab after.

# Checklist:

- [x] I have performed a self-review of my code
