### PR TITLE
chore: expose the quote inputs from the widget

### DIFF
--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
@@ -4,7 +4,7 @@ import { useManager } from '@rango-dev/queue-manager-react';
 import React, { createContext, useContext } from 'react';
 
 import { useLanguage } from '../../hooks/useLanguage';
-import { useUpdateQuoteInput } from '../../hooks/useUpdateQuoteInput/useUpdateQuoteInput';
+import { useUpdateQuoteInputs } from '../../hooks/useUpdateQuoteInputs/useUpdateQuoteInputs';
 import { useAppStore } from '../../store/AppStore';
 import { useNotificationStore } from '../../store/notification';
 import { useQuoteStore } from '../../store/quote';
@@ -36,7 +36,9 @@ export function WidgetInfo(props: React.PropsWithChildren) {
   const resetLanguage = useLanguage().resetLanguage;
   const notifications = useNotificationStore().getNotifications();
   const clearNotifications = useNotificationStore().clearNotifications;
-  const updateQuoteInput = useUpdateQuoteInput();
+  const updateQuoteInputs = useUpdateQuoteInputs();
+  const { fromBlockchain, toBlockchain, fromToken, toToken, inputAmount } =
+    useQuoteStore();
 
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   const value: WidgetInfoContextInterface = {
@@ -62,7 +64,26 @@ export function WidgetInfo(props: React.PropsWithChildren) {
       clearAll: clearNotifications,
     },
     quote: {
-      updateQuoteInput,
+      quoteInputs: {
+        fromBlockchain: fromBlockchain?.name ?? null,
+        fromToken: fromToken
+          ? {
+              symbol: fromToken.symbol,
+              blockchain: fromToken.blockchain,
+              address: fromToken.address,
+            }
+          : null,
+        toBlockchain: toBlockchain?.name ?? null,
+        toToken: toToken
+          ? {
+              symbol: toToken.symbol,
+              blockchain: toToken.blockchain,
+              address: toToken.address,
+            }
+          : null,
+        requestAmount: inputAmount,
+      },
+      updateQuoteInputs,
     },
   };
 

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.types.ts
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.types.ts
@@ -1,7 +1,7 @@
 import type { WidgetHistory } from './WidgetInfo.helpers';
 import type { FetchStatus, FindToken } from '../../store/slices/data';
 import type { ConnectedWallet } from '../../store/wallets';
-import type { UpdateQuoteInput, Wallet } from '../../types';
+import type { QuoteInputs, UpdateQuoteInputs, Wallet } from '../../types';
 import type { Notification } from '../../types/notification';
 import type { BlockchainMeta, SwapperMeta, Token } from 'rango-sdk';
 
@@ -28,6 +28,7 @@ export interface WidgetInfoContextInterface {
     clearAll: () => void;
   };
   quote: {
-    updateQuoteInput: UpdateQuoteInput;
+    quoteInputs: QuoteInputs;
+    updateQuoteInputs: UpdateQuoteInputs;
   };
 }

--- a/widget/embedded/src/hooks/useUpdateQuoteInput/index.ts
+++ b/widget/embedded/src/hooks/useUpdateQuoteInput/index.ts
@@ -1,1 +1,0 @@
-export { useUpdateQuoteInput } from './useUpdateQuoteInput';

--- a/widget/embedded/src/hooks/useUpdateQuoteInputs/index.ts
+++ b/widget/embedded/src/hooks/useUpdateQuoteInputs/index.ts
@@ -1,0 +1,1 @@
+export { useUpdateQuoteInputs } from './useUpdateQuoteInputs';

--- a/widget/embedded/src/hooks/useUpdateQuoteInputs/useUpdateQuoteInputs.ts
+++ b/widget/embedded/src/hooks/useUpdateQuoteInputs/useUpdateQuoteInputs.ts
@@ -1,10 +1,10 @@
-import type { UpdateQuoteInput } from '../../types';
+import type { UpdateQuoteInputs } from '../../types';
 
 import { useAppStore } from '../../store/AppStore';
 import { useQuoteStore } from '../../store/quote';
 
 // This hook provides a function to update quote inputs using fewer and simpler parameters.
-export function useUpdateQuoteInput() {
+export function useUpdateQuoteInputs() {
   const { findToken } = useAppStore();
   const blockchains = useAppStore().blockchains();
   const tokens = useAppStore().tokens();
@@ -16,7 +16,7 @@ export function useUpdateQuoteInput() {
     setInputAmount,
   } = useQuoteStore();
 
-  const updateQuoteInput: UpdateQuoteInput = (params) => {
+  const updateQuoteInputs: UpdateQuoteInputs = (params) => {
     const { fromBlockchain, fromToken, toBlockchain, toToken, requestAmount } =
       params;
     const meta = { blockchains, tokens };
@@ -46,5 +46,5 @@ export function useUpdateQuoteInput() {
     }
   };
 
-  return updateQuoteInput;
+  return updateQuoteInputs;
 }

--- a/widget/embedded/src/types/quote.ts
+++ b/widget/embedded/src/types/quote.ts
@@ -133,10 +133,12 @@ export type QuoteErrorResponse = {
   options: QuoteError;
 };
 
-export type UpdateQuoteInput = (params: {
-  fromBlockchain?: string | null;
-  toBlockchain?: string | null;
-  fromToken?: Asset | null;
-  toToken?: Asset | null;
-  requestAmount?: string;
-}) => void;
+export type QuoteInputs = {
+  fromBlockchain: string | null;
+  toBlockchain: string | null;
+  fromToken: Asset | null;
+  toToken: Asset | null;
+  requestAmount: string;
+};
+
+export type UpdateQuoteInputs = (params: Partial<QuoteInputs>) => void;


### PR DESCRIPTION
# Summary

To get the latest state of the quote inputs from outside the widget, we expose these states using the `useWidget` hook.
https://github.com/rango-exchange/rango-client/pull/815

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
