### PR TITLE
fix: improve widget performance

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     // use Node's module resolution algorithm, instead of the legacy TS one
+    "target": "ES2015",
     "moduleResolution": "node",
     // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -31,7 +31,12 @@ export const WidgetContext = createContext<WidgetContextInterface>({
 });
 
 function Main(props: PropsWithChildren<PropTypes>) {
-  const { updateConfig, updateSettings, fetch: fetchMeta } = useAppStore();
+  const {
+    updateConfig,
+    updateSettings,
+    fetch: fetchMeta,
+    fetchStatus,
+  } = useAppStore();
   const blockchains = useAppStore().blockchains();
   const { findToken } = useAppStore();
   const config = useAppStore().config;
@@ -60,7 +65,7 @@ function Main(props: PropsWithChildren<PropTypes>) {
         dappConfig: props.config,
       };
     }
-  }, [props.config]);
+  }, [props.config, fetchStatus]);
 
   const evmBasedChainNames = blockchains
     .filter(isEvmBlockchain)

--- a/widget/embedded/src/services/cacheService.ts
+++ b/widget/embedded/src/services/cacheService.ts
@@ -1,0 +1,35 @@
+import type { Token } from 'rango-sdk';
+
+interface CacheServiceInterface<V> {
+  get<K extends keyof V>(key: K): V[K] | undefined;
+  set<K extends keyof V>(key: K, value: V[K]): void;
+  remove<K extends keyof V>(key: K): void;
+  clear(): void;
+}
+
+class CacheService<T> implements CacheServiceInterface<T> {
+  #cache: Map<string, T[keyof T]> = new Map();
+
+  get<K extends keyof T>(key: K): T[K] | undefined {
+    return this.#cache.get(key as string) as T[K];
+  }
+
+  set<K extends keyof T>(key: K, value: T[K]): void {
+    this.#cache.set(key as string, value);
+  }
+
+  remove<K extends keyof T>(key: K): void {
+    this.#cache.delete(key as string);
+  }
+
+  clear(): void {
+    this.#cache.clear();
+  }
+}
+
+export type CachedEntries = {
+  supportedSourceTokens: Token[];
+  supportedDestinationTokens: Token[];
+};
+
+export const cacheService = new CacheService<CachedEntries>();

--- a/widget/embedded/src/store/slices/data.ts
+++ b/widget/embedded/src/store/slices/data.ts
@@ -1,16 +1,18 @@
 // We keep all the received data from server in this slice
 
 import type { ConfigSlice } from './config';
-import type { Balance, TokenHash } from '../../types';
+import type { CachedEntries } from '../../services/cacheService';
+import type { Balance, Blockchain, TokenHash } from '../../types';
 import type { Asset, BlockchainMeta, SwapperMeta, Token } from 'rango-sdk';
 import type { StateCreator } from 'zustand';
 
+import { cacheService } from '../../services/cacheService';
 import { httpService as sdk } from '../../services/httpService';
 import { compareWithSearchFor, containsText } from '../../utils/common';
-import { isTokenExcludedInConfig } from '../../utils/configs';
 import { createTokenHash, isTokenNative } from '../../utils/meta';
 import { sortLiquiditySourcesByGroupTitle } from '../../utils/settings';
 import { areTokensEqual, compareTokenBalance } from '../../utils/wallets';
+import { matchTokensFromConfigWithMeta } from '../utils';
 
 type BlockchainOptions = {
   type?: 'source' | 'destination';
@@ -30,6 +32,7 @@ export type FetchStatus = 'loading' | 'success' | 'failed';
 export interface DataSlice {
   _blockchainsMapByName: Map<string, BlockchainMeta>;
   _tokensMapByTokenHash: Map<TokenHash, Token>;
+  _tokensMapByBlockchainName: Record<Blockchain, TokenHash[]>;
   _popularTokens: Token[];
   _swappers: SwapperMeta[];
   fetchStatus: FetchStatus;
@@ -48,8 +51,9 @@ export const createDataSlice: StateCreator<
   DataSlice
 > = (set, get) => ({
   // State
-  _blockchainsMapByName: new Map<string, BlockchainMeta>(),
-  _tokensMapByTokenHash: new Map<TokenHash, Token>(),
+  _blockchainsMapByName: new Map(),
+  _tokensMapByTokenHash: new Map(),
+  _tokensMapByBlockchainName: {},
   _popularTokens: [],
   _swappers: [],
   fetchStatus: 'loading',
@@ -84,31 +88,41 @@ export const createDataSlice: StateCreator<
     return list;
   },
   tokens: (options) => {
-    const tokensMapByHashToken = get()._tokensMapByTokenHash;
-    const tokensFromState = Array.from(tokensMapByHashToken?.values() || []);
+    const { _tokensMapByTokenHash, _tokensMapByBlockchainName, config } = get();
+    const tokensFromState = Array.from(_tokensMapByTokenHash.values());
     const blockchainsMapByName = get()._blockchainsMapByName;
-
-    if (!options || !options?.type) {
+    if (!options || !options.type) {
       return tokensFromState;
     }
 
-    const config = get().config;
-    const supportedTokensConfig =
-      (options.type === 'source' ? config.from?.tokens : config.to?.tokens) ??
-      {};
+    const configType = options.type === 'source' ? 'from' : 'to';
+    const cacheKey: keyof CachedEntries =
+      options.type === 'source'
+        ? 'supportedSourceTokens'
+        : 'supportedDestinationTokens';
+
+    let supportedTokens = cacheService.get(cacheKey);
+    if (!supportedTokens) {
+      supportedTokens = matchTokensFromConfigWithMeta({
+        type: options.type,
+        config: {
+          blockchains: config[configType]?.blockchains,
+          tokens: config[configType]?.tokens,
+        },
+        meta: {
+          tokensMapByTokenHash: _tokensMapByTokenHash,
+          tokensMapByBlockchainName: _tokensMapByBlockchainName,
+        },
+      });
+      cacheService.set(cacheKey, supportedTokens);
+    }
+
     const blockchains = get().blockchains({
       type: options.type,
     });
 
-    const list = tokensFromState
+    const list = supportedTokens
       .filter((token) => {
-        if (
-          supportedTokensConfig &&
-          isTokenExcludedInConfig(token, supportedTokensConfig)
-        ) {
-          return false;
-        }
-
         // If a specific blockchain has passed, we only keep that blockchain's tokens.
         if (!!options.blockchain && token.blockchain !== options.blockchain) {
           return false;
@@ -261,17 +275,18 @@ export const createDataSlice: StateCreator<
       const response = await sdk().getAllMetadata({
         enableCentralizedSwappers,
       });
-
       set({ fetchStatus: 'success' });
       const blockchainsMapByName: Map<string, BlockchainMeta> = new Map<
         string,
         BlockchainMeta
       >();
 
-      const tokensMapByHashToken: Map<TokenHash, Token> = new Map<
+      const tokensMapByTokenHash: Map<TokenHash, Token> = new Map<
         TokenHash,
         Token
       >();
+      const tokensMapByBlockchainName: DataSlice['_tokensMapByBlockchainName'] =
+        {};
       const tokens: Token[] = [];
       const popularTokens: Token[] = response.popularTokens;
       const swappers: SwapperMeta[] = response.swappers;
@@ -299,12 +314,17 @@ export const createDataSlice: StateCreator<
 
       tokens.forEach((token) => {
         const tokenHash = createTokenHash(token);
-        tokensMapByHashToken.set(tokenHash, token);
+        if (!tokensMapByBlockchainName[token.blockchain]) {
+          tokensMapByBlockchainName[token.blockchain] = [];
+        }
+        tokensMapByTokenHash.set(tokenHash, token);
+        tokensMapByBlockchainName[token.blockchain].push(tokenHash);
       });
 
       set({
         _blockchainsMapByName: blockchainsMapByName,
-        _tokensMapByTokenHash: tokensMapByHashToken,
+        _tokensMapByTokenHash: tokensMapByTokenHash,
+        _tokensMapByBlockchainName: tokensMapByBlockchainName,
         _popularTokens: popularTokens,
         _swappers: swappers,
       });

--- a/widget/embedded/src/store/utils/data.test.ts
+++ b/widget/embedded/src/store/utils/data.test.ts
@@ -1,0 +1,175 @@
+import type { Token } from 'rango-sdk';
+
+import { describe, expect, test } from 'vitest';
+
+import { createToken } from '../../test-utils/fixtures';
+import { createTokenHash } from '../../utils/meta';
+
+import { matchTokensFromConfigWithMeta } from './data'; // Adjust path as necessary
+
+type MatchTokensFromConfigWithMetaParam = Parameters<
+  typeof matchTokensFromConfigWithMeta
+>[0];
+
+const BLOCKCHAIN_A = 'blockchainA';
+const BLOCKCHAIN_B = 'blockchainB';
+const BLOCKCHAIN_C = 'blockchainC';
+
+const tokens: Token[] = [
+  { ...createToken(), blockchain: BLOCKCHAIN_A },
+  { ...createToken(), blockchain: BLOCKCHAIN_A },
+  { ...createToken(), blockchain: BLOCKCHAIN_B },
+  { ...createToken(), blockchain: BLOCKCHAIN_C },
+];
+
+function createMetaForMockData(
+  tokens: Token[]
+): MatchTokensFromConfigWithMetaParam['meta'] {
+  const meta: MatchTokensFromConfigWithMetaParam['meta'] = {
+    tokensMapByTokenHash: new Map(),
+    tokensMapByBlockchainName: {},
+  };
+  tokens.forEach((token) => {
+    const tokenHash = createTokenHash(token);
+    meta.tokensMapByTokenHash.set(tokenHash, token);
+    if (!meta.tokensMapByBlockchainName[token.blockchain]) {
+      meta.tokensMapByBlockchainName[token.blockchain] = [];
+    }
+    meta.tokensMapByBlockchainName[token.blockchain].push(tokenHash);
+  });
+
+  return meta;
+}
+
+describe('matchTokensFromConfigWithMeta', () => {
+  test('should include tokens from config.tokens array that exist in meta', () => {
+    const mockData: MatchTokensFromConfigWithMetaParam = {
+      type: 'source',
+      meta: createMetaForMockData(tokens),
+      config: {
+        blockchains: undefined,
+        tokens: [tokens[0], tokens[1]],
+      },
+    };
+
+    const result = matchTokensFromConfigWithMeta(mockData);
+    expect(result).toEqual([tokens[0], tokens[1]]);
+  });
+
+  test('If config.blockchains is not defined or is empty, we should include all tokens from the meta for every blockchain that does not have tokens specified in the config, as well as tokens specified in the config that exist in the meta.', () => {
+    const mockData: MatchTokensFromConfigWithMetaParam = {
+      type: 'source',
+      meta: createMetaForMockData(tokens),
+      config: {
+        blockchains: undefined,
+        tokens: {
+          [BLOCKCHAIN_A]: { tokens: [tokens[0]], isExcluded: false },
+        },
+      },
+    };
+
+    const runTestWithConfig = (config: {
+      blockchains: MatchTokensFromConfigWithMetaParam['config']['blockchains'];
+    }) => {
+      mockData.config.blockchains = config.blockchains;
+      const result = matchTokensFromConfigWithMeta(mockData);
+      /**
+       * In this case, the result might differ from what was expected.
+       * To pass the test, we reordered the expected result.
+       * Changing the order of tokens does not impact the overall behavior of our app,
+       * as we have a comprehensive sorting logic applied to tokens within the data slice.
+       */
+      // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+      expect(result).toEqual([tokens[2], tokens[3], tokens[0]]);
+    };
+
+    runTestWithConfig({ blockchains: undefined });
+    runTestWithConfig({ blockchains: [] });
+  });
+
+  test('should include tokens from config.tokens object that exist in meta', () => {
+    const mockData: MatchTokensFromConfigWithMetaParam = {
+      type: 'source',
+      meta: createMetaForMockData(tokens),
+      config: {
+        blockchains: [BLOCKCHAIN_A, BLOCKCHAIN_B],
+        tokens: {
+          [BLOCKCHAIN_A]: { tokens: [tokens[0]], isExcluded: false },
+          [BLOCKCHAIN_B]: { tokens: [tokens[2]], isExcluded: false },
+        },
+      },
+    };
+
+    const result = matchTokensFromConfigWithMeta(mockData);
+    expect(result).toEqual([tokens[0], tokens[2]]);
+  });
+
+  test('should not include tokens from config.tokens whose blockchain does not exist in config.blockchains', () => {
+    const mockData: MatchTokensFromConfigWithMetaParam = {
+      type: 'source',
+      meta: createMetaForMockData(tokens),
+      config: {
+        blockchains: [BLOCKCHAIN_A],
+        tokens: {
+          [BLOCKCHAIN_B]: { tokens: [tokens[2]], isExcluded: false },
+        },
+      },
+    };
+
+    const result = matchTokensFromConfigWithMeta(mockData);
+    expect(result).toEqual([tokens[0], tokens[1]]);
+  });
+
+  test('should include all tokens from a blockchain if that blockchain does not have any tokens in config.tokens', () => {
+    const mockData: MatchTokensFromConfigWithMetaParam = {
+      type: 'source',
+      meta: createMetaForMockData(tokens),
+      config: {
+        blockchains: [BLOCKCHAIN_A],
+        tokens: {},
+      },
+    };
+
+    const result = matchTokensFromConfigWithMeta(mockData);
+    expect(result).toEqual([tokens[0], tokens[1]]);
+  });
+
+  test('should include all tokens from config.blockchains that exist in the meta, except tokens excluded in config.token', () => {
+    const mockData: MatchTokensFromConfigWithMetaParam = {
+      type: 'source',
+      meta: createMetaForMockData(tokens),
+      config: {
+        blockchains: [BLOCKCHAIN_A],
+        tokens: {
+          [BLOCKCHAIN_A]: { tokens: [tokens[0]], isExcluded: true },
+        },
+      },
+    };
+
+    const result = matchTokensFromConfigWithMeta(mockData);
+    expect(result).toEqual([tokens[1]]);
+  });
+
+  test('should include all tokens from the meta when config parameters are empty values', () => {
+    const mockData: MatchTokensFromConfigWithMetaParam = {
+      type: 'source',
+      meta: createMetaForMockData(tokens),
+      config: {
+        blockchains: [],
+        tokens: {},
+      },
+    };
+
+    const runTestWithConfig = (
+      config: MatchTokensFromConfigWithMetaParam['config']
+    ) => {
+      mockData.config = config;
+      const result = matchTokensFromConfigWithMeta(mockData);
+      expect(result).toEqual(tokens);
+    };
+
+    runTestWithConfig({ blockchains: [], tokens: {} });
+    runTestWithConfig({ blockchains: undefined, tokens: undefined });
+    runTestWithConfig({ blockchains: [], tokens: [] });
+  });
+});

--- a/widget/embedded/src/store/utils/data.ts
+++ b/widget/embedded/src/store/utils/data.ts
@@ -1,0 +1,117 @@
+import type { BlockchainAndTokenConfig, TokenHash } from '../../types';
+import type { DataSlice } from '../slices/data';
+import type { Asset, Token } from 'rango-sdk';
+
+import { createTokenHash } from '../../utils/meta';
+
+/**
+ * This function retrieves tokens and blockchains from the widget configuration and combines them with token data from the meta response to determine which tokens should be displayed in the widget.
+ * To optimize performance, the function minimizes unnecessary iterations over the meta tokens.
+ * The result of this function should be cached and recalculated whenever the widget configuration changes.
+ */
+export function matchTokensFromConfigWithMeta(params: {
+  type: 'source' | 'destination';
+  config: {
+    blockchains: BlockchainAndTokenConfig['blockchains'];
+    tokens: BlockchainAndTokenConfig['tokens'];
+  };
+  meta: {
+    tokensMapByTokenHash: DataSlice['_tokensMapByTokenHash'];
+    tokensMapByBlockchainName: DataSlice['_tokensMapByBlockchainName'];
+  };
+}): Token[] {
+  const { config, meta } = params;
+  const result: Record<TokenHash, Token> = {};
+  const configTokens = config.tokens;
+
+  // Helper function to add tokens to result
+  const addTokens = (tokens: (Asset | TokenHash)[]) => {
+    tokens.forEach((item) => {
+      if (typeof item !== 'string') {
+        item = createTokenHash(item);
+      }
+      const tokenFromMeta = meta.tokensMapByTokenHash.get(item);
+      if (tokenFromMeta) {
+        result[item] = tokenFromMeta;
+      }
+    });
+  };
+
+  /**
+   * We support two types of configurations for passing tokens in the widget config.
+   * We check the type of configuration and calculate the result based on that.
+   */
+  if (Array.isArray(configTokens)) {
+    /**
+     * If "config.tokens" is an array,
+     * we iterate through it and include any token that exists in the meta data in the result.
+     */
+    if (configTokens.length > 0) {
+      addTokens(configTokens);
+      return Object.values(result);
+    }
+    return Array.from(meta.tokensMapByTokenHash.values());
+  }
+
+  /**
+   * From this point onward,
+   * the function handles the other type of widget configuration.
+   */
+  if (!configTokens) {
+    return Array.from(meta.tokensMapByTokenHash.values());
+  }
+
+  let configBlockchains: string[];
+
+  if (config.blockchains?.length) {
+    configBlockchains = config.blockchains;
+  } else {
+    /**
+     * If config.blockchains does not exist,
+     * we include all tokens from every blockchain in the meta data that are not specified in the tokens from the config.
+     */
+    configBlockchains = Object.keys(configTokens);
+    const configBlockchainsSet = new Set(configBlockchains);
+
+    Object.keys(meta.tokensMapByBlockchainName).forEach((blockchain) => {
+      if (!configBlockchainsSet.has(blockchain)) {
+        addTokens(meta.tokensMapByBlockchainName[blockchain]);
+      }
+    });
+  }
+  //We iterate over each blockchain and retrieve the related tokens for each one from the configuration.
+  configBlockchains.forEach((blockchain) => {
+    const targetTokensForBlockchain = configTokens[blockchain];
+    /**
+     * If no tokens exist for a blockchain,
+     * we include all tokens for that blockchain from the meta response.
+     */
+    if (
+      !targetTokensForBlockchain &&
+      meta.tokensMapByBlockchainName?.[blockchain]
+    ) {
+      addTokens(meta.tokensMapByBlockchainName[blockchain]);
+      return;
+    }
+
+    if (targetTokensForBlockchain) {
+      if (targetTokensForBlockchain.isExcluded) {
+        /**
+         * If tokens are excluded,
+         * we first include all tokens from the meta for that blockchain,
+         * then remove the excluded tokens from the result.
+         */
+        addTokens(meta.tokensMapByBlockchainName[blockchain]);
+        targetTokensForBlockchain.tokens.forEach((token) => {
+          const tokenHash = createTokenHash(token);
+          delete result[tokenHash];
+        });
+      } else {
+        //We retrieve the corresponding token from the meta and include it in the result.
+        addTokens(targetTokensForBlockchain.tokens);
+      }
+    }
+  });
+
+  return Object.values(result);
+}

--- a/widget/embedded/src/store/utils/index.ts
+++ b/widget/embedded/src/store/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './data';

--- a/widget/embedded/src/test-utils/fixtures.ts
+++ b/widget/embedded/src/test-utils/fixtures.ts
@@ -1,5 +1,5 @@
 import type { AppStoreState } from '../store/app';
-import type { TokenHash, WidgetConfig } from '../types';
+import type { Blockchain, TokenHash, WidgetConfig } from '../types';
 import type { BlockchainMeta, EvmBlockchainMeta, Token } from 'rango-sdk';
 
 import { faker } from '@faker-js/faker';
@@ -231,13 +231,20 @@ export function createInitialAppStore() {
     blockchains: blockchains.map((b) => b.name),
   });
 
+  const tokensMapByTokenHash: Map<TokenHash, Token> = new Map();
+  const tokensMapByBlockchainName: Record<Blockchain, TokenHash[]> = {};
+  tokens.forEach((token) => {
+    const tokenHash = createTokenHash(token);
+    if (!tokensMapByBlockchainName[token.blockchain]) {
+      tokensMapByBlockchainName[token.blockchain] = [];
+    }
+    tokensMapByTokenHash.set(tokenHash, token);
+    tokensMapByBlockchainName[token.blockchain].push(tokenHash);
+  });
+
   return {
-    _tokensMapByTokenHash: new Map<TokenHash, Token>(
-      tokens.map((token) => {
-        const tokenHash = createTokenHash(token);
-        return [tokenHash, token];
-      })
-    ),
+    _tokensMapByTokenHash: tokensMapByTokenHash,
+    _tokensMapByBlockchainName: tokensMapByBlockchainName,
     _blockchainsMapByName: new Map<string, BlockchainMeta>(
       blockchains.map((meta) => [meta.name, meta])
     ),

--- a/widget/embedded/src/types/wallets.ts
+++ b/widget/embedded/src/types/wallets.ts
@@ -13,7 +13,7 @@ export type Balance = {
   usdValue: string;
 };
 
-type Blockchain = string;
+export type Blockchain = string;
 type TokenSymbol = string;
 type Address = string;
 


### PR DESCRIPTION
# Summary

If a token is excluded from a blockchain that hosts numerous tokens, such as Ethereum, it leads to a decline in the widget's performance.

# How did you test this change?

You can verify this using the playground. In either the 'from' or 'to' section, navigate to the Ethereum tokens subsection, exclude one token, and confirm the adjustments. Afterwards, attempt to interact with the widget by transitioning from the home page to the tokens page and searching for a token.

# Checklist:

- [x] I have performed a self-review of my code