### PR TITLE
chore: fix the analyze bundle script when a new package is added

### DIFF
--- a/scripts/analyze-bundle/compare.mjs
+++ b/scripts/analyze-bundle/compare.mjs
@@ -108,9 +108,7 @@ export async function compareBuildJsonFiles(
     changes[getPackageName(item)] = {
       'current branch': size(currentBranchPackagesAndBundlesSize[item]),
       'target branch': size(0),
-      diff: formatBundleSizeDiff(
-        formatBundleSizeDiff(currentBranchPackagesAndBundlesSize[item], 0)
-      ),
+      diff: formatBundleSizeDiff(currentBranchPackagesAndBundlesSize[item], 0),
     };
   });
 


### PR DESCRIPTION
# Summary

The bundle analyze script throws an error when attempting to create a report after a new package is added to our repository.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
