### PR TITLE
feat: hide balance and max button when no wallet connected

### DIFF
--- a/widget/embedded/src/containers/Inputs/Inputs.tsx
+++ b/widget/embedded/src/containers/Inputs/Inputs.tsx
@@ -109,6 +109,7 @@ export function Inputs(props: PropTypes) {
           onSelectMaxBalance={() => {
             setInputAmount(tokenBalanceReal.split(',').join(''));
           }}
+          anyWalletConnected={connectedWallets.length > 0}
         />
         <SwitchFromAndToButton />
       </FromContainer>

--- a/widget/ui/src/containers/SwapInput/SwapInput.tsx
+++ b/widget/ui/src/containers/SwapInput/SwapInput.tsx
@@ -32,7 +32,8 @@ export function SwapInput(props: SwapInputPropTypes) {
     'balance' in props &&
     !props.loading &&
     !props.loadingBalance &&
-    props.token.displayName;
+    props.token.displayName &&
+    props.anyWalletConnected;
 
   const showBalanceSkeleton =
     'balance' in props && (props.loading || props.loadingBalance);

--- a/widget/ui/src/containers/SwapInput/SwapInput.types.ts
+++ b/widget/ui/src/containers/SwapInput/SwapInput.types.ts
@@ -31,6 +31,7 @@ type FromProps = {
   loadingBalance: boolean;
   onSelectMaxBalance: () => void;
   onInputChange: (inputAmount: string) => void;
+  anyWalletConnected: boolean;
 };
 
 type ToProps = {


### PR DESCRIPTION
# Summary

Hide balance and max button when no wallet connected in widget home page.

Fixes # 1678


# How did you test this change?

Tested by checking home page when a wallet is connected and no wallet is connected.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
