### PR TITLE
feat: make update settings optional to make it enable in playground

### DIFF
--- a/widget/embedded/src/store/slices/settings.ts
+++ b/widget/embedded/src/store/slices/settings.ts
@@ -169,6 +169,9 @@ export const createSettingsSlice: StateCreator<
       ...(isLiquidityHidden && {
         disabledLiquiditySources: nextConfig.liquiditySources || [],
       }),
+      ...(nextConfig?._INTERNAL_SETTINGS_?.autoUpdateSettings && {
+        language: nextConfig.language || DEFAULT_LANGUAGE,
+      }),
     });
   },
 });

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -219,4 +219,9 @@ export type WidgetConfig = {
   __UNSTABLE_OR_INTERNAL__?: {
     walletConnectListedDesktopWalletLink?: string;
   };
+
+  // Internal configuration options. Not intended for public use or modification.
+  _INTERNAL_SETTINGS_?: {
+    autoUpdateSettings?: boolean; // If true, settings will be updated automatically based on the configuration.
+  };
 };

--- a/widget/playground/src/App.tsx
+++ b/widget/playground/src/App.tsx
@@ -23,6 +23,9 @@ export function App() {
     features: {
       theme: 'hidden',
     },
+    _INTERNAL_SETTINGS_: {
+      autoUpdateSettings: true,
+    },
   };
 
   /*


### PR DESCRIPTION
# Summary
Source of truth of the values should be config object in Playground, but if any changes happens inside the widget, it has more priority than config. We need to reset all the widget values in Playground on reload to make sure configs will be applied.

Note: It seemed that the problem was from Zustand's persistor, but the problem was that the setting wasn't updated by the config

Fixes # (issue)


# How did you test this change?

Change the font in the playground first, then the widget. After changing the font once more in the playground, the widget's font should also change.


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
