### PR TITLE
fix: improve header component to center the title properly

### DIFF
--- a/widget/embedded/src/components/Layout/Layout.tsx
+++ b/widget/embedded/src/components/Layout/Layout.tsx
@@ -109,17 +109,15 @@ function Layout(props: PropsWithChildren<PropTypes>) {
       ref={containerRef}>
       <Header
         prefix={
-          <>
-            {showBackButton && (
-              <BackButton
-                onClick={() => {
-                  navigateBack();
-                  // As an example, used in routes page to add a custom logic when navigating back to the home page.
-                  header.onBack && header.onBack();
-                }}
-              />
-            )}
-          </>
+          showBackButton ? (
+            <BackButton
+              onClick={() => {
+                navigateBack();
+                // As an example, used in routes page to add a custom logic when navigating back to the home page.
+                header.onBack && header.onBack();
+              }}
+            />
+          ) : null
         }
         title={header.title}
         suffix={

--- a/widget/storybook/src/components/Header.stories.tsx
+++ b/widget/storybook/src/components/Header.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { Header } from './Header.js';
+import { Header } from '@rango-dev/ui';
 
 const meta: Meta<typeof Header> = {
   component: Header,

--- a/widget/ui/src/components/Header/Header.styles.ts
+++ b/widget/ui/src/components/Header/Header.styles.ts
@@ -14,7 +14,6 @@ export const globalHeaderStyles = globalCss({
 
 export const Container = styled('div', {
   display: 'flex',
-  justifyContent: 'space-between',
   alignItems: 'center',
   padding: '$20 $20 $15 $20',
   $$color: '$colors$neutral100',
@@ -23,6 +22,20 @@ export const Container = styled('div', {
   },
   backgroundColor: '$$color',
   position: 'relative',
+
+  variants: {
+    titlePosition: {
+      left: {
+        justifyContent: 'start',
+      },
+      center: {
+        justifyContent: 'center',
+      },
+      right: {
+        justifyContent: 'end',
+      },
+    },
+  },
 
   '.rng-curve-left,.rng-curve-right': {
     width: HEADER_CORNDER_RADIUS * 2,
@@ -59,7 +72,17 @@ export const Container = styled('div', {
   },
 });
 
+export const Prefix = styled('div', {
+  position: 'absolute',
+  left: '$20',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '$5',
+});
+
 export const Suffix = styled('div', {
+  position: 'absolute',
+  right: '$20',
   display: 'flex',
   alignItems: 'center',
   gap: '$5',

--- a/widget/ui/src/components/Header/Header.tsx
+++ b/widget/ui/src/components/Header/Header.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import { Typography } from '../Typography/index.js';
 
-import { Container, globalHeaderStyles, Suffix } from './Header.styles.js';
+import { Container, globalHeaderStyles, Prefix, Suffix } from './Header.styles';
 
 export function Header({
   prefix,
@@ -14,12 +14,33 @@ export function Header({
 }: PropsWithChildren<PropTypes>) {
   globalHeaderStyles();
 
+  const getTitlePosition = () => {
+    if (!prefix) {
+      return 'left';
+    }
+    if (!suffix) {
+      return 'right';
+    }
+    return 'center';
+  };
+
+  const renderTitle = () => {
+    if (!title) {
+      return null;
+    } else if (typeof title === 'string') {
+      return (
+        <Typography variant="headline" size="small">
+          {title}
+        </Typography>
+      );
+    }
+    return title;
+  };
+
   return (
-    <Container>
-      {prefix}
-      <Typography variant="headline" size="small">
-        {title}
-      </Typography>
+    <Container titlePosition={getTitlePosition()}>
+      <Prefix>{prefix}</Prefix>
+      {renderTitle()}
       <Suffix>{suffix}</Suffix>
       <div className="rng-curve-left"></div>
       <div className="rng-curve-right"></div>

--- a/widget/ui/src/components/Header/Header.types.ts
+++ b/widget/ui/src/components/Header/Header.types.ts
@@ -1,5 +1,5 @@
 export interface PropTypes {
   prefix?: React.ReactNode;
   suffix?: React.ReactNode;
-  title: string;
+  title?: string | React.ReactNode;
 }


### PR DESCRIPTION
# Summary

Improved header component to center the title properly. In the result of these changes, the title in the header component is positioned correctly in the center of header and the position of title will not change in result of changing the width of prefix and postfix of header.

Fixes # 1674


# How did you test this change?

If you compare header of the pages in this branch with production, you will see that title is centered regardless of width of prefix and postfix. You can test this by checking each header of each page to see everything is positioned properly.


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
