### PR TITLE
fix: make sure to correctly pass validation parameters when setting up a new swap

### DIFF
--- a/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.ts
+++ b/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.ts
@@ -89,14 +89,6 @@ export function useConfirmSwap(): ConfirmSwap {
           slippage: userSlippage.toString(),
           disabledSwappersGroups: disabledLiquiditySources,
         };
-        const swap = calculatePendingSwap(
-          inputAmount.toString(),
-          result,
-          getWalletsForNewSwap(selectedWallets),
-          swapSettings,
-          false,
-          { blockchains, tokens }
-        );
 
         const confirmSwapWarnings = generateWarnings(
           initialQuote ?? undefined,
@@ -113,6 +105,17 @@ export function useConfirmSwap(): ConfirmSwap {
           setQuoteWarningsConfirmed(false);
         }
         resetAlerts();
+
+        const proceedAnyway = !!confirmSwapWarnings.balance;
+
+        const swap = calculatePendingSwap(
+          inputAmount.toString(),
+          result,
+          getWalletsForNewSwap(selectedWallets),
+          swapSettings,
+          proceedAnyway ? false : true,
+          { blockchains, tokens }
+        );
 
         return {
           quote: currentQuote,


### PR DESCRIPTION
# Summary

We should fix passing validations parameters in create transaction step:
```validations: {balance: false, fee: false}```

if user proceed anyway => pass both `false`
otherwise => pass both `true`

# Checklist:

- [x] I have performed a self-review of my code