### PR TITLE
feat: display all notifications in the notification popover

### DIFF
--- a/widget/embedded/src/components/NotificationContent/NotificationContent.tsx
+++ b/widget/embedded/src/components/NotificationContent/NotificationContent.tsx
@@ -1,32 +1,13 @@
 import type { Notification } from '../../types/notification';
 
-import { i18n } from '@lingui/core';
-import { EventSeverity } from '@rango-dev/queue-manager-rango-preset';
-import {
-  ChainToken,
-  ChevronRightIcon,
-  Divider,
-  Typography,
-} from '@rango-dev/ui';
+import { Notifications } from '@rango-dev/ui';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { navigationRoutes } from '../../constants/navigationRoutes';
 import { useAppStore } from '../../store/AppStore';
 import { useNotificationStore } from '../../store/notification';
-
-import {
-  ClearAllButton,
-  Container,
-  Header,
-  IconContainer,
-  Images,
-  List,
-  ListItem,
-} from './NotificationContent.styles';
-import { NotificationNotFound } from './NotificationNotFound';
-
-const MAX_NOTIFICATIONS_DISPLAYED = 4;
+import { getBlockchainImage } from '../../utils/meta';
 
 export function NotificationContent() {
   const navigate = useNavigate();
@@ -36,102 +17,20 @@ export function NotificationContent() {
   const notifications: Notification[] = getNotifications();
   const blockchains = useAppStore().blockchains();
   const { findToken } = useAppStore();
-  const sortedNotification = notifications
-    .sort((a, b) => b.creationTime - a.creationTime)
-    .slice(0, MAX_NOTIFICATIONS_DISPLAYED);
 
-  const handleOnClick = (requestId: Notification['requestId']) => {
+  const onClickItem = (requestId: Notification['requestId']) => {
     navigate(`${navigationRoutes.swaps}/${requestId}`);
   };
 
   return (
-    <Container>
-      {sortedNotification.length > 0 && (
-        <>
-          <Header>
-            <Typography variant="label" size="medium">
-              {i18n.t('Notifications')}
-            </Typography>
-            <ClearAllButton
-              variant="ghost"
-              size="xsmall"
-              onClick={clearNotifications}>
-              <Typography variant="body" size="xsmall">
-                {i18n.t('Clear all')}
-              </Typography>
-            </ClearAllButton>
-          </Header>
-          <Divider direction="vertical" size={4} />
-        </>
-      )}
-      {sortedNotification.length ? (
-        <List>
-          {sortedNotification.map((notificationItem, index) => {
-            const { route, requestId, event } = notificationItem;
-            const fromToken = findToken(route.from);
-
-            const fromBlockchain = blockchains.find(
-              (blockchainItem) => blockchainItem.name === route.from.blockchain
-            );
-
-            const toToken = findToken(route.to);
-
-            const toBlockchain = blockchains.find(
-              (blockchainItem) => blockchainItem.name === route.to.blockchain
-            );
-
-            return (
-              <React.Fragment key={requestId}>
-                {index > 0 && <Divider size={4} />}
-                <ListItem
-                  onClick={() => handleOnClick(requestId)}
-                  actionRequired={
-                    event.messageSeverity === EventSeverity.WARNING
-                  }
-                  title={
-                    <Typography
-                      variant="body"
-                      size="small"
-                      color={
-                        event.messageSeverity === EventSeverity.WARNING
-                          ? '$foreground'
-                          : '$neutral700'
-                      }>
-                      {i18n.t(event.message)}
-                    </Typography>
-                  }
-                  id={requestId}
-                  start={
-                    <Images>
-                      <div className="from-chain-token">
-                        <ChainToken
-                          tokenImage={fromToken ? fromToken.image : ''}
-                          chainImage={fromBlockchain ? fromBlockchain.logo : ''}
-                          size="small"
-                        />
-                      </div>
-                      <div className="to-chain-token">
-                        <ChainToken
-                          tokenImage={toToken ? toToken.image : ''}
-                          chainImage={toBlockchain ? toBlockchain.logo : ''}
-                          size="small"
-                        />
-                      </div>
-                    </Images>
-                  }
-                  end={
-                    <IconContainer>
-                      <ChevronRightIcon size={12} color="gray" />
-                    </IconContainer>
-                  }
-                />
-              </React.Fragment>
-            );
-          })}
-        </List>
-      ) : (
-        <NotificationNotFound />
-      )}
-    </Container>
+    <Notifications
+      list={notifications}
+      getBlockchainImage={(blockchain) =>
+        getBlockchainImage(blockchain, blockchains) ?? ''
+      }
+      getTokenImage={(token) => findToken(token)?.image ?? ''}
+      onClickItem={onClickItem}
+      onClearAll={clearNotifications}
+    />
   );
 }

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
@@ -34,6 +34,7 @@ export function WidgetInfo(props: React.PropsWithChildren) {
   const loadingStatus = useAppStore().fetchStatus;
   const resetLanguage = useLanguage().resetLanguage;
   const notifications = useNotificationStore().getNotifications();
+  const clearNotifications = useNotificationStore().clearNotifications;
 
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   const value: WidgetInfoContextInterface = {
@@ -51,10 +52,12 @@ export function WidgetInfo(props: React.PropsWithChildren) {
       tokens,
       swappers,
       loadingStatus,
+      findToken,
     },
     resetLanguage,
     notifications: {
       list: notifications,
+      clearAll: clearNotifications,
     },
   };
 

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.types.ts
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.types.ts
@@ -1,5 +1,5 @@
 import type { WidgetHistory } from './WidgetInfo.helpers';
-import type { FetchStatus } from '../../store/slices/data';
+import type { FetchStatus, FindToken } from '../../store/slices/data';
 import type { ConnectedWallet } from '../../store/wallets';
 import type { Wallet } from '../../types';
 import type { Notification } from '../../types/notification';
@@ -20,9 +20,11 @@ export interface WidgetInfoContextInterface {
     tokens: Token[];
     swappers: SwapperMeta[];
     loadingStatus: FetchStatus;
+    findToken: FindToken;
   };
   resetLanguage: () => void;
   notifications: {
     list: Notification[];
+    clearAll: () => void;
   };
 }

--- a/widget/embedded/src/store/notification.ts
+++ b/widget/embedded/src/store/notification.ts
@@ -66,7 +66,9 @@ export const useNotificationStore = createSelectors(
         },
         getNotifications: () => {
           const { isSynced, notifications } = get();
-          return isSynced ? notifications : [];
+          return isSynced
+            ? notifications.sort((a, b) => b.creationTime - a.creationTime)
+            : [];
         },
         syncNotifications: (swaps) => {
           const { isSynced, notifications } = get();

--- a/widget/embedded/src/utils/meta.ts
+++ b/widget/embedded/src/utils/meta.ts
@@ -16,6 +16,14 @@ export function getBlockchainShortNameFor(
     ?.shortName;
 }
 
+export function getBlockchainImage(
+  blockchainName: string,
+  blockchains: BlockchainMeta[]
+): string | undefined {
+  return blockchains.find((blockchain) => blockchain.name === blockchainName)
+    ?.logo;
+}
+
 export function getSwapperDisplayName(
   swapperId: string,
   swappers: SwapperMeta[]

--- a/widget/ui/src/containers/Notifications/NotificationNotFound.tsx
+++ b/widget/ui/src/containers/Notifications/NotificationNotFound.tsx
@@ -1,8 +1,10 @@
 import { i18n } from '@lingui/core';
-import { Divider, NoNotificationIcon, Typography } from '@rango-dev/ui';
 import React from 'react';
 
-import { NotFoundContainer } from './NotificationContent.styles';
+import { Divider, Typography } from '../../components';
+import { NoNotificationIcon } from '../../icons';
+
+import { NotFoundContainer } from './Notifications.styles';
 
 export function NotificationNotFound() {
   return (

--- a/widget/ui/src/containers/Notifications/Notifications.styles.ts
+++ b/widget/ui/src/containers/Notifications/Notifications.styles.ts
@@ -1,17 +1,33 @@
-import { Button, darkTheme, ListItemButton, styled } from '@rango-dev/ui';
+import { Button, ListItemButton } from '../../components';
+import { darkTheme, styled } from '../../theme';
 
 export const Container = styled('div', {
-  padding: '$10',
+  borderRadius: '$sm',
+  padding: '0 $10 $10 $10',
   width: '350px',
   maxWidth: '90vw',
   minHeight: '150px',
+  maxHeight: '207px',
+  overflowY: 'auto',
+  background: 'inherit',
+  variants: {
+    equalPadding: {
+      true: {
+        padding: '$10',
+      },
+    },
+  },
 });
 
 export const Header = styled('div', {
-  padding: '0 $10',
+  padding: '$10 $10 0 $10',
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
+  background: 'inherit',
+  position: 'sticky',
+  top: '0',
+  zIndex: 999,
 });
 
 export const ClearAllButton = styled(Button, {
@@ -59,5 +75,8 @@ export const NotFoundContainer = styled('div', {
 });
 
 export const IconContainer = styled('span', {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
   paddingRight: '$8',
 });

--- a/widget/ui/src/containers/Notifications/Notifications.tsx
+++ b/widget/ui/src/containers/Notifications/Notifications.tsx
@@ -1,0 +1,108 @@
+import type { PropTypes } from './Notifications.types';
+
+import { i18n } from '@lingui/core';
+import React from 'react';
+
+import { ChainToken, Divider, Typography } from '../../components';
+import { ChevronRightIcon } from '../../icons';
+
+import { NotificationNotFound } from './NotificationNotFound';
+import {
+  ClearAllButton,
+  Container,
+  Header,
+  IconContainer,
+  Images,
+  List,
+  ListItem,
+} from './Notifications.styles';
+
+export function Notifications(props: PropTypes) {
+  const {
+    list,
+    getBlockchainImage,
+    getTokenImage,
+    onClickItem,
+    onClearAll,
+    containerStyles,
+  } = props;
+  return (
+    <Container equalPadding={list.length === 0} css={containerStyles}>
+      {list.length > 0 && (
+        <>
+          <Header>
+            <Typography variant="label" size="medium">
+              {i18n.t('Notifications')}
+            </Typography>
+            <ClearAllButton variant="ghost" size="xsmall" onClick={onClearAll}>
+              <Typography variant="body" size="xsmall" color="neutral700">
+                {i18n.t('Clear all')}
+              </Typography>
+            </ClearAllButton>
+          </Header>
+          <Divider direction="vertical" size={4} />
+        </>
+      )}
+      {list.length ? (
+        <List>
+          {list.map((notificationItem, index) => {
+            const { route, requestId, event } = notificationItem;
+            const fromTokenImage = getTokenImage(route.from);
+
+            const fromBlockchainImage = getBlockchainImage(
+              route.from.blockchain
+            );
+
+            const toTokenImage = getTokenImage(route.to);
+
+            const toBlockchainImage = getBlockchainImage(route.to.blockchain);
+
+            return (
+              <React.Fragment key={requestId}>
+                {index > 0 && <Divider size={4} />}
+                <ListItem
+                  onClick={() => onClickItem(requestId)}
+                  actionRequired={event.messageSeverity === 'warning'}
+                  title={
+                    <Typography
+                      variant="body"
+                      size="small"
+                      color={
+                        event.messageSeverity === 'warning'
+                          ? '$foreground'
+                          : '$neutral700'
+                      }>
+                      {i18n.t(event.message)}
+                    </Typography>
+                  }
+                  id={requestId}
+                  start={
+                    <Images>
+                      <ChainToken
+                        tokenImage={fromTokenImage}
+                        chainImage={fromBlockchainImage}
+                        size="small"
+                      />
+                      <ChainToken
+                        tokenImage={toTokenImage}
+                        chainImage={toBlockchainImage}
+                        size="small"
+                      />
+                    </Images>
+                  }
+                  end={
+                    <IconContainer>
+                      <ChevronRightIcon size={12} color="gray" />
+                    </IconContainer>
+                  }
+                />
+              </React.Fragment>
+            );
+          })}
+        </List>
+      ) : (
+        <NotificationNotFound />
+      )}
+    </Container>
+  );
+}

--- a/widget/ui/src/containers/Notifications/Notifications.types.ts
+++ b/widget/ui/src/containers/Notifications/Notifications.types.ts
@@ -1,0 +1,17 @@
+import type { CSS } from '../../theme';
+import type { Asset } from 'rango-sdk';
+
+type Notification = {
+  route: { from: Asset; to: Asset };
+  event: { messageSeverity: string; message: string };
+  requestId: string;
+};
+
+export type PropTypes = {
+  list: Notification[];
+  getBlockchainImage: (blockchain: string) => string;
+  getTokenImage: (token: Asset) => string;
+  onClickItem: (requestId: string) => void;
+  onClearAll: () => void;
+  containerStyles?: CSS;
+};

--- a/widget/ui/src/containers/Notifications/index.ts
+++ b/widget/ui/src/containers/Notifications/index.ts
@@ -1,0 +1,1 @@
+export * from './Notifications';

--- a/widget/ui/src/containers/index.ts
+++ b/widget/ui/src/containers/index.ts
@@ -1,3 +1,4 @@
 export * from './ConnectWalletsModal';
 export * from './Warnings';
 export * from './SwapInput';
+export * from './Notifications';


### PR DESCRIPTION
# Summary

Moving the notifications components to the UI package for use in the `widget-embedded` and `Dapp`. Display all notifications without limitations; it can be scrollable.

We can add properties to the notifications store to save and persist token and blockchain images, removing the utility functions for finding these images. However, this would require writing a migration and syncing older versions of the notifications store, potentially adding unnecessary complexity at this time.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
