### PR TITLE
fix: fix missing usd value in estimated output

### DIFF
--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -188,13 +188,7 @@ export function SwapDetails(props: SwapDetailsProps) {
   )?.diagnosisUrl;
 
   const outputUsdValue = numberToString(
-    parseFloat(
-      numberToString(
-        outputAmount,
-        TOKEN_AMOUNT_MIN_DECIMALS,
-        TOKEN_AMOUNT_MAX_DECIMALS
-      )
-    ) * (lastStep.toUsdPrice || 0),
+    parseFloat(outputAmount || '0') * (lastStep.toUsdPrice || 0),
     USD_VALUE_MIN_DECIMALS,
     USD_VALUE_MAX_DECIMALS
   );


### PR DESCRIPTION
# Summary

USD was missed for low values and also was incorrect in some cases in estimated output in swap details page. Fixed by removing a redundant normalizing.

Fixes # 1665


# How did you test this change?

Tested by trying to swap below values and see the correct value in swap details page:
Ethereum.USDC:0.0001 => Ethereum.ETH


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
