### PR TITLE
chore: verify token equality with greater assurance

### DIFF
--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -427,8 +427,8 @@ export function areTokensEqual(
 ) {
   return (
     tokenA?.blockchain === tokenB?.blockchain &&
-    tokenA?.symbol === tokenB?.symbol &&
-    tokenA?.address === tokenB?.address
+    tokenA?.symbol.toLowerCase() === tokenB?.symbol.toLowerCase() &&
+    tokenA?.address?.toLowerCase() === tokenB?.address?.toLowerCase()
   );
 }
 


### PR DESCRIPTION
# Summary


Occasionally, the server may provide a token symbol or token address with differences in capitalization between the ‍`Bests` response and the `Meta` response. 
These changes enhances the confidence level when checking tokens against each other

# Checklist:

- [x] I have performed a self-review of my code