### PR TITLE
feat: add an option to wallet connect provider to open a desktop wall…

### DIFF
--- a/wallets/provider-walletconnect-2/src/index.ts
+++ b/wallets/provider-walletconnect-2/src/index.ts
@@ -1,4 +1,4 @@
-import type { WCInstance } from './types';
+import type { Environments, WCInstance } from './types';
 import type {
   CanSwitchNetwork,
   Connect,
@@ -47,13 +47,13 @@ import signer from './signer';
 
 const WALLET = WalletTypes.WALLET_CONNECT_2;
 
-export interface Environments extends Record<string, string> {
-  WC_PROJECT_ID: string;
-}
-
 let envs: Environments = {
   WC_PROJECT_ID: '',
+  DISABLE_MODAL_AND_OPEN_LINK: undefined,
 };
+
+export type { Environments };
+
 export const init = (environments: Environments) => {
   envs = environments;
 
@@ -102,7 +102,7 @@ export const getInstance: GetInstance = async (options) => {
 export const connect: Connect = async ({ instance, meta }) => {
   const { client } = instance as WCInstance;
   // Try to restore the session first, if couldn't, create a new session by showing a modal.
-  const session = await tryConnect(client, { meta });
+  const session = await tryConnect(client, { meta, envs });
   // Override the value (session).
   instance.session = session;
   const currentChainId = await getPersistedChainId(client);

--- a/wallets/provider-walletconnect-2/src/types.ts
+++ b/wallets/provider-walletconnect-2/src/types.ts
@@ -2,6 +2,11 @@ import type { SignClient } from '@walletconnect/sign-client/dist/types/client';
 import type { ProposalTypes, SessionTypes } from '@walletconnect/types';
 import type { BlockchainMeta, CosmosBlockchainMeta } from 'rango-types/lib';
 
+export interface Environments extends Record<string, string | undefined> {
+  WC_PROJECT_ID: string;
+  // This is useful for directly opening a listed WC wallet. you will need to pass a url.
+  DISABLE_MODAL_AND_OPEN_LINK?: string;
+}
 export interface WCInstance {
   client: SignClient;
   session: SessionTypes.Struct | null;
@@ -16,6 +21,7 @@ export interface CreateSessionParams {
 
 export interface ConnectParams {
   meta: BlockchainMeta[];
+  envs: Environments;
 }
 
 export interface CosmosMeta extends CosmosBlockchainMeta {

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -38,6 +38,9 @@ function Main(props: PropsWithChildren<PropTypes>) {
 
   const walletOptions: ProvidersOptions = {
     walletConnectProjectId: props.config?.walletConnectProjectId,
+    walletConnectListedDesktopWalletLink:
+      props.config.__UNSTABLE_OR_INTERNAL__
+        ?.walletConnectListedDesktopWalletLink,
   };
   const { providers } = useWalletProviders(config.wallets, walletOptions);
   const { connectWallet, disconnectWallet } = useWalletsStore();

--- a/widget/embedded/src/hooks/useWalletList.ts
+++ b/widget/embedded/src/hooks/useWalletList.ts
@@ -45,6 +45,8 @@ export function useWalletList(params: Params) {
   const listAvailableWalletTypes =
     configWalletsToWalletName(config?.wallets, {
       walletConnectProjectId: config?.walletConnectProjectId,
+      walletConnectListedDesktopWalletLink:
+        config.__UNSTABLE_OR_INTERNAL__?.walletConnectListedDesktopWalletLink,
     }) || ALL_SUPPORTED_WALLETS;
 
   let wallets = mapWalletTypesToWalletInfo(

--- a/widget/embedded/src/hooks/useWalletProviders.ts
+++ b/widget/embedded/src/hooks/useWalletProviders.ts
@@ -14,16 +14,12 @@ export function useWalletProviders(
   const clearConnectedWallet = useWalletsStore.use.clearConnectedWallet();
   let generateProviders: ProviderInterface[] = matchAndGenerateProviders(
     providers,
-    {
-      walletConnectProjectId: options?.walletConnectProjectId,
-    }
+    options
   );
 
   useEffect(() => {
     clearConnectedWallet();
-    generateProviders = matchAndGenerateProviders(providers, {
-      walletConnectProjectId: options?.walletConnectProjectId,
-    });
+    generateProviders = matchAndGenerateProviders(providers, options);
   }, [providers?.length]);
 
   return {

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -214,4 +214,9 @@ export type WidgetConfig = {
   variant?: WidgetVariant;
   enableCentralizedSwappers?: boolean;
   signers?: SignersConfig;
+
+  // These are likely to change or remove at anytime. Please use with a caution.
+  __UNSTABLE_OR_INTERNAL__?: {
+    walletConnectListedDesktopWalletLink?: string;
+  };
 };

--- a/widget/embedded/src/utils/providers.ts
+++ b/widget/embedded/src/utils/providers.ts
@@ -5,6 +5,9 @@ import { allProviders } from '@rango-dev/provider-all';
 
 export interface ProvidersOptions {
   walletConnectProjectId?: WidgetConfig['walletConnectProjectId'];
+  walletConnectListedDesktopWalletLink?: NonNullable<
+    WidgetConfig['__UNSTABLE_OR_INTERNAL__']
+  >['walletConnectListedDesktopWalletLink'];
 }
 
 /**
@@ -20,6 +23,8 @@ export function matchAndGenerateProviders(
   const all = allProviders({
     walletconnect2: {
       WC_PROJECT_ID: options?.walletConnectProjectId || '',
+      DISABLE_MODAL_AND_OPEN_LINK:
+        options?.walletConnectListedDesktopWalletLink,
     },
     selectedProviders: providers,
   });


### PR DESCRIPTION
# Summary

In this PR, a new feature is added to WalletConnect provider to be able to connect to a specific wallet directly, instead of opening a QR code modal.

If wallet has been submitted to WalletConnect's Explorer and listed there, we can have direct connect for that wallet.

I couldn't find any document for solving this issue, I took a look at `@walletconnect/modal` [source code](https://docs.walletconnect.com/cloud/explorer-submission) and tried to see the process.

Before describing steps, I would like to tell how WC works. When a dApp is trying to a wallet using WC, an URI will be generated (e.g. `wc:....`). This URI includes enough information to make a connection possible between two parties. Normally, you will scan a QR code using your wallet so It's not obvious what data inside the QR code, as you can guess, it's the URI in fact.

Regarding the source code, when you are choosing a wallet from the opened modal, following steps will be taken:

1. When modal has opened a request will be sent to `https://explorer-api.walletconnect.com/w3m/v1/getDesktopListings`
2. In response, there are some wallets that listed in Explorer. Which has information about each wallet and also an object like this: 
```js
{
  desktop: {
    native: "infinity://"
    universal: "https://infinitywallet.io/"
  }
}
```
3. When user choosing a wallet, a redirect link will be generated in this format:
```
"${desktop.universal}/wc?uri=wc..."
```
4. User will be redirected, and wallet will take the rest with making the connection using provided URI.




Fixes RF-1535

# Solution

I've added a config called `walletConnectListedDesktopWalletLink`, which can be retrieved from the dApp that integrated us. if the value is provided, instead of opening QR modal, we will redirect the user to wallet's link.

I've put it behind a `__UNSTABLE_OR_INTERNAL__` flag to make sure it communicates to dApp users it's not a general solution yet and will be moved to main object whenever we tested and iterated the feature.

Also, in this implementation if user has passed `walletConnectListedDesktopWalletLink` option, the wallet connect will be connected to only that specific wallet whic means you can not use WalletConnect for other wallets. 

If we are going to keep WalletConnect in our list to be able to connect to other wallets as well and add a new item in our list besides the WalletConnect, we can go with that approach as well.


# How did you test this change?

This PR included with a sample (it will be removed when we decided to merge), ِyou can check the preview deployment or if you want to test it locally, you can run `yarn dev:widget` and click on WalletConnect in Wallets page.

You can also remove the config from this path `widget/app/src/App.tsx` to see the normal flow without specifying a wallet.


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
