### PR TITLE
 fix: some bugs in playground

### DIFF
--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -37,7 +37,7 @@ function Main(props: PropsWithChildren<PropTypes>) {
   const config = useAppStore().config;
 
   const walletOptions: ProvidersOptions = {
-    walletConnectProjectId: props.config?.walletConnectProjectId,
+    walletConnectProjectId: config?.walletConnectProjectId,
     walletConnectListedDesktopWalletLink:
       props.config.__UNSTABLE_OR_INTERNAL__
         ?.walletConnectListedDesktopWalletLink,

--- a/widget/embedded/src/hooks/useWalletList.ts
+++ b/widget/embedded/src/hooks/useWalletList.ts
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { useAppStore } from '../store/AppStore';
 import { useWalletsStore } from '../store/wallets';
+import { isSingleWalletActive } from '../utils/common';
 import { configWalletsToWalletName } from '../utils/providers';
 import {
   hashWalletsState,
@@ -82,10 +83,7 @@ export function useWalletList(params: Params) {
       if (wallet.connected) {
         await disconnect(type);
       } else {
-        const atLeastOneWalletIsConnected = !!wallets.find(
-          (w) => w.state === WalletState.CONNECTED
-        );
-        if (config?.multiWallets === false && atLeastOneWalletIsConnected) {
+        if (isSingleWalletActive(wallets, config.multiWallets)) {
           return;
         }
         onBeforeConnect?.(type);

--- a/widget/embedded/src/utils/common.ts
+++ b/widget/embedded/src/utils/common.ts
@@ -1,6 +1,7 @@
+import type { WalletInfoWithNamespaces } from '../types';
 import type { Token } from 'rango-sdk';
 
-import { BlockchainCategories } from '@rango-dev/ui';
+import { BlockchainCategories, WalletState } from '@rango-dev/ui';
 import { TransactionType } from 'rango-sdk';
 
 import { WIDGET_UI_ID } from '../constants';
@@ -247,3 +248,13 @@ export const getFontUrlByName = (fontName: string) => {
   const font = SUPPORTED_FONTS.find((font) => font.value === fontName);
   return font?.url;
 };
+
+export function isSingleWalletActive(
+  wallets: WalletInfoWithNamespaces[],
+  multiWallets?: boolean
+) {
+  const atLeastOneWalletIsConnected = !!wallets.find(
+    (w) => w.state === WalletState.CONNECTED
+  );
+  return multiWallets === false && atLeastOneWalletIsConnected;
+}

--- a/widget/playground/src/App.tsx
+++ b/widget/playground/src/App.tsx
@@ -10,7 +10,7 @@ import { ConfigContainer } from './containers/configContainer';
 import { useTheme } from './hooks/useTheme';
 import { initialConfig, useConfigStore } from './store/config';
 import { useMetaStore } from './store/meta';
-import { RANGO_PUBLIC_API_KEY } from './utils/configs';
+import { getConfig, RANGO_PUBLIC_API_KEY } from './utils/configs';
 import { filterConfig } from './utils/export';
 
 export function App() {
@@ -21,6 +21,7 @@ export function App() {
 
   const overridedConfig: WidgetConfig = {
     theme: {},
+    ...config,
     ...filteredConfigForExport,
     apiKey: RANGO_PUBLIC_API_KEY,
     features: {
@@ -35,7 +36,11 @@ export function App() {
    * Playground widget provider should contain all wallets so we need to remove 'wallets' from config
    * to make sure we can access to list of all wallets in playground
    */
-  const playgroundConfig = { ...overridedConfig, wallets: undefined };
+  const playgroundConfig = {
+    ...overridedConfig,
+    wallets: undefined,
+    walletConnectProjectId: getConfig('WC_PROJECT_ID'),
+  };
 
   useEffect(() => {
     void fetchMeta();

--- a/widget/playground/src/components/MultiSelect/MultiSelect.styles.ts
+++ b/widget/playground/src/components/MultiSelect/MultiSelect.styles.ts
@@ -35,6 +35,16 @@ export const Select = styled('div', {
           cursor: 'pointer',
         },
       },
+      true: {
+        '& .chips': {
+          '& div': {
+            backgroundColor: '$neutral500',
+            '& span': {
+              color: '$neutral600',
+            },
+          },
+        },
+      },
     },
   },
 });

--- a/widget/playground/src/components/Slider/Slider.tsx
+++ b/widget/playground/src/components/Slider/Slider.tsx
@@ -3,6 +3,8 @@ import type { PropTypes } from './Slider.types';
 import { Typography } from '@rango-dev/ui';
 import React, { useEffect } from 'react';
 
+import { DEFAULT_THEME_COLORS, PLAYGROUND_CONTAINER_ID } from '../../constants';
+
 import {
   Content,
   RangeWrapper,
@@ -11,6 +13,7 @@ import {
 } from './Slider.styles';
 
 const MAX_VALUE = 100;
+const DEFAULT_COLOR = DEFAULT_THEME_COLORS.light.secondary;
 function Slider(props: PropTypes) {
   const {
     title,
@@ -20,6 +23,7 @@ function Slider(props: PropTypes) {
     variant = 'custom',
     min,
     max = MAX_VALUE,
+    color = DEFAULT_COLOR,
     id,
   } = props;
 
@@ -27,12 +31,20 @@ function Slider(props: PropTypes) {
     const sliderEl = document.querySelector(`#${id}`) as HTMLInputElement;
     const sliderValue = parseInt(sliderEl.value);
     const mainValue = sliderValue * (MAX_VALUE / (max as number));
-    sliderEl.style.background = `linear-gradient(to right, #5BABFF ${mainValue}%, #C8E2FF ${mainValue}%)`;
+    // Get CSS variables
+    const referenceElement = document.querySelector(
+      `#${PLAYGROUND_CONTAINER_ID}`
+    ) as Element;
+    const sliderActiveColor = color;
+    const sliderColorInactive = getComputedStyle(
+      referenceElement
+    ).getPropertyValue('--colors-secondary100');
+    sliderEl.style.background = `linear-gradient(to right, ${sliderActiveColor} ${mainValue}%, ${sliderColorInactive} ${mainValue}%)`;
   };
 
   useEffect(() => {
     progressScript();
-  }, []);
+  }, [value, color]);
 
   return (
     <SliderContainer>

--- a/widget/playground/src/components/Slider/Slider.types.ts
+++ b/widget/playground/src/components/Slider/Slider.types.ts
@@ -8,5 +8,6 @@ export interface PropTypes {
   variant?: 'custom' | 'regular';
   min?: string;
   max?: string;
+  color?: string;
   id: string;
 }

--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
@@ -1,5 +1,4 @@
 import type { WalletType } from '@rango-dev/wallets-shared';
-import type { WidgetConfig } from '@rango-dev/widget-embedded';
 
 import {
   Button,
@@ -14,7 +13,6 @@ import { useWallets } from '@rango-dev/widget-embedded';
 import React from 'react';
 
 import { MultiSelect } from '../../components/MultiSelect';
-import { NOT_FOUND } from '../../constants';
 import { useConfigStore } from '../../store/config';
 import { getCategoryNetworks } from '../../utils/blockchains';
 import { excludedWallets } from '../../utils/common';
@@ -37,38 +35,28 @@ export function WalletSection() {
   const allWalletList = Object.values(WalletTypes)
     .filter((wallet) => !excludedWallets.includes(wallet))
     .map((wallet) => {
-      const { name: title, img: logo, supportedChains } = getWalletInfo(wallet);
+      const type = wallet as string;
+
+      const { name: title, img: logo, supportedChains } = getWalletInfo(type);
       return {
         title,
         logo,
-        name: wallet,
+        name: type,
         supportedNetworks: getCategoryNetworks(supportedChains),
       };
     });
 
   const onChangeExternalWallet = (checked: boolean) => {
-    let selectedWallets: WidgetConfig['wallets'] = !!wallets
-      ? [...wallets]
-      : [];
-    if (checked) {
-      const index = selectedWallets.findIndex(
-        (wallet) => wallet === WalletTypes.META_MASK
-      );
-      if (index !== NOT_FOUND) {
-        selectedWallets.splice(index, 1);
-      }
-      selectedWallets = [...selectedWallets, WalletTypes.META_MASK];
-    } else {
+    if (!checked) {
       if (state('metamask').connected) {
         void disconnect(WalletTypes.META_MASK);
       }
-      if (selectedWallets.length === 1) {
-        selectedWallets = [];
-      }
     }
     onChangeBooleansConfig('externalWallets', checked);
-    onChangeWallets(!selectedWallets.length ? undefined : selectedWallets);
   };
+
+  const isSelectAllWallets =
+    wallets?.length === allWalletList.length || externalWallets;
 
   return (
     <>
@@ -76,16 +64,13 @@ export function WalletSection() {
         label="Supported Wallets"
         icon={<WalletIcon />}
         type="Wallets"
-        value={
-          wallets?.length === allWalletList.length
-            ? undefined
-            : (wallets as WalletType[])
-        }
+        value={isSelectAllWallets ? undefined : (wallets as WalletType[])}
         defaultSelectedItems={
           (wallets as WalletType[]) ||
           allWalletList.map((wallet) => wallet.name)
         }
         list={allWalletList}
+        disabled={!!externalWallets}
         onChange={onChangeWallets}
       />
       <Divider size={24} />

--- a/widget/playground/src/containers/StyleLayout/StyleLayout.General.tsx
+++ b/widget/playground/src/containers/StyleLayout/StyleLayout.General.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../constants';
 import { DEFAULT_FONT } from '../../constants/fonts';
 import { VARIANTS } from '../../constants/variants';
+import { useTheme } from '../../hooks/useTheme';
 import { useConfigStore } from '../../store/config';
 
 import { Field, FieldTitle, GeneralContainer } from './StyleLayout.styles';
@@ -39,7 +40,9 @@ export function General() {
   const onChangeVariant = useConfigStore.use.onChangeVariant();
 
   const borderRadius = useConfigStore.use.config().theme?.borderRadius;
-
+  const colors = useConfigStore.use.config().theme?.colors;
+  const { activeStyle } = useTheme();
+  const mode = activeStyle.indexOf('dark') !== -1 ? 'dark' : 'light';
   const secondaryBorderRadius =
     useConfigStore.use.config().theme?.secondaryBorderRadius;
   const fontFamily =
@@ -139,6 +142,7 @@ export function General() {
           </FieldTitle>
           <Divider size={16} />
           <Slider
+            color={colors?.[mode]?.secondary}
             showValue
             title="Widget"
             id="range1"
@@ -148,6 +152,7 @@ export function General() {
           />
           <Divider size={4} />
           <Slider
+            color={colors?.[mode]?.secondary}
             id="range2"
             showValue
             title="Button"

--- a/widget/playground/src/store/config.ts
+++ b/widget/playground/src/store/config.ts
@@ -95,7 +95,7 @@ export const initialConfig: WidgetConfig = {
   },
   liquiditySources: undefined,
   wallets: undefined,
-  multiWallets: undefined,
+  multiWallets: true,
   customDestination: undefined,
   language: undefined,
   excludeLiquiditySources: undefined,

--- a/widget/playground/src/utils/export.ts
+++ b/widget/playground/src/utils/export.ts
@@ -24,9 +24,9 @@ export function filterConfig(
 ) {
   const config = {
     ...WidgetConfig,
-    wallets: WidgetConfig.wallets?.filter(
-      (wallet) => typeof wallet === 'string'
-    ),
+    wallets: WidgetConfig.externalWallets
+      ? undefined
+      : WidgetConfig.wallets?.filter((wallet) => typeof wallet === 'string'),
   };
 
   const userSelectedConfig = clearEmpties(
@@ -51,7 +51,10 @@ export function filterConfig(
     filteredConfigForExport.apiKey = config.apiKey;
   }
 
-  if (!filteredConfigForExport.walletConnectProjectId) {
+  const isWalletConnectProjectIdNeeded =
+    !filteredConfigForExport.walletConnectProjectId &&
+    (!config.wallets || config.wallets.includes('wallet-connect-2'));
+  if (isWalletConnectProjectIdNeeded) {
     filteredConfigForExport.walletConnectProjectId =
       config.walletConnectProjectId;
   }
@@ -111,14 +114,15 @@ export function formatConfig(config: WidgetConfig) {
     `,
     formatedConfig.indexOf('apiKey')
   );
-
-  formatedConfig = insertAt(
-    formatedConfig,
-    `// This project id is only for test purpose. Don't use it in production.
+  if (config.walletConnectProjectId) {
+    formatedConfig = insertAt(
+      formatedConfig,
+      `// This project id is only for test purpose. Don't use it in production.
     // Get your Wallet Connect project id from https://cloud.walletconnect.com/
     `,
-    formatedConfig.indexOf('walletConnectProjectId')
-  );
+      formatedConfig.indexOf('walletConnectProjectId')
+    );
+  }
 
   if (!!config.wallets) {
     formatedConfig = insertAt(


### PR DESCRIPTION
# Summary

Fix walletConnectProjectId:

Don't insert 'walletConnectProjectId' in exported code if wallet-connect is excludedCurrently if the user exclude 'wallet-connect' in the list of wallets, we insert walletConnectProjectId in the exported code anyway. It should be removed if 'wallet-connect' is excluded.

Fix external wallets and supported wallets mismatch:

Reproduce

- Enable external wallet option
- Click on supported wallets (metamask is selected by default), Click on Select All and then Confirm.
- Click on export code button, it eliminated wallets and only keeps externalWallets: true.

Possible solution:
When external wallets has been enabled, we can disable Supported Wallets input to stop user from doing incorrect behaviour.
fix Enable Multi Wallets Simultaneously

Reproduce:
- Disable and enable  Enable Multi Wallets Simultaneously option.
- It will add multiWallets: true,

Solution:
When the option has been enabled, we can eliminate multiWallets: true, from exported config.

Fix slider bug:

- When the config was reset, the slider wasn't reset
- The color of the slider wasn't changed with the theme

Fixes # (issue)


# How did you test this change?

You can test on the playground



# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas