### PR TITLE
fix: excluding ledger on mobile

### DIFF
--- a/wallets/provider-ledger/src/index.ts
+++ b/wallets/provider-ledger/src/index.ts
@@ -63,5 +63,6 @@ export const getWalletInfo: (allBlockChains: BlockchainMeta[]) => WalletInfo = (
     supportedChains,
     namespaces: [Namespace.Evm, Namespace.Solana],
     singleNamespace: true,
+    showOnMobile: false,
   };
 };

--- a/widget/embedded/src/hooks/useWalletList.ts
+++ b/widget/embedded/src/hooks/useWalletList.ts
@@ -56,7 +56,8 @@ export function useWalletList(params: Params) {
 
   wallets = detectMobileScreens()
     ? wallets.filter(
-        (wallet) => wallet.showOnMobile || state(wallet.type).installed
+        (wallet) =>
+          wallet.showOnMobile !== false && state(wallet.type).installed
       )
     : wallets;
 
@@ -137,9 +138,11 @@ export function useWalletList(params: Params) {
     const isEvmWalletInstalledExceptDefault = wallets.filter(
       (wallet) =>
         wallet.state != WalletState.NOT_INSTALLED &&
-        ![WalletTypes.DEFAULT, WalletTypes.WALLET_CONNECT_2].includes(
-          wallet.type as WalletTypes
-        ) &&
+        ![
+          WalletTypes.DEFAULT,
+          WalletTypes.WALLET_CONNECT_2,
+          WalletTypes.LEDGER,
+        ].includes(wallet.type as WalletTypes) &&
         getWalletInfo(wallet.type).supportedChains.filter(
           (blockchain) => blockchain.type == 'EVM'
         ).length > 0


### PR DESCRIPTION
# Summary

Shouldn't show Ledger in mobile view.
The ledger was causing problems for the Injected wallet
NOTE: Injected wallet for when we don't support an evm wallet and the user wants to connect with that wallet


Fixes # (issue)

# How did you test this change?
Test on mobile display

For instance, you could try removing Metamask from the provider all and connecting to Metamask using the injected wallet to test the injected wallet.



# Checklist:

- [x] I have performed a self-review of my code
