### PR TITLE
fix: disable the confirm wallet button if all required wallets are not selected

### DIFF
--- a/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWallets.helpers.ts
+++ b/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWallets.helpers.ts
@@ -1,22 +1,4 @@
-import type { BlockchainMeta, SwapResult } from 'rango-sdk';
-
-export function getRequiredWallets(swaps: SwapResult[] | null): string[] {
-  const wallets: string[] = [];
-
-  swaps?.forEach((swap) => {
-    const currentStepFromBlockchain = swap.from.blockchain;
-    const currentStepToBlockchain = swap.to.blockchain;
-    let lastAddedWallet = wallets[wallets.length - 1];
-    if (currentStepFromBlockchain != lastAddedWallet) {
-      wallets.push(currentStepFromBlockchain);
-    }
-    lastAddedWallet = wallets[wallets.length - 1];
-    if (currentStepToBlockchain != lastAddedWallet) {
-      wallets.push(currentStepToBlockchain);
-    }
-  });
-  return wallets;
-}
+import type { BlockchainMeta } from 'rango-sdk';
 
 export function isValidAddress(
   chain: BlockchainMeta,


### PR DESCRIPTION
# Summary

If a user connects a wallet different from the required type for the swap process and attempts to confirm the wallet, no wallet is selected in the confirmation modal. However, if the user inputs a valid custom address, the confirm button becomes enabled, allowing the user to proceed with the swap. In this scenario, no selected wallet is transmitted to the server, potentially resulting in the failure of the transaction creation process: 


# How did you test this change?

First, connect only the `Keplr` wallet. Then, attempt a swap on an EVM route. In the confirm wallet modal, enter a valid custom address.

# Checklist:

- [x] I have performed a self-review of my code