### PR TITLE
feat: improve solana simulation failed errors

### DIFF
--- a/signers/signer-solana/src/utils/main.ts
+++ b/signers/signer-solana/src/utils/main.ts
@@ -51,6 +51,13 @@ export async function executeSolanaTransaction(
   const DefaultSolanaSigner: SolanaWeb3Signer = async (
     solanaWeb3Transaction
   ) => {
+    if (tx.from !== solanaProvider.publicKey?.toString()) {
+      throw new SignerError(
+        SignerErrorCode.SIGN_TX_ERROR,
+        `Your connected account doesn't match with the required account. Please ensure that you are connected with the correct account and try again.`
+      );
+    }
+
     try {
       const signedTransaction = await solanaProvider.signTransaction(
         solanaWeb3Transaction


### PR DESCRIPTION
# Summary

Improved some Solana simulation errors:

1. AccountNotFound error changed to "Fee payer of transaction is an unknown account"
2. SBF program panicked changed to "Program failed to complete"
3. Th error message related to the third error in "@solana-web3.js" was "Custom program error". Considering that it is similar to the current error and it is not human friendly either, I didin't change it.

Fixes # 1513

# How did you test this change?

1. create a solana transaction with a new solana account. (no balance and previous transactions)
2. create transaction from AVAX.SOLANA to USDT.SOLANA and sign it with an account with no balance.
2. create transaction from USDC.SOLANA to ATOM.Cosmos and sign it with an account with no balance.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
