### PR TITLE
fix: fix wallet modal closing bug

### DIFF
--- a/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
@@ -327,6 +327,7 @@ export function ConfirmWalletsModal(props: PropTypes) {
       dismissible={!showMoreWalletFor}
       container={modalContainer}
       {...(!showMoreWalletFor && {
+        styles: { container: { height: '100%' } },
         footer: (
           <ConfirmButton>
             <Button
@@ -350,7 +351,7 @@ export function ConfirmWalletsModal(props: PropTypes) {
         ),
       })}
       {...(showMoreWalletFor && {
-        styles: { container: { padding: '$0' } },
+        styles: { container: { height: '100%', padding: '$0' } },
         header: (
           <ShowMoreHeader>
             <NavigateBack

--- a/widget/embedded/src/pages/WalletsPage.tsx
+++ b/widget/embedded/src/pages/WalletsPage.tsx
@@ -80,12 +80,14 @@ export function WalletsPage() {
           setSelectedWalletType(type);
         }, TIME_TO_IGNORE_MODAL);
       },
-      onConnect: () => {
+      onConnect: (type) => {
         if (modalTimerId) {
           clearTimeout(modalTimerId);
         }
         setTimeout(() => {
-          setOpenModal(false);
+          if (selectedWalletType === type) {
+            setOpenModal(false);
+          }
         }, TIME_TO_CLOSE_MODAL);
       },
     });


### PR DESCRIPTION
# Summary

Fix bug related to closing wallet modal when it is being opened after another wallet is connected.

# How did you test this change?

Connected a wallet and then immediately connected another wallet.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
