### PR TITLE
fix: sync notifications with persisted swaps

### DIFF
--- a/widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx
+++ b/widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx
@@ -17,8 +17,8 @@ import { NotificationContent } from '../NotificationContent';
 
 import { HeaderButton } from './HeaderButtons.styles';
 import InProgressTransactionBadge from './InProgressTransactionBadge';
+import { NotificationsBadge } from './NotificationsBadge';
 import { RefreshButton } from './RefreshButton';
-import { UnreadNotificationsBadge } from './UnreadNotificationsBadge';
 
 export function HeaderButtons(props: HeaderButtonsPropTypes) {
   const {
@@ -52,6 +52,7 @@ export function HeaderButtons(props: HeaderButtonsPropTypes) {
         <Popover
           align="end"
           alignOffset={-88}
+          sideOffset={15}
           collisionPadding={{ right: 20, left: 20 }}
           container={getContainer()}
           content={<NotificationContent />}>
@@ -62,7 +63,7 @@ export function HeaderButtons(props: HeaderButtonsPropTypes) {
               content={i18n.t('Notifications')}>
               <HeaderButton size="small" variant="ghost">
                 <NotificationsIcon size={18} color="black" />
-                <UnreadNotificationsBadge />
+                <NotificationsBadge />
               </HeaderButton>
             </Tooltip>
           </div>

--- a/widget/embedded/src/components/HeaderButtons/NotificationsBadge.tsx
+++ b/widget/embedded/src/components/HeaderButtons/NotificationsBadge.tsx
@@ -6,10 +6,10 @@ import { useNotificationStore } from '../../store/notification';
 
 import { NotificationsBadgeContainer } from './HeaderButtons.styles';
 
-export function UnreadNotificationsBadge() {
-  const { getUnreadNotifications } = useNotificationStore();
+export function NotificationsBadge() {
+  const { getNotifications } = useNotificationStore();
 
-  const notificationsList = getUnreadNotifications();
+  const notificationsList = getNotifications();
 
   const notificationsCount = notificationsList.length;
 

--- a/widget/embedded/src/components/NotificationContent/NotificationContent.styles.ts
+++ b/widget/embedded/src/components/NotificationContent/NotificationContent.styles.ts
@@ -1,10 +1,21 @@
-import { darkTheme, ListItemButton, styled } from '@rango-dev/ui';
+import { Button, darkTheme, ListItemButton, styled } from '@rango-dev/ui';
 
 export const Container = styled('div', {
   padding: '$10',
   width: '350px',
   maxWidth: '90vw',
   minHeight: '150px',
+});
+
+export const Header = styled('div', {
+  padding: '0 $10',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const ClearAllButton = styled(Button, {
+  padding: '$5 !important',
 });
 
 export const List = styled('ul', {
@@ -32,7 +43,7 @@ export const ListItem = styled(ListItemButton, {
 
 export const Images = styled('div', {
   display: 'flex',
-  padding: 0,
+  padding: '0 0 0 $5',
   alignItems: 'center',
   alignSelf: 'stretch',
 });
@@ -45,4 +56,8 @@ export const NotFoundContainer = styled('div', {
   padding: '$10',
   width: '100%',
   height: '150px',
+});
+
+export const IconContainer = styled('span', {
+  paddingRight: '$8',
 });

--- a/widget/embedded/src/components/NotificationContent/NotificationContent.tsx
+++ b/widget/embedded/src/components/NotificationContent/NotificationContent.tsx
@@ -17,7 +17,10 @@ import { useNotificationStore } from '../../store/notification';
 import { areTokensEqual } from '../../utils/wallets';
 
 import {
+  ClearAllButton,
   Container,
+  Header,
+  IconContainer,
   Images,
   List,
   ListItem,
@@ -29,9 +32,9 @@ const MAX_NOTIFICATIONS_DISPLAYED = 4;
 export function NotificationContent() {
   const navigate = useNavigate();
 
-  const { getUnreadNotifications } = useNotificationStore();
+  const { getNotifications, clearNotifications } = useNotificationStore();
 
-  const notifications: Notification[] = getUnreadNotifications();
+  const notifications: Notification[] = getNotifications();
   const blockchains = useAppStore().blockchains();
   const tokens = useAppStore().tokens();
   const sortedNotification = notifications
@@ -44,6 +47,24 @@ export function NotificationContent() {
 
   return (
     <Container>
+      {sortedNotification.length > 0 && (
+        <>
+          <Header>
+            <Typography variant="label" size="medium">
+              {i18n.t('Notifications')}
+            </Typography>
+            <ClearAllButton
+              variant="ghost"
+              size="xsmall"
+              onClick={clearNotifications}>
+              <Typography variant="body" size="xsmall">
+                {i18n.t('Clear all')}
+              </Typography>
+            </ClearAllButton>
+          </Header>
+          <Divider direction="vertical" size={4} />
+        </>
+      )}
       {sortedNotification.length ? (
         <List>
           {sortedNotification.map((notificationItem, index) => {
@@ -103,7 +124,11 @@ export function NotificationContent() {
                       </div>
                     </Images>
                   }
-                  end={<ChevronRightIcon size={12} color="gray" />}
+                  end={
+                    <IconContainer>
+                      <ChevronRightIcon size={12} color="gray" />
+                    </IconContainer>
+                  }
                 />
               </React.Fragment>
             );

--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -96,21 +96,20 @@ export function SwapDetails(props: SwapDetailsProps) {
     setModalState(null);
   };
 
-  const getUnreadNotifications =
-    useNotificationStore.use.getUnreadNotifications();
-  const setAsRead = useNotificationStore.use.setAsRead();
-  const unreadNotifications = getUnreadNotifications();
+  const getNotifications = useNotificationStore.use.getNotifications();
+  const removeNotification = useNotificationStore.use.removeNotification();
+  const notifications = getNotifications();
   const currentStep = getCurrentStep(swap);
   const currentStepNetworkStatus = currentStep?.networkStatus;
 
   useEffect(() => {
-    const existNotification = unreadNotifications.find(
+    const existNotification = notifications.find(
       (n) => n.requestId === swap.requestId
     );
     if (existNotification) {
       if (swap.status === 'success' || swap.status === 'failed') {
         setShowCompletedModal(swap.status);
-        setAsRead(swap.requestId);
+        removeNotification(swap.requestId);
       } else if (showCompletedModal) {
         setShowCompletedModal(null);
       }

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
@@ -31,7 +31,7 @@ export function WidgetInfo(props: React.PropsWithChildren) {
   const swappers = useAppStore().swappers();
   const loadingStatus = useAppStore().fetchStatus;
   const resetLanguage = useLanguage().resetLanguage;
-  const notifications = useNotificationStore().getUnreadNotifications();
+  const notifications = useNotificationStore().getNotifications();
 
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   const value: WidgetInfoContextInterface = {

--- a/widget/embedded/src/hooks/useBootstrap/useBootstrap.ts
+++ b/widget/embedded/src/hooks/useBootstrap/useBootstrap.ts
@@ -14,11 +14,13 @@ import { tabManager } from '../../store/ui';
 import { useFetchApiConfig } from '../useFetchApiConfig';
 import { useForceAutoConnect } from '../useForceAutoConnect';
 import { useSubscribeToWidgetEvents } from '../useSubscribeToWidgetEvents';
+import { useSyncNotifications } from '../useSyncNotifications';
 
 export function useBootstrap() {
   globalFont();
   useForceAutoConnect();
   useSubscribeToWidgetEvents();
+  useSyncNotifications();
   const blockchains = useAppStore().blockchains();
   const { canSwitchNetworkTo } = useWallets();
   const [lastConnectedWalletWithNetwork, setLastConnectedWalletWithNetwork] =

--- a/widget/embedded/src/hooks/useSyncNotifications/index.ts
+++ b/widget/embedded/src/hooks/useSyncNotifications/index.ts
@@ -1,0 +1,1 @@
+export { useSyncNotifications } from './useSyncNotifications';

--- a/widget/embedded/src/hooks/useSyncNotifications/useSyncNotifications.ts
+++ b/widget/embedded/src/hooks/useSyncNotifications/useSyncNotifications.ts
@@ -1,0 +1,25 @@
+import { useManager } from '@rango-dev/queue-manager-react';
+import { useEffect } from 'react';
+
+import { useNotificationStore } from '../../store/notification';
+import { getPendingSwaps } from '../../utils/queue';
+
+export function useSyncNotifications() {
+  const { isSynced, syncNotifications } = useNotificationStore();
+  const { manager, state } = useManager();
+
+  useEffect(() => {
+    const shouldSyncNotifications =
+      useNotificationStore.persist.hasHydrated() &&
+      state.loadedFromPersistor &&
+      !isSynced;
+
+    if (shouldSyncNotifications) {
+      syncNotifications(getPendingSwaps(manager));
+    }
+  }, [
+    useNotificationStore.persist.hasHydrated(),
+    state.loadedFromPersistor,
+    isSynced,
+  ]);
+}

--- a/widget/embedded/src/types/notification.ts
+++ b/widget/embedded/src/types/notification.ts
@@ -21,6 +21,5 @@ type NotificationRoute = {
 export type Notification = Pick<Route, 'requestId'> & {
   event: RouteEvent | StepEvent;
   creationTime: number;
-  read: boolean;
   route: NotificationRoute;
 };

--- a/widget/embedded/src/utils/swap.ts
+++ b/widget/embedded/src/utils/swap.ts
@@ -23,6 +23,11 @@ import type {
 import type { PendingSwap, PendingSwapStep } from 'rango-types';
 
 import { i18n } from '@lingui/core';
+import {
+  type RouteEvent,
+  RouteEventType,
+  type StepEvent,
+} from '@rango-dev/queue-manager-rango-preset';
 import BigNumber from 'bignumber.js';
 import { PendingSwapNetworkStatus } from 'rango-types';
 
@@ -780,5 +785,12 @@ export function isTokensIdentical(tokenA: Token, tokenB: Token) {
     tokenA.blockchain === tokenB.blockchain &&
     tokenA.symbol === tokenB.symbol &&
     tokenA.address === tokenB.address
+  );
+}
+
+export function isSwapFinished(event: RouteEvent | StepEvent) {
+  return (
+    event.type === RouteEventType.FAILED ||
+    event.type === RouteEventType.SUCCEEDED
   );
 }


### PR DESCRIPTION
# Summary

Sometimes, browsers may delete `indexedDB` data, causing notifications and swaps to become out of sync. As a result, clicking on notifications could lead users to empty pages because the related swaps no longer exist. These notifications then remain unread indefinitely. This pull request tackles this problem by addressing the issue and removing unnecessary notifications from the user's local storage. Additionally, it introduces a button for clearing all notifications.
https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria

# How did you test this change?

Initiate a swap.
Use Chrome `DevTools` to clear the `indexedDB` database for swaps.
After refreshing the page, no notifications should remain.

If a swap has been completed (whether successful or failed) and the user has read the associated notifications, those notifications should be deleted from local storage. This can be verified in Chrome `DevTools` by searching for `notifications` in the `localStorage` section.

# Checklist:

- [x] I have performed a self-review of my code
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.