### PR TITLE
fix: persist external wallets in storage

### DIFF
--- a/widget/playground/src/store/config.ts
+++ b/widget/playground/src/store/config.ts
@@ -254,15 +254,6 @@ export const useConfigStore = createSelectors(
       })),
       {
         name: 'user-config',
-
-        partialize: (state) => {
-          const { externalWallets, ...config } = state.config;
-
-          return {
-            ...state,
-            config,
-          };
-        },
         storage: {
           getItem: (name) => {
             const str = localStorage.getItem(name);


### PR DESCRIPTION
# Summary

Persisted external wallets in storage.

Fixes # 1627

# How did you test this change?

You can test this by checking/unchecking external wallets in playground and refreshing the page to see if it persists.


# Checklist:

- [ ] I have performed a self-review of my code
