### PR TITLE
feat: accept multiple entrypoints for build script

### DIFF
--- a/scripts/build/command.mjs
+++ b/scripts/build/command.mjs
@@ -14,8 +14,12 @@ import { BUILD_META_FILE_SUFFIX } from '../common/constants.mjs';
 const root = join(printDirname(), '..', '..');
 
 async function run() {
-  const optionDefinitions = [{ name: 'path', type: String }];
-  const { path } = commandLineArgs(optionDefinitions);
+  const optionDefinitions = [
+    { name: 'path', type: String },
+    // It accepts a comma separated file paths. e.g. src/main.ts,src/net.ts
+    { name: 'inputs', type: String },
+  ];
+  const { path, inputs } = commandLineArgs(optionDefinitions);
 
   if (!path) {
     throw new Error('You need to specify package name.');
@@ -24,6 +28,13 @@ async function run() {
   const pkgPath = `${root}/${path}`;
   const entryPoint = `${pkgPath}/src/index.ts`;
   const packageName = packageNameWithoutScope(packageJson(path).name);
+
+  let entryPoints = [];
+  if (!inputs) {
+    entryPoints = [`${pkgPath}/src/index.ts`];
+  } else {
+    entryPoints = inputs.split(',').map((input) => `${pkgPath}/${input}`);
+  }
 
   console.log(`[build] Running for ${path}`);
 
@@ -41,7 +52,7 @@ async function run() {
     format: 'esm',
     packages: 'external',
     outdir: `${pkgPath}/dist`,
-    entryPoints: [entryPoint],
+    entryPoints: entryPoints,
     metafile: true,
   });
   const result = await Promise.all([typeCheckingTask, esbuildTask]);


### PR DESCRIPTION
# Summary

Our scripts/build now accepts --inputs to accept more than one entry point. This is useful for supporting exports.


# How did you test this change?

```
cd wallets/core
node ../../scripts/build/command.mjs --path wallets/core --inputs src/persistor.ts,src/index.ts
```

then check `/dist`, it should has two output: `index.js` and `persistor.js`

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
