### PR TITLE
fix: fix tx data for evm signer when transferring native token

### DIFF
--- a/signers/signer-evm/src/signer.ts
+++ b/signers/signer-evm/src/signer.ts
@@ -63,14 +63,18 @@ export class DefaultEvmSigner implements GenericSigner<EvmTransaction> {
   static buildTx(evmTx: EvmTransaction, disableV2 = false): TransactionRequest {
     const TO_STRING_BASE = 16;
     let tx: TransactionRequest = {};
+    /*
+     * it's better to pass 0x instead of undefined, otherwise some wallets could face issue
+     * https://github.com/WalletConnect/web3modal/issues/1082#issuecomment-1637793242
+     */
+    tx = {
+      data: evmTx.data || '0x',
+    };
     if (evmTx.from) {
       tx = { ...tx, from: evmTx.from };
     }
     if (evmTx.to) {
       tx = { ...tx, to: evmTx.to };
-    }
-    if (evmTx.data) {
-      tx = { ...tx, data: evmTx.data };
     }
     if (evmTx.value) {
       tx = { ...tx, value: evmTx.value };

--- a/wallets/provider-walletconnect-2/src/signers/evm.ts
+++ b/wallets/provider-walletconnect-2/src/signers/evm.ts
@@ -66,11 +66,11 @@ class EVMSigner implements GenericSigner<EvmTransaction> {
     address: string,
     chainId: string | null
   ): Promise<{ hash: string }> {
-    const requestedFor = this.isNetworkAndAccountExistInSession({
-      address,
-      chainId,
-    });
     try {
+      const requestedFor = this.isNetworkAndAccountExistInSession({
+        address,
+        chainId,
+      });
       const transaction = DefaultEvmSigner.buildTx(tx);
       const hash: string = await this.client.request({
         topic: this.session.topic,


### PR DESCRIPTION
# Summary

We are facing `Unknown method(s) requested` error in wallet connect (using trust wallet) for some routes.
I've fixed the problem based on [this suggestion](https://github.com/WalletConnect/web3modal/issues/1082#issuecomment-1637793242) and added a default `0x` for the data field.

# How did you test this change?

You could test this route before and after this change: (using trust wallet + wallet connect)
`0.1000 x BSC.BNB →[SWFT]→ ? ETH.ETH`

You need to enable centralized swappers to get this route. 

 
# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
