### PR TITLE
hotfix: ignore confirm transaction unknown errors and proceed with check status

### DIFF
--- a/queue-manager/rango-preset/src/helpers.ts
+++ b/queue-manager/rango-preset/src/helpers.ts
@@ -351,15 +351,20 @@ export function updateSwapStatus({
     const failureType = mapAppErrorCodesToAPIErrorCode(errorCode);
     updatedResult.failureType = failureType;
 
+    // If trace of error was available, we will send it to the api (except user rejection)
+    const errorReasonForAPI =
+      errorCode !== 'USER_REJECT' &&
+      trace?.message &&
+      typeof trace.message === 'string'
+        ? trace.message
+        : errorReason || '';
+
     httpService()
       .reportFailure({
         requestId: swap.requestId,
         step: currentStep?.id || 1,
         eventType: failureType,
-        reason:
-          trace?.message && typeof trace?.message === 'string'
-            ? trace?.message
-            : errorReason || '',
+        reason: errorReasonForAPI,
         tags: walletType
           ? {
               wallet: walletType,

--- a/signers/signer-evm/src/signer.ts
+++ b/signers/signer-evm/src/signer.ts
@@ -219,12 +219,15 @@ export class DefaultEvmSigner implements GenericSigner<EvmTransaction> {
           /**
            * In cases where the is no error returen from tenderly, we could ignore
            * the error and proceed with check status flow.
-           *
            */
           return { hash: txHash };
         }
       }
-      throw cleanEvmError(error);
+      /**
+       * Ignore other errors in confirming transaction and proceed with check status flow,
+       * Some times rpc gives internal error or other type of errors even if the transaction succeeded
+       */
+      return { hash: txHash };
     }
   }
 }

--- a/signers/signer-evm/src/types.ts
+++ b/signers/signer-evm/src/types.ts
@@ -1,6 +1,6 @@
 export const MetamaskErrorCodes = {
   rpc: {
-    invalidInput: -32000,
+    // invalidInput: -32000,
     resourceNotFound: -32001,
     resourceUnavailable: -32002,
     transactionRejected: -32003,


### PR DESCRIPTION

# Summary

- In this PR, I've disabled unhandled errors in confirm transaction as they could be false positive.
- I've also commented one of the metamask errors to check something in production.
- Avoid sending trace of rpc errors to api when user reject the transactions.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
