### PR TITLE
fix: fix the automatic selection of the connected wallets in the confirm wallets modal

### DIFF
--- a/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
@@ -50,7 +50,8 @@ interface WalletNamespacesModalState {
 
 const ACCOUNT_ADDRESS_MAX_CHARACTERS = 7;
 export function WalletList(props: PropTypes) {
-  const { chain, isSelected, selectWallet, limit, onShowMore } = props;
+  const { chain, isSelected, selectWallet, limit, onShowMore, onConnect } =
+    props;
   const isActiveTab = useUiStore.use.isActiveTab();
 
   const connectedWallets = useWalletsStore.use.connectedWallets();
@@ -80,7 +81,8 @@ export function WalletList(props: PropTypes) {
         setOpenWalletStateModal(type);
       }, TIME_TO_IGNORE_MODAL);
     },
-    onConnect: () => {
+    onConnect: (type) => {
+      onConnect?.(type);
       if (modalTimerId) {
         clearTimeout(modalTimerId);
       }

--- a/widget/embedded/src/components/ConfirmWalletsModal/WalletList.type.ts
+++ b/widget/embedded/src/components/ConfirmWalletsModal/WalletList.type.ts
@@ -6,4 +6,5 @@ export type PropTypes = {
   selectWallet: (wallet: Wallet) => void;
   limit?: number;
   onShowMore: () => void;
+  onConnect?: (walletType: string) => void;
 };

--- a/widget/embedded/src/store/wallets.ts
+++ b/widget/embedded/src/store/wallets.ts
@@ -65,10 +65,15 @@ export const useWalletsStore = createSelectors(
             .filter((wallet) => wallet.walletType !== accounts[0].walletType)
             .concat(
               accounts.map((account) => {
-                const shouldMarkWalletAsSelected = !state.connectedWallets.find(
+                const shouldMarkWalletAsSelected = !state.connectedWallets.some(
                   (connectedWallet) =>
                     connectedWallet.chain === account.chain &&
-                    connectedWallet.selected
+                    connectedWallet.selected &&
+                    /**
+                     * Sometimes, the connect function can be called multiple times for a particular wallet type when using the auto-connect feature.
+                     * This check is there to make sure the chosen wallet doesn't end up unselected.
+                     */
+                    connectedWallet.walletType !== account.walletType
                 );
                 return {
                   balances: [],


### PR DESCRIPTION
# Summary

Sometimes, connected wallets fail to be automatically selected in the confirm wallets modal.

# How did you test this change?

Navigate to the confirm wallets modal and attempt to connect multiple wallets for a specific blockchain request. The latest connected wallet should be automatically chosen. Additionally, you should be able to switch between your selected wallets for a blockchain seamlessly.

This feature should function seamlessly with external wallets. To verify, enable external wallets in the widget playground and select multiple options like `MetaMask` and `Coinbase`. Next, navigate to the confirm wallets modal within the widget. Changes in the connection status of `MetaMask` wallet should reflect in the selected wallet within the confirm wallet modal.

# Checklist:

- [x] I have performed a self-review of my code