### PR TITLE
fix: fix bugs in fetching quotes

### DIFF
--- a/widget/embedded/src/hooks/useSyncStoresWithConfig.ts
+++ b/widget/embedded/src/hooks/useSyncStoresWithConfig.ts
@@ -16,6 +16,7 @@ export function useSyncStoresWithConfig() {
     setToToken,
     setToBlockchain,
     setFromBlockchain,
+    resetQuote,
     setFromToken,
     fromToken,
     toToken,
@@ -46,6 +47,7 @@ export function useSyncStoresWithConfig() {
 
   useEffect(() => {
     if (fetchMetaStatus === 'success') {
+      resetQuote();
       const chain = blockchains.find(
         (chain) => chain.name === config?.from?.blockchain
       );
@@ -95,6 +97,7 @@ export function useSyncStoresWithConfig() {
 
   useEffect(() => {
     if (fetchMetaStatus === 'success') {
+      resetQuote();
       const chain = blockchains.find(
         (chain) => chain.name === config?.to?.blockchain
       );

--- a/widget/embedded/src/pages/ConfirmSwapPage.tsx
+++ b/widget/embedded/src/pages/ConfirmSwapPage.tsx
@@ -17,7 +17,7 @@ import {
   WalletIcon,
 } from '@rango-dev/ui';
 import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { ConfirmWalletsModal } from '../components/ConfirmWalletsModal/ConfirmWalletsModal';
 import { RefreshButton } from '../components/HeaderButtons/RefreshButton';
@@ -72,7 +72,6 @@ export function ConfirmSwapPage() {
     quoteWarningsConfirmed,
   } = useQuoteStore();
   const navigate = useNavigate();
-  const location = useLocation();
   const [dbErrorMessage, setDbErrorMessage] = useState<string>('');
 
   const showWalletsOnInit = !quoteWalletsConfirmed;
@@ -185,10 +184,10 @@ export function ConfirmSwapPage() {
   }, []);
 
   useLayoutEffect(() => {
-    if (!selectedQuote) {
+    if (!selectedQuote?.requestId) {
       navigate(`../${location.search}`);
     }
-  }, []);
+  }, [selectedQuote?.requestId]);
 
   const quoteWarning = confirmSwapResult.warnings?.quote ?? null;
   const quoteError = confirmSwapResult.error;

--- a/widget/embedded/src/pages/Routes.tsx
+++ b/widget/embedded/src/pages/Routes.tsx
@@ -15,7 +15,6 @@ import { useQuoteStore } from '../store/quote';
 export function RoutesPage() {
   const navigate = useNavigate();
   const navigateBack = useNavigateBack();
-
   const {
     selectedQuote,
     refetchQuote,
@@ -41,6 +40,7 @@ export function RoutesPage() {
       header={{
         onWallet: () => {
           navigate(wallets_url);
+          updateQuotePartialState('refetchQuote', true);
         },
         onBack: () => {
           updateQuotePartialState('refetchQuote', false);
@@ -52,7 +52,10 @@ export function RoutesPage() {
               !!selectedQuote || quoteError ? fetchQuote : undefined
             }
             hidden={['notifications', 'history']}
-            onClickSettings={() => navigate(settings_url)}
+            onClickSettings={() => {
+              navigate(settings_url);
+              updateQuotePartialState('refetchQuote', true);
+            }}
           />
         ),
       }}>


### PR DESCRIPTION
# Summary

When we move from the routes page to the settings page and then return to the routes page, the fetching of quotes doesn't activate. 
The debouncing of the quotes request should only occur when there's a change in the input amount.
If the parameters for the quote are altered in the widget configuration (such as in the playground), the widget shouldn't be left in a broken state. This issue currently occurs on the `confirm swap` page and `routes` page. To address this, we can reset the quote state and redirect the user to the home page.

# How did you test this change?

You can disable certain swappers or tweak the slippage, ensuring they're properly applied to the quotes request. 
After setting all the quotes parameters. Navigate from the home page to other pages. The quotes request should be triggered without any debounce.

# Checklist:

- [x] I have performed a self-review of my code