### PR TITLE
feat: adding 'shadows' to widget config for theme

### DIFF
--- a/widget/embedded/src/components/Layout/Layout.styles.ts
+++ b/widget/embedded/src/components/Layout/Layout.styles.ts
@@ -7,7 +7,7 @@ export const LayoutContainer = css({
   display: 'flex',
   flexDirection: 'column',
   overflow: 'hidden',
-  boxShadow: '15px 15px 15px 0px rgba(0, 0, 0, 0.05)',
+  boxShadow: '$mainContainer',
 });
 
 export const Container = styled('div', {

--- a/widget/embedded/src/hooks/useTheme.ts
+++ b/widget/embedded/src/hooks/useTheme.ts
@@ -30,6 +30,7 @@ export function useTheme(props: WidgetTheme) {
   const { dark, light } = customizedThemeTokens(colors);
 
   const baseTheme = createTheme({
+    shadows: props.shadows || {},
     radii: {
       primary: `${borderRadius}px`,
       secondary: `${secondaryBorderRadius}px`,

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -1,4 +1,4 @@
-import type { Language } from '@rango-dev/ui';
+import type { Language, theme } from '@rango-dev/ui';
 import type { ProviderInterface } from '@rango-dev/wallets-react';
 import type { WalletType } from '@rango-dev/wallets-shared';
 import type { Asset } from 'rango-sdk';
@@ -49,6 +49,7 @@ export type WidgetTheme = {
   mode?: 'auto' | 'light' | 'dark';
   fontFamily?: string;
   colors?: { light?: WidgetColors; dark?: WidgetColors };
+  shadows?: typeof theme.shadows;
   borderRadius?: number;
   secondaryBorderRadius?: number;
   width?: number;

--- a/widget/ui/src/theme.ts
+++ b/widget/ui/src/theme.ts
@@ -162,7 +162,8 @@ export const theme = {
   borderWidths: {},
   borderStyles: {},
   shadows: {
-    s: '0px 3px 5px 3px #f0f2f5, 0px 6px 10px 3px #f0f2f5, 0px 1px 18px 3px #f0f2f5',
+    /** Shadow for swap box */
+    mainContainer: '15px 15px 15px 0px rgba(0, 0, 0, 0.05)',
   },
   zIndices: {},
   transitions: {},
@@ -221,9 +222,6 @@ export const lightTheme = createTheme('light-theme-ui', {});
 
 export const darkTheme = createTheme('dark-theme-ui', {
   colors: darkColors,
-  shadows: {
-    s: '0px 3px 5px 3px #222, 0px 6px 10px 3px #222, 0px 1px 18px 3px #222',
-  },
 });
 
 export const rangoDarkColors = {


### PR DESCRIPTION
# Summary

For one of our users, we need to let them to hide the shadow around swap box. We don't have any specific way to override some styles directly so I solved it using `theme`. I'm not a fan of aliasing theme tokens (e.g. `mainContainer` that I've used ) but we didn't define `shadows` in our design system so they are hardcoded values right now. In our next iteration on design system we can rethink this part too. So I think it's the easiest way to achieve the user to hide the shadow. 

# How did you test this change?

you need to pass this object as config:
```typescript
{
  theme: {
    shadows: {
      mainContainer: '15px 15px 15px 0px rgba(0, 0, 0, 1)',
      },
  },
}
```


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
