### PR TITLE
chore: restructure shared and react to use /core package

### DIFF
--- a/examples/queue-manager-demo/src/flows/rango/helpers.ts
+++ b/examples/queue-manager-demo/src/flows/rango/helpers.ts
@@ -32,7 +32,7 @@ import type {
 } from 'rango-types';
 
 import { SUPPORTED_ETH_CHAINS as XDEFI_WALLET_SUPPORTED_EVM_CHAINS } from '@rango-dev/provider-xdefi';
-import { readAccountAddress } from '@rango-dev/wallets-react';
+import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core';
 import {
   Networks,
   WalletTypes,

--- a/examples/wallets-demo/src/components/List/Item.tsx
+++ b/examples/wallets-demo/src/components/List/Item.tsx
@@ -14,7 +14,8 @@ import {
   Tooltip,
   Typography,
 } from '@rango-dev/ui';
-import { readAccountAddress, useWallets } from '@rango-dev/wallets-react';
+import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core';
+import { useWallets } from '@rango-dev/wallets-react';
 import { detectInstallLink, Networks } from '@rango-dev/wallets-shared';
 import React, { useState } from 'react';
 import './styles.css';

--- a/examples/wallets-demo/src/helper.ts
+++ b/examples/wallets-demo/src/helper.ts
@@ -1,7 +1,7 @@
 import type { Network } from '@rango-dev/wallets-shared';
 import type { BlockchainMeta } from 'rango-sdk';
 
-import { readAccountAddress } from '@rango-dev/wallets-react';
+import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core';
 import { Networks } from '@rango-dev/wallets-shared';
 import { isEvmBlockchain } from 'rango-sdk';
 

--- a/queue-manager/rango-preset/src/helpers.ts
+++ b/queue-manager/rango-preset/src/helpers.ts
@@ -38,7 +38,7 @@ import type {
 
 import { warn } from '@rango-dev/logging-core';
 import { Status } from '@rango-dev/queue-manager-core';
-import { readAccountAddress } from '@rango-dev/wallets-core';
+import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core/legacy';
 import {
   getBlockChainNameFromId,
   getEvmProvider,

--- a/queue-manager/rango-preset/src/types.ts
+++ b/queue-manager/rango-preset/src/types.ts
@@ -4,7 +4,7 @@ import type {
   QueueDef,
   QueueStorage,
 } from '@rango-dev/queue-manager-core';
-import type { ConnectResult } from '@rango-dev/wallets-core';
+import type { LegacyConnectResult as ConnectResult } from '@rango-dev/wallets-core/legacy';
 import type {
   Meta,
   Network,

--- a/wallets/core/legacy/package.json
+++ b/wallets/core/legacy/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rango-dev/wallets-core/legacy",
+  "type": "module",
+  "main": "../dist/legacy/mod.js",
+  "module": "../dist/legacy/mod.js",
+  "types": "../dist/legacy/mod.d.ts",
+  "sideEffects": false
+}

--- a/wallets/core/package.json
+++ b/wallets/core/package.json
@@ -3,13 +3,17 @@
   "version": "0.37.0",
   "license": "MIT",
   "type": "module",
-  "source": "./src/legacy/index.ts",
-  "main": "./dist/index.js",
-  "typings": "./dist/legacy/index.d.ts",
+  "source": "./src/mod.ts",
+  "main": "./dist/mod.js",
+  "typings": "./dist/mod.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/legacy/index.d.ts",
-      "default": "./dist/index.js"
+      "types": "./dist/mod.d.ts",
+      "default": "./dist/mod.js"
+    },
+    "./legacy": {
+      "types": "./dist/legacy/mod.d.ts",
+      "default": "./dist/legacy/mod.js"
     }
   },
   "files": [
@@ -17,7 +21,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/core --inputs src/legacy/index.ts",
+    "build": "node ../../scripts/build/command.mjs --path wallets/core --inputs src/mod.ts,src/legacy/mod.ts",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",
@@ -29,7 +33,6 @@
     "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@rango-dev/wallets-shared": "^0.36.0",
     "rango-types": "^0.1.69"
   },
   "publishConfig": {

--- a/wallets/core/src/legacy/helpers.ts
+++ b/wallets/core/src/legacy/helpers.ts
@@ -1,5 +1,8 @@
+import type { Network } from './types.js';
 import type { Options } from './wallet.js';
-import type { Network } from '@rango-dev/wallets-shared';
+import type { BlockchainMeta } from 'rango-types';
+
+import { Networks } from './types.js';
 
 export function formatAddressWithNetwork(
   address: string,
@@ -37,3 +40,36 @@ export function needsCheckInstallation(options: Options) {
   const { checkInstallation = true } = options.config;
   return checkInstallation;
 }
+
+export const getBlockChainNameFromId = (
+  chainId: string | number,
+  blockchains: BlockchainMeta[]
+): Network | null => {
+  chainId =
+    typeof chainId === 'string' && chainId.startsWith('0x')
+      ? parseInt(chainId)
+      : chainId;
+
+  /*
+   * Sometimes providers are passing `Network` as chainId.
+   * If chainId is a `Network`, we return itself.
+   */
+  const allNetworks = Object.values(Networks);
+  if (allNetworks.includes(String(chainId) as Networks)) {
+    return chainId as Networks;
+  }
+
+  if (chainId === 'Binance-Chain-Tigris') {
+    return Networks.BINANCE;
+  }
+  return (
+    blockchains
+      .filter((blockchainMeta) => !!blockchainMeta.chainId)
+      .find((blockchainMeta) => {
+        const blockchainChainId = blockchainMeta.chainId?.startsWith('0x')
+          ? parseInt(blockchainMeta.chainId)
+          : blockchainMeta.chainId;
+        return blockchainChainId == chainId;
+      })?.name || null
+  );
+};

--- a/wallets/core/src/legacy/index.ts
+++ b/wallets/core/src/legacy/index.ts
@@ -1,6 +1,0 @@
-export type { EventHandler, State, Options } from './wallet.js';
-export * from './types.js';
-
-export { Persistor } from './persistor.js';
-export * from './helpers.js';
-export { default } from './wallet.js';

--- a/wallets/core/src/legacy/mod.ts
+++ b/wallets/core/src/legacy/mod.ts
@@ -1,0 +1,39 @@
+/*
+ * All the exported types/values from legacy should be prefixed with `Legacy`
+ * since they will be removed soon and isn't part of the main interface for this package.
+ */
+export type {
+  EventHandler as LegacyEventHandler,
+  State as LegacyState,
+  Options as LegacyOptions,
+} from './wallet.js';
+
+export type {
+  Connect as LegacyConnect,
+  Disconnect as LegacyDisconnect,
+  Subscribe as LegacySubscribe,
+  CanEagerConnect as LegacyCanEagerConnect,
+  SwitchNetwork as LegacySwitchNetwork,
+  Suggest as LegacySuggest,
+  CanSwitchNetwork as LegacyCanSwitchNetwork,
+  NamespaceData as LegacyNamespaceData,
+  ProviderInterface as LegacyProviderInterface,
+  Network as LegacyNetwork,
+  WalletType as LegacyWalletType,
+  InstallObjects as LegacyInstallObjects,
+  WalletInfo as LegacyWalletInfo,
+  ConnectResult as LegacyConnectResult,
+} from './types.js';
+
+export {
+  Events as LegacyEvents,
+  Namespace as LegacyNamespace,
+  Networks as LegacyNetworks,
+} from './types.js';
+
+export { Persistor } from './persistor.js';
+export {
+  readAccountAddress as legacyReadAccountAddress,
+  getBlockChainNameFromId as legacyGetBlockChainNameFromId,
+} from './helpers.js';
+export { default as LegacyWallet } from './wallet.js';

--- a/wallets/core/src/legacy/types.ts
+++ b/wallets/core/src/legacy/types.ts
@@ -1,11 +1,107 @@
 import type { State as WalletState } from './wallet.js';
-import type {
-  NamespaceData,
-  Network,
-  WalletInfo,
-  WalletType,
-} from '@rango-dev/wallets-shared';
 import type { BlockchainMeta, SignerFactory } from 'rango-types';
+
+export enum Networks {
+  BTC = 'BTC',
+  BSC = 'BSC',
+  LTC = 'LTC',
+  THORCHAIN = 'THOR',
+  BCH = 'BCH',
+  BINANCE = 'BNB',
+  ETHEREUM = 'ETH',
+  POLYGON = 'POLYGON',
+  TERRA = 'TERRA',
+  POLKADOT = '',
+  TRON = 'TRON',
+  DOGE = 'DOGE',
+  HARMONY = 'HARMONY',
+  AVAX_CCHAIN = 'AVAX_CCHAIN',
+  FANTOM = 'FANTOM',
+  MOONBEAM = 'MOONBEAM',
+  ARBITRUM = 'ARBITRUM',
+  BOBA = 'BOBA',
+  OPTIMISM = 'OPTIMISM',
+  FUSE = 'FUSE',
+  CRONOS = 'CRONOS',
+  SOLANA = 'SOLANA',
+  MOONRIVER = 'MOONRIVER',
+  GNOSIS = 'GNOSIS',
+  COSMOS = 'COSMOS',
+  OSMOSIS = 'OSMOSIS',
+  AXELAR = 'AXELAR',
+  MARS = 'MARS',
+  STRIDE = 'STRIDE',
+  MAYA = 'MAYA',
+  AKASH = 'AKASH',
+  IRIS = 'IRIS',
+  PERSISTENCE = 'PERSISTENCE',
+  SENTINEL = 'SENTINEL',
+  REGEN = 'REGEN',
+  CRYPTO_ORG = 'CRYPTO_ORG',
+  SIF = 'SIF',
+  CHIHUAHUA = 'CHIHUAHUA',
+  JUNO = 'JUNO',
+  KUJIRA = 'KUJIRA',
+  STARNAME = 'STARNAME',
+  COMDEX = 'COMDEX',
+  STARGAZE = 'STARGAZE',
+  DESMOS = 'DESMOS',
+  BITCANNA = 'BITCANNA',
+  SECRET = 'SECRET',
+  INJECTIVE = 'INJECTIVE',
+  LUMNETWORK = 'LUMNETWORK',
+  BANDCHAIN = 'BANDCHAIN',
+  EMONEY = 'EMONEY',
+  BITSONG = 'BITSONG',
+  KI = 'KI',
+  MEDIBLOC = 'MEDIBLOC',
+  KONSTELLATION = 'KONSTELLATION',
+  UMEE = 'UMEE',
+  STARKNET = 'STARKNET',
+  TON = 'TON',
+
+  // Using instead of null
+  Unknown = 'Unkown',
+}
+
+export enum Namespace {
+  Solana = 'Solana',
+  Evm = 'EVM',
+  Cosmos = 'Cosmos',
+  Utxo = 'UTXO',
+  Starknet = 'Starknet',
+  Tron = 'Tron',
+}
+
+export type NamespaceData = {
+  namespace: Namespace;
+  derivationPath?: string;
+};
+
+export type WalletType = string;
+export type Network = string;
+
+export type InstallObjects = {
+  CHROME?: string;
+  FIREFOX?: string;
+  EDGE?: string;
+  BRAVE?: string;
+  DEFAULT: string;
+};
+
+export type WalletInfo = {
+  name: string;
+  img: string;
+  installLink: InstallObjects | string;
+  color: string;
+  supportedChains: BlockchainMeta[];
+  showOnMobile?: boolean;
+  isContractWallet?: boolean;
+  mobileWallet?: boolean;
+  namespaces?: Namespace[];
+  singleNamespace?: boolean;
+  needsDerivationPath?: boolean;
+};
 
 export type State = {
   [key: string]: WalletState | undefined;

--- a/wallets/core/src/legacy/wallet.ts
+++ b/wallets/core/src/legacy/wallet.ts
@@ -1,22 +1,19 @@
 import type {
   GetInstanceOptions,
-  WalletActions,
-  WalletConfig,
-} from './types.js';
-import type {
   NamespaceData,
   Network,
+  WalletActions,
+  WalletConfig,
   WalletType,
-} from '@rango-dev/wallets-shared';
+} from './types.js';
 import type { BlockchainMeta } from 'rango-types';
-
-import { getBlockChainNameFromId, Networks } from '@rango-dev/wallets-shared';
 
 import {
   accountAddressesWithNetwork,
+  getBlockChainNameFromId,
   needsCheckInstallation,
 } from './helpers.js';
-import { Events } from './types.js';
+import { Events, Networks } from './types.js';
 
 export type EventHandler = (
   type: WalletType,

--- a/wallets/core/src/mod.ts
+++ b/wallets/core/src/mod.ts
@@ -1,0 +1,1 @@
+// This file will be updated to export Hub methods and types.

--- a/wallets/react/src/index.ts
+++ b/wallets/react/src/index.ts
@@ -2,6 +2,3 @@ export * from './legacy/helpers.js';
 export { default as Provider } from './provider.js';
 export { useWallets } from './legacy/hooks.js';
 export * from './legacy/types.js';
-
-export type { EventHandler } from '@rango-dev/wallets-core';
-export { Events, readAccountAddress } from '@rango-dev/wallets-core';

--- a/wallets/react/src/legacy/helpers.ts
+++ b/wallets/react/src/legacy/helpers.ts
@@ -4,15 +4,15 @@ import type {
   WalletActions,
   WalletProviders,
 } from './types.js';
-import type Wallet from '@rango-dev/wallets-core';
 import type {
-  Options,
-  EventHandler as WalletEventHandler,
-  State as WalletState,
-} from '@rango-dev/wallets-core';
+  LegacyOptions as Options,
+  LegacyWallet as Wallet,
+  LegacyEventHandler as WalletEventHandler,
+  LegacyState as WalletState,
+} from '@rango-dev/wallets-core/legacy';
 import type { WalletConfig, WalletType } from '@rango-dev/wallets-shared';
 
-import { Persistor } from '@rango-dev/wallets-core';
+import { Persistor } from '@rango-dev/wallets-core/legacy';
 
 import { LAST_CONNECTED_WALLETS } from './constants.js';
 

--- a/wallets/react/src/legacy/hooks.ts
+++ b/wallets/react/src/legacy/hooks.ts
@@ -1,7 +1,7 @@
 import type { ProviderContext, WalletActions, WalletConfig } from './types.js';
-import type { EventHandler as WalletEventHandler } from '@rango-dev/wallets-core';
+import type { LegacyEventHandler as WalletEventHandler } from '@rango-dev/wallets-core/legacy';
 
-import Wallet from '@rango-dev/wallets-core';
+import { LegacyWallet as Wallet } from '@rango-dev/wallets-core/legacy';
 import { useContext, useRef } from 'react';
 
 import { WalletContext } from './context.js';

--- a/wallets/react/src/legacy/types.ts
+++ b/wallets/react/src/legacy/types.ts
@@ -1,13 +1,11 @@
 import type {
-  EventHandler as WalletEventHandler,
-  State as WalletState,
-} from '@rango-dev/wallets-core';
-import type {
-  NamespaceData,
-  Network,
-  WalletInfo,
-  WalletType,
-} from '@rango-dev/wallets-shared';
+  LegacyNamespaceData as NamespaceData,
+  LegacyNetwork as Network,
+  LegacyEventHandler as WalletEventHandler,
+  LegacyWalletInfo as WalletInfo,
+  LegacyState as WalletState,
+  LegacyWalletType as WalletType,
+} from '@rango-dev/wallets-core/legacy';
 import type { BlockchainMeta, SignerFactory } from 'rango-types';
 import type { PropsWithChildren } from 'react';
 

--- a/wallets/shared/package.json
+++ b/wallets/shared/package.json
@@ -27,6 +27,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@rango-dev/wallets-core": "0.37.0",
     "ethers": "^5.7.2",
     "rango-types": "^0.1.69"
   },

--- a/wallets/shared/src/rango.ts
+++ b/wallets/shared/src/rango.ts
@@ -1,52 +1,42 @@
+import type {
+  LegacyNetwork as Network,
+  LegacyWalletInfo as WalletInfo,
+  LegacyWalletType as WalletType,
+} from '@rango-dev/wallets-core/legacy';
 import type { BlockchainMeta, EvmBlockchainMeta } from 'rango-types';
+
+import {
+  LegacyNamespace as Namespace,
+  LegacyNetworks as Networks,
+} from '@rango-dev/wallets-core/legacy';
+
+export type {
+  LegacyNetwork as Network,
+  LegacyConnect as Connect,
+  LegacyDisconnect as Disconnect,
+  LegacySubscribe as Subscribe,
+  LegacyCanEagerConnect as CanEagerConnect,
+  LegacySwitchNetwork as SwitchNetwork,
+  LegacySuggest as Suggest,
+  LegacyCanSwitchNetwork as CanSwitchNetwork,
+  LegacyInstallObjects as InstallObjects,
+  LegacyWalletInfo as WalletInfo,
+  LegacyWalletType as WalletType,
+  LegacyNamespaceData as NamespaceData,
+} from '@rango-dev/wallets-core/legacy';
+
+export {
+  LegacyNetworks as Networks,
+  LegacyNamespace as Namespace,
+  legacyGetBlockChainNameFromId as getBlockChainNameFromId,
+} from '@rango-dev/wallets-core/legacy';
 
 export const IS_DEV =
   !process.env.NODE_ENV || process.env.NODE_ENV === 'development';
 
-export const getBlockChainNameFromId = (
-  chainId: string | number,
-  blockchains: BlockchainMeta[]
-): Network | null => {
-  chainId =
-    typeof chainId === 'string' && chainId.startsWith('0x')
-      ? parseInt(chainId)
-      : chainId;
-
-  /*
-   * Sometimes providers are passing `Network` as chainId.
-   * If chainId is a `Network`, we return itself.
-   */
-  const allNetworks = Object.values(Networks) as string[];
-  if (allNetworks.includes(String(chainId))) {
-    return chainId as Networks;
-  }
-
-  if (chainId === 'Binance-Chain-Tigris') {
-    return Networks.BINANCE;
-  }
-  return (
-    blockchains
-      .filter((blockchainMeta) => !!blockchainMeta.chainId)
-      .find((blockchainMeta) => {
-        const blockchainChainId = blockchainMeta.chainId?.startsWith('0x')
-          ? parseInt(blockchainMeta.chainId)
-          : blockchainMeta.chainId;
-        return blockchainChainId == chainId;
-      })?.name || null
-  );
-};
-
-export const getBlockchainChainIdByName = (
-  netwok: Network,
-  allBlockChains: AllBlockchains
-) => allBlockChains[netwok]?.chainId || null;
-
 export const uint8ArrayToHex = (buffer: Uint8Array): string => {
   return Buffer.from(buffer).toString('hex');
 };
-
-export type WalletType = string;
-export type Network = string;
 
 export enum WalletTypes {
   DEFAULT = 'default',
@@ -86,83 +76,6 @@ export enum WalletTypes {
   TREZOR = 'trezor',
   SOLFLARE = 'solflare',
 }
-
-export enum Networks {
-  BTC = 'BTC',
-  BSC = 'BSC',
-  LTC = 'LTC',
-  THORCHAIN = 'THOR',
-  BCH = 'BCH',
-  BINANCE = 'BNB',
-  ETHEREUM = 'ETH',
-  POLYGON = 'POLYGON',
-  TERRA = 'TERRA',
-  POLKADOT = '',
-  TRON = 'TRON',
-  DOGE = 'DOGE',
-  HARMONY = 'HARMONY',
-  AVAX_CCHAIN = 'AVAX_CCHAIN',
-  FANTOM = 'FANTOM',
-  MOONBEAM = 'MOONBEAM',
-  ARBITRUM = 'ARBITRUM',
-  BOBA = 'BOBA',
-  OPTIMISM = 'OPTIMISM',
-  FUSE = 'FUSE',
-  CRONOS = 'CRONOS',
-  SOLANA = 'SOLANA',
-  MOONRIVER = 'MOONRIVER',
-  GNOSIS = 'GNOSIS',
-  COSMOS = 'COSMOS',
-  OSMOSIS = 'OSMOSIS',
-  AXELAR = 'AXELAR',
-  MARS = 'MARS',
-  STRIDE = 'STRIDE',
-  MAYA = 'MAYA',
-  AKASH = 'AKASH',
-  IRIS = 'IRIS',
-  PERSISTENCE = 'PERSISTENCE',
-  SENTINEL = 'SENTINEL',
-  REGEN = 'REGEN',
-  CRYPTO_ORG = 'CRYPTO_ORG',
-  SIF = 'SIF',
-  CHIHUAHUA = 'CHIHUAHUA',
-  JUNO = 'JUNO',
-  KUJIRA = 'KUJIRA',
-  STARNAME = 'STARNAME',
-  COMDEX = 'COMDEX',
-  STARGAZE = 'STARGAZE',
-  DESMOS = 'DESMOS',
-  BITCANNA = 'BITCANNA',
-  SECRET = 'SECRET',
-  INJECTIVE = 'INJECTIVE',
-  LUMNETWORK = 'LUMNETWORK',
-  BANDCHAIN = 'BANDCHAIN',
-  EMONEY = 'EMONEY',
-  BITSONG = 'BITSONG',
-  KI = 'KI',
-  MEDIBLOC = 'MEDIBLOC',
-  KONSTELLATION = 'KONSTELLATION',
-  UMEE = 'UMEE',
-  STARKNET = 'STARKNET',
-  TON = 'TON',
-
-  // Using instead of null
-  Unknown = 'Unkown',
-}
-
-export enum Namespace {
-  Solana = 'Solana',
-  Evm = 'EVM',
-  Cosmos = 'Cosmos',
-  Utxo = 'UTXO',
-  Starknet = 'Starknet',
-  Tron = 'Tron',
-}
-
-export type NamespaceData = {
-  namespace: Namespace;
-  derivationPath?: string;
-};
 
 export const namespaces: Record<
   Namespace,
@@ -320,78 +233,6 @@ export type GetInstance =
 export type ProviderConnectResult = {
   accounts: string[];
   chainId: string;
-};
-
-export type Connect = (options: {
-  instance: any;
-  network?: Network;
-  meta: BlockchainMeta[];
-  namespaces?: NamespaceData[];
-}) => Promise<ProviderConnectResult | ProviderConnectResult[]>;
-
-export type Disconnect = (options: {
-  instance: any;
-  destroyInstance: () => void;
-}) => Promise<void>;
-
-type CleanupSubscribe = () => void;
-
-export type Subscribe = (options: {
-  instance: any;
-  state: WalletState;
-  meta: BlockchainMeta[];
-  updateChainId: (chainId: string) => void;
-  updateAccounts: (accounts: string[], chainId?: string) => void;
-  connect: (network?: Network) => void;
-  disconnect: () => void;
-}) => CleanupSubscribe | void;
-
-export type CanEagerConnect = (options: {
-  instance: any;
-  meta: BlockchainMeta[];
-}) => Promise<boolean>;
-
-export type SwitchNetwork = (options: {
-  instance: any;
-  network: Network;
-  meta: BlockchainMeta[];
-  newInstance?: TryGetInstance;
-  getState?: () => WalletState;
-  updateChainId: (chainId: string) => void;
-}) => Promise<void>;
-
-export type Suggest = (options: {
-  instance: any;
-  network: Network;
-  meta: BlockchainMeta[];
-}) => Promise<void>;
-
-export type CanSwitchNetwork = (options: {
-  network: Network;
-  meta: BlockchainMeta[];
-  provider: any;
-}) => boolean;
-
-export type InstallObjects = {
-  CHROME?: string;
-  FIREFOX?: string;
-  EDGE?: string;
-  BRAVE?: string;
-  DEFAULT: string;
-};
-
-export type WalletInfo = {
-  name: string;
-  img: string;
-  installLink: InstallObjects | string;
-  color: string;
-  supportedChains: BlockchainMeta[];
-  showOnMobile?: boolean;
-  isContractWallet?: boolean;
-  mobileWallet?: boolean;
-  namespaces?: Namespace[];
-  singleNamespace?: boolean;
-  needsDerivationPath?: boolean;
 };
 
 export interface Wallet {

--- a/widget/embedded/package.json
+++ b/widget/embedded/package.json
@@ -32,6 +32,7 @@
     "@rango-dev/signer-solana": "^0.31.1-next.0",
     "@rango-dev/ui": "^0.37.1-next.1",
     "@rango-dev/wallets-react": "^0.22.0",
+    "@rango-dev/wallets-core": "^0.37.0",
     "@rango-dev/wallets-shared": "^0.36.0",
     "bignumber.js": "^9.1.1",
     "copy-to-clipboard": "^3.3.3",

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -4,7 +4,7 @@ import type {
   WidgetContextInterface,
 } from './Wallets.types';
 import type { ProvidersOptions } from '../../utils/providers';
-import type { EventHandler } from '@rango-dev/wallets-react';
+import type { LegacyEventHandler as EventHandler } from '@rango-dev/wallets-core/legacy';
 import type { PropsWithChildren } from 'react';
 
 import { Events, Provider } from '@rango-dev/wallets-react';

--- a/widget/embedded/src/containers/Wallets/Wallets.types.ts
+++ b/widget/embedded/src/containers/Wallets/Wallets.types.ts
@@ -1,5 +1,5 @@
 import type { WidgetConfig } from '../../types';
-import type { EventHandler } from '@rango-dev/wallets-react';
+import type { LegacyEventHandler as EventHandler } from '@rango-dev/wallets-core/legacy';
 
 export type OnWalletConnectionChange = (key: string) => void;
 export interface WidgetContextInterface {

--- a/widget/embedded/src/containers/WidgetProvider/WidgetProvider.types.ts
+++ b/widget/embedded/src/containers/WidgetProvider/WidgetProvider.types.ts
@@ -1,5 +1,5 @@
 import type { WidgetConfig } from '../../types';
-import type { EventHandler } from '@rango-dev/wallets-react';
+import type { LegacyEventHandler as EventHandler } from '@rango-dev/wallets-core/legacy';
 
 export type PropTypes = {
   onUpdateState?: EventHandler;

--- a/widget/embedded/src/index.ts
+++ b/widget/embedded/src/index.ts
@@ -35,9 +35,9 @@ import type {
   StepTxExecutionUpdatedEvent,
 } from '@rango-dev/queue-manager-rango-preset';
 import type {
-  EventHandler as HandleWalletsUpdate,
-  ProviderInterface,
-} from '@rango-dev/wallets-react';
+  LegacyEventHandler as HandleWalletsUpdate,
+  LegacyProviderInterface as ProviderInterface,
+} from '@rango-dev/wallets-core/legacy';
 import type {
   WalletInfo,
   WalletState,
@@ -52,11 +52,8 @@ import {
   StepExecutionBlockedEventStatus,
   StepExecutionEventStatus,
 } from '@rango-dev/queue-manager-rango-preset';
-import {
-  readAccountAddress,
-  useWallets,
-  Events as WalletEvents,
-} from '@rango-dev/wallets-react';
+import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core/legacy';
+import { useWallets, Events as WalletEvents } from '@rango-dev/wallets-react';
 import { Networks, WalletTypes } from '@rango-dev/wallets-shared';
 import { PendingSwapNetworkStatus } from 'rango-types';
 

--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -26,7 +26,7 @@ import {
   BlockchainCategories,
   WalletState as WalletStatus,
 } from '@rango-dev/ui';
-import { readAccountAddress } from '@rango-dev/wallets-react';
+import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core/legacy';
 import {
   detectInstallLink,
   getCosmosExperimentalChainInfo,

--- a/widget/embedded/tsconfig.build.json
+++ b/widget/embedded/tsconfig.build.json
@@ -8,7 +8,6 @@
     "./global-env.d.ts"
   ],
   "compilerOptions": {
-    "module": "esnext",
     "outDir": "dist",
     "downlevelIteration": true,
     "lib": ["dom", "esnext"],

--- a/widget/ui/package.json
+++ b/widget/ui/package.json
@@ -5,8 +5,11 @@
   "type": "module",
   "source": "./src/index.ts",
   "main": "./dist/index.js",
-  "exports": "./dist/index.js",
-  "typings": "dist/widget/ui/src/index.d.ts",
+  "exports": {
+    "types": "./dist/widget/ui/src/index.d.ts",
+    "default": "./dist/index.js"
+  },
+  "typings": "./dist/widget/ui/src/index.d.ts",
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
# Summary

Update all imports from `core` to import from `core/legacy` and move some functionality from `/shared` to `/core`.

In long term we will remove `wallets-shared`, a part of this PR is moving `core`-related functionality to `wallets-ocre`. And also this PR prefixed all the legacy core with `legacyThenSomething` to make sure we are flagging them and give a notice they are deprecated and will be removed in next major version.

### Aliasing 

In those packages who imported types or functions from legacy code, you will see I'm aliasing the `legacySomething` to `legacySomething as something`, this is because I wanted to update only imports and not the usages. I believe this is more appropriate way to reduce the changes.

### `core/legacy/package.json`

module system other than `node16` and `bundler` doesn't have support for `package.json`'s `exports` field. For backward-compatibility reasons we needed a workaround. I checked some repositories and all of them used the way thar I used in this PR. [here is an example](https://github.com/apollographql/apollo-server/blob/main/packages/server/errors/package.json).


# How did you test this change?

It shouldn't have any side effect on user side. it can affect our building process. so make sure the project will be build correctly. 


# Related PRs

- https://github.com/rango-exchange/rango-client/pull/623

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
