### PR TITLE
fix: bug in updating input & output amount

### DIFF
--- a/widget/embedded/src/containers/Inputs/Inputs.tsx
+++ b/widget/embedded/src/containers/Inputs/Inputs.tsx
@@ -40,7 +40,6 @@ export function Inputs(props: PropTypes) {
   } = useQuoteStore();
   const { connectedWallets, getBalanceFor } = useWalletsStore();
   const fromTokenBalance = fromToken ? getBalanceFor(fromToken) : null;
-
   const fromTokenFormattedBalance =
     formatBalance(fromTokenBalance)?.amount ?? '0';
 
@@ -69,6 +68,7 @@ export function Inputs(props: PropTypes) {
     !inputUsdValue || !outputUsdValue || !outputUsdValue.gt(0)
       ? null
       : getPriceImpact(inputUsdValue.toString(), outputUsdValue.toString());
+
   return (
     <Container>
       <FromContainer>

--- a/widget/embedded/src/store/quote.ts
+++ b/widget/embedded/src/store/quote.ts
@@ -160,11 +160,12 @@ export const useQuoteStore = createSelectors(
 
           return {
             fromBlockchain: chain,
+            inputUsdValue: new BigNumber(0),
             ...(state.fromToken && {
               selectedQuote: null,
               fromToken: null,
               outputAmount: null,
-              outputUsdValue: null,
+              outputUsdValue: new BigNumber(0),
             }),
           };
         });
@@ -195,7 +196,7 @@ export const useQuoteStore = createSelectors(
               selectedQuote: null,
               toToken: null,
               outputAmount: null,
-              outputUsdValue: null,
+              outputUsdValue: new BigNumber(0),
             }),
           };
         });
@@ -260,8 +261,10 @@ export const useQuoteStore = createSelectors(
         set(() => ({
           fromToken: null,
           fromBlockchain: null,
+          outputUsdValue: new BigNumber(0),
+          inputUsdValue: new BigNumber(0),
+          inputAmount: '',
           outputAmount: null,
-          outputUsdValue: null,
           selectedQuote: null,
         })),
       resetToBlockchain: () =>
@@ -269,7 +272,7 @@ export const useQuoteStore = createSelectors(
           toToken: null,
           toBlockchain: null,
           outputAmount: null,
-          outputUsdValue: null,
+          outputUsdValue: new BigNumber(0),
           selectedQuote: null,
         })),
       setQuoteWalletConfirmed: (flag) =>


### PR DESCRIPTION
# Summary
solved two issues:
1. Incorrect updating of the input amount occurs when the source token is eliminated.
2. The dollar value at the destination is not updated accurately when tokens are removed.

Fixes # (issue)

The issue was that the values weren't updated appropriately when the tokens were removed.
In order to improve display, I added a condition to the inputs component that states that values will be presented correctly in the event that the token is removed or the USD value is null.

# How did you test this change?

It is preferable to take the test on the playground:

1. First, indicate the token and input's default values.
2. Navigate to the token selection page. Choose all options without choosing a token.
3. Return to the home screen.
In this instance, the USD values ought to be shown appropriately.

# Checklist:

- [x] I have performed a self-review of my code
