### PR TITLE
fix: fix sort logic of notifications

### DIFF
--- a/widget/embedded/src/store/notification.ts
+++ b/widget/embedded/src/store/notification.ts
@@ -36,6 +36,7 @@ export const useNotificationStore = createSelectors(
             creationTime: Date.now(),
             requestId: route.requestId,
             route: {
+              creationTime: parseInt(route.creationTime),
               from: {
                 blockchain: fromStep.fromBlockchain,
                 address: fromStep.fromSymbolAddress,
@@ -67,7 +68,18 @@ export const useNotificationStore = createSelectors(
         getNotifications: () => {
           const { isSynced, notifications } = get();
           return isSynced
-            ? notifications.sort((a, b) => b.creationTime - a.creationTime)
+            ? notifications.sort((a, b) => {
+                if (a.route.creationTime && !b.route.creationTime) {
+                  return -1;
+                }
+                if (!a.route.creationTime && b.route.creationTime) {
+                  return 1;
+                }
+                if (!a.route.creationTime && !b.route.creationTime) {
+                  return b.creationTime - a.creationTime;
+                }
+                return b.route.creationTime - a.route.creationTime;
+              })
             : [];
         },
         syncNotifications: (swaps) => {

--- a/widget/embedded/src/types/notification.ts
+++ b/widget/embedded/src/types/notification.ts
@@ -6,6 +6,7 @@ import {
 } from '@rango-dev/queue-manager-rango-preset';
 
 type NotificationRoute = {
+  creationTime: number;
   from: {
     blockchain: Step['fromBlockchain'];
     symbol: Step['fromSymbol'];


### PR DESCRIPTION
# Summary

Fixed sort logic of notifications so they get displayed sorted based on transactionCreationTime.

Fixes # 1662


# How did you test this change?

Tested this by creating a transaction. So when that tx is in the check status state, if I get a new notification, it will appear on top of the old check status notification in notifications list.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
