### PR TITLE
fix: fix the bug where xdefi is not displayed for experimental networks

### DIFF
--- a/wallets/shared/src/rango.ts
+++ b/wallets/shared/src/rango.ts
@@ -178,6 +178,7 @@ export const KEPLR_COMPATIBLE_WALLETS: string[] = [
   WalletTypes.KEPLR,
   WalletTypes.COSMOSTATION,
   WalletTypes.LEAP_COSMOS,
+  WalletTypes.XDEFI,
 ];
 
 export const DEFAULT_COSMOS_RPC_URL = 'https://cosmos-rpc.polkachu.com';


### PR DESCRIPTION
# Summary

When the `XDefi` wallet is not connected, it does not appear in the confirm wallets modal for the `Kujira` network. however, it appears after connecting

Fixes # (issue)


# Checklist:

- [x] I have performed a self-review of my code
