### PR TITLE
fix: exclude the gas price from evm transaction specifications in version 2

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -89,7 +89,8 @@
     "@typescript-eslint/no-magic-numbers": [
       "error",
       {
-        "ignore": [-1, 0, 1, 2]
+        "ignore": [-1, 0, 1, 2],
+        "ignoreTypeIndexes": true
       }
     ],
     "@typescript-eslint/consistent-type-exports": "error",

--- a/queue-manager/rango-preset/src/helpers.ts
+++ b/queue-manager/rango-preset/src/helpers.ts
@@ -288,6 +288,7 @@ export function updateSwapStatus({
   details,
   errorCode = null,
   hasAlreadyProceededToSign,
+  trace = null,
 }: {
   getStorage: ExecuterActions<
     SwapStorage,
@@ -305,6 +306,7 @@ export function updateSwapStatus({
   details?: string | null | undefined;
   errorCode?: APIErrorCode | SignerErrorCode | null;
   hasAlreadyProceededToSign?: boolean;
+  trace?: Error | null | undefined;
 }): {
   swap: PendingSwap;
   step: PendingSwapStep | null;
@@ -354,7 +356,10 @@ export function updateSwapStatus({
         requestId: swap.requestId,
         step: currentStep?.id || 1,
         eventType: failureType,
-        reason: errorReason || '',
+        reason:
+          trace?.message && typeof trace?.message === 'string'
+            ? trace?.message
+            : errorReason || '',
         tags: walletType
           ? {
               wallet: walletType,
@@ -1151,6 +1156,7 @@ export function signTransaction(
         message: extraMessage,
         details: extraMessageDetail,
         errorCode: extraMessageErrorCode,
+        trace: error?.trace,
       });
 
       notifier({

--- a/yarn.lock
+++ b/yarn.lock
@@ -5451,14 +5451,6 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@rango-dev/wallets-shared@^0.32.0":
-  version "0.32.0"
-  resolved "https://registry.yarnpkg.com/@rango-dev/wallets-shared/-/wallets-shared-0.32.0.tgz#b0c14e34dee26334712cb13959fdac8692786d2f"
-  integrity sha512-dL1R5e3OQYNCAxl2TNP5y42qdVR9GMRKg4Hwtu4leY2RwgKchDyhNi3yPsL/nh9KNiU0ROlrO9CZ0cNQoT3x6g==
-  dependencies:
-    ethers "^5.7.2"
-    rango-types "^0.1.59"
-
 "@reach/router@^1.2.1":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -16294,6 +16286,7 @@ rango-types@^0.1.59:
   resolved "https://registry.yarnpkg.com/rango-types/-/rango-types-0.1.59.tgz#800c2eda06d36e0099b3e50d8dfcb048c3d9de73"
   integrity sha512-sdbR2L5KVnGoVE1CVgtZyK21DKcTtivw+ajC15B2d2+BSQFmPQwe/gPAEJb3My6n2iR3rgVUdOoDTcAuZU3WLA==
 
+
 raw-body@2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
@@ -17606,16 +17599,7 @@ string-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/string-format/-/string-format-2.0.0.tgz#f2df2e7097440d3b65de31b6d40d54c96eaffb9b"
   integrity sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17707,14 +17691,7 @@ stringify-object@^5.0.0:
     is-obj "^3.0.0"
     is-regexp "^3.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -19085,7 +19062,7 @@ wordwrapjs@^4.0.0:
     reduce-flatten "^2.0.0"
     typical "^5.2.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19098,15 +19075,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Summary

For EVM transaction v2, the `gasPrice` should be omitted, and only the `maxFeePerGas` and `maxPriorityFeePerGas` should be provided to the provider for signing the transaction.

# Checklist:

- [x] I have performed a self-review of my code