### PR TITLE
feat: implement sign message method for providers with a custom signer

### DIFF
--- a/signers/signer-solana/src/signer.ts
+++ b/signers/signer-solana/src/signer.ts
@@ -21,7 +21,7 @@ export class DefaultSolanaSigner implements GenericSigner<SolanaTransaction> {
           message: encodedMessage,
         },
       });
-      return signature;
+      return Buffer.from(signature).toString('base64');
     } catch (error) {
       throw new SignerError(SignerErrorCode.SIGN_TX_ERROR, undefined, error);
     }

--- a/signers/signer-terra/src/signer.ts
+++ b/signers/signer-terra/src/signer.ts
@@ -1,4 +1,5 @@
-import type { GenericSigner, CosmosTransaction } from 'rango-types';
+import type { CosmosTransaction, GenericSigner } from 'rango-types';
+
 import { executeTerraTransaction } from './helpers';
 
 type TerraExternalProvider = any;
@@ -15,9 +16,14 @@ export class DefaultTerraSigner implements GenericSigner<CosmosTransaction> {
     address: string,
     chainId: string | null
   ): Promise<string> {
-    if (!chainId) throw Error('ChainId is required');
-    const { result } = await this.provider.signBytes(msg, address);
-    return result.signature;
+    if (!chainId) {
+      throw Error('ChainId is required');
+    }
+    const { result } = await this.provider.signBytes(
+      Buffer.from(msg, 'utf-8'),
+      address
+    );
+    return Buffer.from(result.signature).toString('base64');
   }
 
   async signAndSendTx(tx: CosmosTransaction): Promise<{ hash: string }> {

--- a/wallets/provider-coin98/src/solana-signer.ts
+++ b/wallets/provider-coin98/src/solana-signer.ts
@@ -1,13 +1,16 @@
-import { GenericSigner, SignerError, SolanaTransaction } from 'rango-types';
-import { PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
-import bs58 from 'bs58';
-import {
-  SolanaWeb3Signer,
-  generalSolanaTransactionExecutor,
-} from '@rango-dev/signer-solana';
+import type { SolanaWeb3Signer } from '@rango-dev/signer-solana';
+import type { Transaction, VersionedTransaction } from '@solana/web3.js';
+import type { GenericSigner, SolanaTransaction } from 'rango-types';
 
-// TODO - replace with real type
-// tslint:disable-next-line: no-any
+import { generalSolanaTransactionExecutor } from '@rango-dev/signer-solana';
+import { PublicKey } from '@solana/web3.js';
+import bs58 from 'bs58';
+import { SignerError, SignerErrorCode } from 'rango-types';
+
+/*
+ * TODO - replace with real type
+ * tslint:disable-next-line: no-any
+ */
 type SolanaExternalProvider = any;
 
 export class CustomSolanaSigner implements GenericSigner<SolanaTransaction> {
@@ -16,8 +19,13 @@ export class CustomSolanaSigner implements GenericSigner<SolanaTransaction> {
     this.provider = provider;
   }
 
-  async signMessage(): Promise<string> {
-    throw SignerError.UnimplementedError('signMessage');
+  async signMessage(msg: string): Promise<string> {
+    try {
+      const result = await this.provider.signMessage(msg);
+      return result.signature;
+    } catch (error) {
+      throw new SignerError(SignerErrorCode.SIGN_TX_ERROR, undefined, error);
+    }
   }
 
   async signAndSendTx(tx: SolanaTransaction): Promise<{ hash: string }> {

--- a/wallets/provider-solflare-snap/src/signers/solanaSigner.ts
+++ b/wallets/provider-solflare-snap/src/signers/solanaSigner.ts
@@ -19,8 +19,14 @@ export class SolflareSnapSolanaSigner
     this.provider = provider;
   }
 
-  async signMessage(): Promise<string> {
-    throw SignerError.UnimplementedError('signMessage');
+  async signMessage(msg: string): Promise<string> {
+    try {
+      const encodedMessage = new TextEncoder().encode(msg);
+      const signature = await this.provider.signMessage(encodedMessage);
+      return Buffer.from(signature).toString('base64');
+    } catch (error) {
+      throw new SignerError(SignerErrorCode.SIGN_TX_ERROR, undefined, error);
+    }
   }
 
   async signAndSendTx(tx: SolanaTransaction): Promise<{ hash: string }> {


### PR DESCRIPTION
# Summary

Some providers have implemented a custom signer instead of using the base signers/implementations. We need to implement the `signMessage` method for these providers.
The `signMethod` of some default signers (Solana and Terra) didn't work as expected. These issues have also been addressed in this PR.

# How did you test this change?

You can use the wallets-demo package and the sign buttons in the UI to test it.
(tron provider, coin98 solana provider, ledger ethereum and solana providers, solflare provider, xdefi cosmos provider)
You can test the default Solana signer with the Phantom wallet. However, we currently don't have any enabled wallets that support Terra, so there's no straightforward way to test it at this time. Code changes are needed to address this.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
