### PR TITLE
chore: exclude tsconfig files from analyze bundle required artifacts

### DIFF
--- a/.github/actions/upload-build-artifacts/action.yml
+++ b/.github/actions/upload-build-artifacts/action.yml
@@ -2,7 +2,7 @@ name: Upload Build Artifacts
 description: 'Upload ESBuild build artifacts'
 outputs:
   hashed:
-    description: "Hashed branch name"
+    description: 'Hashed branch name'
     value: ${{ steps.hash_current_branch_name.outputs.hashed }}
 
 runs:
@@ -20,6 +20,7 @@ runs:
         name: ${{steps.hash_current_branch_name.outputs.hashed}}
         path: |
           **/**/**.build.json
+          !**/**/tsconfig.build.json
           !**/node_modules/**
         retention-days: 30
         overwrite: true


### PR DESCRIPTION
# Summary

exclude tsconfig files from analyze bundle required artifacts to fix failing analyze bundle workflow.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
