### PR TITLE
fix: fix StepDetalis types import path

### DIFF
--- a/widget/ui/src/components/StepDetails/StepDetails.types.ts
+++ b/widget/ui/src/components/StepDetails/StepDetails.types.ts
@@ -1,6 +1,6 @@
 import type { SwapperType } from 'rango-sdk';
 import type { ReactNode } from 'react';
-import type { SwapInputPropTypes } from '../../../src/containers/SwapInput/SwapInput.types';
+import type { SwapInputPropTypes } from '../../containers/SwapInput/SwapInput.types';
 
 type BaseStep = Pick<SwapInputPropTypes, 'chain' | 'token' | 'price'>;
 type BaseInternalStep = {

--- a/widget/ui/src/components/StepDetails/StepDetails.types.ts
+++ b/widget/ui/src/components/StepDetails/StepDetails.types.ts
@@ -1,6 +1,6 @@
 import type { SwapperType } from 'rango-sdk';
 import type { ReactNode } from 'react';
-import type { SwapInputPropTypes } from 'src/containers/SwapInput/SwapInput.types';
+import type { SwapInputPropTypes } from '../../../src/containers/SwapInput/SwapInput.types';
 
 type BaseStep = Pick<SwapInputPropTypes, 'chain' | 'token' | 'price'>;
 type BaseInternalStep = {


### PR DESCRIPTION
Fixes # (issue)
Replaced SwapInputPropTypes source path to relative, because having 'src/..' causes problems when having the same name 'src' inside project.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
