### PR TITLE
fix: fix the issue with the wallets state after retrying to fetch the balance following a failed attempt.

### DIFF
--- a/widget/embedded/src/store/wallets.ts
+++ b/widget/embedded/src/store/wallets.ts
@@ -220,13 +220,13 @@ export const useWalletsStore = createSelectors(
                             findToken
                           ),
                           loading: false,
+                          error: false,
                         }
                       : connectedWallet;
                   }
                 );
 
                 const balances = makeTokensBalance(connectedWallets);
-
                 return {
                   loading: false,
                   balances,


### PR DESCRIPTION
# Summary

When getWalletsDetails fails,

The error field for connected wallets is changed to `true`.

But the problem here is that it remains `true`.

And it will not be updated in the next successful request.

Now I solved this problem in such a way that when the request succeeds, it returns the error field to `false`.


Fixes # (issue)


# How did you test this change?

For testing, you can link the `@rango-dev/widget-embedded` and use it in the `app` project and try again in the Wallet Details section after an error, and see the result.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
