### PR TITLE
chore: keep utm search params in url

### DIFF
--- a/widget/embedded/src/hooks/useSyncUrlAndStore/useSyncUrlAndStore.ts
+++ b/widget/embedded/src/hooks/useSyncUrlAndStore/useSyncUrlAndStore.ts
@@ -38,6 +38,13 @@ export function useSyncUrlAndStore() {
   const liquiditySourcesParamsRef = useRef<string>();
 
   const getUrlSearchParams = () => {
+    const utmQueryParams: Record<string, string> = {};
+
+    for (const [key, value] of searchParams.entries()) {
+      if (key.startsWith('utm_')) {
+        utmQueryParams[key] = value;
+      }
+    }
     const fromAmount = searchParams.get(SearchParams.FROM_AMOUNT);
     const fromBlockchain = searchParams.get(SearchParams.FROM_BLOCKCHAIN);
     const fromToken = searchParams.get(SearchParams.FROM_TOKEN);
@@ -56,6 +63,7 @@ export function useSyncUrlAndStore() {
       autoConnect,
       clientUrl,
       liquiditySources,
+      utmQueryParams,
     };
   };
 
@@ -71,7 +79,7 @@ export function useSyncUrlAndStore() {
   };
 
   useEffect(() => {
-    const { autoConnect, clientUrl } = getUrlSearchParams();
+    const { autoConnect, clientUrl, utmQueryParams } = getUrlSearchParams();
     if (isInRouterContext && fetchMetaStatus === 'success') {
       updateUrlSearchParams({
         [SearchParams.FROM_BLOCKCHAIN]: fromBlockchain?.name,
@@ -84,6 +92,7 @@ export function useSyncUrlAndStore() {
         [SearchParams.LIQUIDITY_SOURCES]: campaignMode
           ? liquiditySourcesParamsRef.current
           : undefined,
+        ...utmQueryParams,
       });
     }
   }, [

--- a/widget/embedded/tsconfig.json
+++ b/widget/embedded/tsconfig.json
@@ -10,6 +10,7 @@
   "compilerOptions": {
     "module": "esnext",
     "outDir": "dist",
+    "downlevelIteration": true,
     "lib": ["dom", "esnext"],
     // match output dir to input dir. e.g. dist/index instead of dist/src/index
     "rootDir": "./src",


### PR DESCRIPTION
# Summary
We should keep "utm_" params in first load.

# How did you test this change?
set search params including utm_

# Checklist:

- [ ] I have performed a self-review of my code
