### PR TITLE
fix: state of custom destination in playground

### DIFF
--- a/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
@@ -513,7 +513,7 @@ export function ConfirmWalletsModal(props: PropTypes) {
                     />
                   </ListContainer>
                   {!isLastWallet && <Divider size={32} />}
-                  {isLastWallet && config?.customDestination && (
+                  {isLastWallet && config?.customDestination !== false && (
                     <CustomDestination>
                       <CustomCollapsible
                         onOpenChange={


### PR DESCRIPTION
# Summary

The custom destination was disabled as its value was altered in the widget and it had an undefined value in the playground.
So we don't display the custom destination in the playground by mistake.

Fixes # (issue)


# How did you test this change?

Test in playground

# Checklist:

- [x] I have performed a self-review of my code
