### PR TITLE
feat: add custom solana rpc url to config

### DIFF
--- a/signers/signer-solana/src/config.ts
+++ b/signers/signer-solana/src/config.ts
@@ -1,0 +1,20 @@
+type SolanaSignerConfig = {
+  customRPC?: string;
+};
+
+const solanaSignerConfig: SolanaSignerConfig = {};
+
+export function setSolanaSignerConfig<Key extends keyof SolanaSignerConfig>(
+  key: Key,
+  value: SolanaSignerConfig[Key]
+) {
+  solanaSignerConfig[key] = value;
+
+  return value;
+}
+
+export function getSolanaSignerConfig<Key extends keyof SolanaSignerConfig>(
+  key: Key
+): SolanaSignerConfig[Key] {
+  return solanaSignerConfig[key];
+}

--- a/signers/signer-solana/src/index.ts
+++ b/signers/signer-solana/src/index.ts
@@ -6,3 +6,4 @@ export {
   simulateTransaction,
 } from './utils';
 export type { SolanaWeb3Signer } from './utils';
+export { setSolanaSignerConfig } from './config';

--- a/signers/signer-solana/src/utils/helpers.ts
+++ b/signers/signer-solana/src/utils/helpers.ts
@@ -1,12 +1,16 @@
 import { Connection } from '@solana/web3.js';
 
+import { getSolanaSignerConfig } from '../config';
+
 const IS_DEV = !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
 const SOLANA_RPC_URL = !IS_DEV
   ? 'https://purple-practical-friday.solana-mainnet.quiknode.pro/d94ab067f793d48c81354c78c86ae908d9fc1582/'
   : 'https://fluent-still-scion.solana-mainnet.discover.quiknode.pro/fc8be9b8ac7aea382ec591359628e16d8c52ef6a/';
 
 export function getSolanaConnection(): Connection {
-  return new Connection(SOLANA_RPC_URL, {
+  const customRPC = getSolanaSignerConfig('customRPC');
+
+  return new Connection(customRPC || SOLANA_RPC_URL, {
     commitment: 'confirmed',
     disableRetryOnRateLimit: false,
   });

--- a/widget/embedded/package.json
+++ b/widget/embedded/package.json
@@ -29,6 +29,7 @@
     "@rango-dev/queue-manager-core": "^0.26.0",
     "@rango-dev/queue-manager-rango-preset": "^0.33.0",
     "@rango-dev/queue-manager-react": "^0.26.0",
+    "@rango-dev/signer-solana": "^0.28.0",
     "@rango-dev/ui": "^0.34.1-next.1",
     "@rango-dev/wallets-react": "^0.19.0",
     "@rango-dev/wallets-shared": "^0.33.0",

--- a/widget/embedded/src/containers/WidgetProvider/WidgetProvider.tsx
+++ b/widget/embedded/src/containers/WidgetProvider/WidgetProvider.tsx
@@ -1,7 +1,8 @@
 import type { PropTypes } from './WidgetProvider.types';
 import type { PropsWithChildren } from 'react';
 
-import React, { useEffect, useMemo } from 'react';
+import { setSolanaSignerConfig } from '@rango-dev/signer-solana';
+import React, { useEffect } from 'react';
 
 import { DEFAULT_BASE_URL, RANGO_PUBLIC_API_KEY } from '../../constants';
 import useFontLoader from '../../hooks/useFontLoader';
@@ -13,13 +14,6 @@ import { WidgetInfo } from '../WidgetInfo';
 export function WidgetProvider(props: PropsWithChildren<PropTypes>) {
   const { onUpdateState, config } = props;
 
-  useMemo(() => {
-    initConfig({
-      API_KEY: config?.apiKey || RANGO_PUBLIC_API_KEY,
-      BASE_URL: config?.apiUrl || DEFAULT_BASE_URL,
-    });
-  }, [config.apiKey, config.apiUrl]);
-
   const fontFamily = props.config?.theme?.fontFamily;
 
   const { handleLoadCustomFont } = useFontLoader();
@@ -29,6 +23,19 @@ export function WidgetProvider(props: PropsWithChildren<PropTypes>) {
       handleLoadCustomFont(fontFamily);
     }
   }, [fontFamily]);
+
+  useEffect(() => {
+    initConfig({
+      API_KEY: config?.apiKey || RANGO_PUBLIC_API_KEY,
+      BASE_URL: config?.apiUrl || DEFAULT_BASE_URL,
+    });
+  }, [config.apiKey, config.apiUrl]);
+
+  useEffect(() => {
+    if (props.config?.signers?.customSolanaRPC) {
+      setSolanaSignerConfig('customRPC', props.config.signers.customSolanaRPC);
+    }
+  }, [props.config?.signers?.customSolanaRPC]);
 
   return (
     <WidgetWallets config={config} onUpdateState={onUpdateState}>

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -103,6 +103,10 @@ export type BlockchainAndTokenConfig = {
   tokens?: Asset[] | { [blockchain: string]: Tokens };
 };
 
+export type SignersConfig = {
+  customSolanaRPC?: string;
+};
+
 /**
  * `Features`
  *
@@ -209,4 +213,5 @@ export type WidgetConfig = {
   features?: Features;
   variant?: WidgetVariant;
   enableCentralizedSwappers?: boolean;
+  signers?: SignersConfig;
 };


### PR DESCRIPTION
# Summary

Added custom solana rpc in signer config to widget config.

Fixes # RF-1504

# How did you test this change?

Tested it by adding the below object to widget config:

```
signerConfig: { customSolanaRPC: 'customSolanaRPC' }
```



# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
