### PR TITLE
fix: update `signMessage` in the default Solana signer to return a base58 string instead of base64

### DIFF
--- a/signers/signer-solana/package.json
+++ b/signers/signer-solana/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@solana/web3.js": "^1.91.4",
+    "bs58": "^5.0.0",
     "promise-retry": "^2.0.1",
     "rango-types": "^0.1.69"
   },

--- a/signers/signer-solana/src/signer.ts
+++ b/signers/signer-solana/src/signer.ts
@@ -1,6 +1,7 @@
 import type { SolanaExternalProvider } from './utils/types.js';
 import type { GenericSigner, SolanaTransaction } from 'rango-types';
 
+import base58 from 'bs58';
 import { SignerError, SignerErrorCode } from 'rango-types';
 
 import { executeSolanaTransaction } from './utils/main.js';
@@ -21,7 +22,7 @@ export class DefaultSolanaSigner implements GenericSigner<SolanaTransaction> {
           message: encodedMessage,
         },
       });
-      return Buffer.from(signature).toString('base64');
+      return base58.encode(signature);
     } catch (error) {
       throw new SignerError(SignerErrorCode.SIGN_TX_ERROR, undefined, error);
     }

--- a/wallets/provider-solflare-snap/package.json
+++ b/wallets/provider-solflare-snap/package.json
@@ -25,6 +25,7 @@
     "@rango-dev/signer-solana": "^0.31.1-next.0",
     "@rango-dev/wallets-shared": "^0.36.1-next.0",
     "@solflare-wallet/metamask-sdk": "^1.0.3",
+    "bs58": "^5.0.0",
     "rango-types": "^0.1.69"
   },
   "publishConfig": {

--- a/wallets/provider-solflare-snap/src/signers/solanaSigner.ts
+++ b/wallets/provider-solflare-snap/src/signers/solanaSigner.ts
@@ -6,6 +6,7 @@ import {
   prepareTransaction,
   simulateTransaction,
 } from '@rango-dev/signer-solana';
+import base58 from 'bs58';
 import { SignerError, SignerErrorCode } from 'rango-types';
 
 const REJECTION_CODE = 4001;
@@ -23,7 +24,7 @@ export class SolflareSnapSolanaSigner
     try {
       const encodedMessage = new TextEncoder().encode(msg);
       const signature = await this.provider.signMessage(encodedMessage);
-      return Buffer.from(signature).toString('base64');
+      return base58.encode(signature);
     } catch (error) {
       throw new SignerError(SignerErrorCode.SIGN_TX_ERROR, undefined, error);
     }

--- a/wallets/provider-solflare/package.json
+++ b/wallets/provider-solflare/package.json
@@ -24,6 +24,7 @@
     "@rango-dev/signer-solana": "^0.31.1-next.0",
     "@rango-dev/wallets-shared": "^0.36.1-next.0",
     "@solflare-wallet/sdk": "^1.4.2",
+    "bs58": "^5.0.0",
     "rango-types": "^0.1.69"
   },
   "publishConfig": {

--- a/wallets/provider-solflare/src/signers/solanaSigner.ts
+++ b/wallets/provider-solflare/src/signers/solanaSigner.ts
@@ -2,6 +2,7 @@ import type Solflare from '@solflare-wallet/sdk';
 import type { GenericSigner, SolanaTransaction } from 'rango-types';
 
 import { executeSolanaTransaction } from '@rango-dev/signer-solana';
+import base58 from 'bs58';
 
 export class CustomSolanaSigner implements GenericSigner<SolanaTransaction> {
   private provider: any; // Used any instead of Solflare because there is an issue in type of `signTransaction` method of Solflare
@@ -17,7 +18,7 @@ export class CustomSolanaSigner implements GenericSigner<SolanaTransaction> {
       messageBytes,
       'utf8'
     );
-    return messageSignature.toString();
+    return base58.encode(messageSignature);
   }
 
   async signAndSendTx(tx: SolanaTransaction): Promise<{ hash: string }> {


### PR DESCRIPTION
# Summary

update `signMessage` in the default Solana signer to return a base58 string instead of base64 .

# How did you test this change?

You can test this change using the `wallets-demo` package.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
