### PR TITLE
chore: fix import from wallets core legacy in examples

### DIFF
--- a/examples/queue-manager-demo/src/flows/rango/helpers.ts
+++ b/examples/queue-manager-demo/src/flows/rango/helpers.ts
@@ -32,7 +32,7 @@ import type {
 } from 'rango-types';
 
 import { SUPPORTED_ETH_CHAINS as XDEFI_WALLET_SUPPORTED_EVM_CHAINS } from '@rango-dev/provider-xdefi';
-import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core';
+import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core/legacy';
 import {
   Networks,
   WalletTypes,

--- a/examples/wallets-demo/src/components/List/Item.tsx
+++ b/examples/wallets-demo/src/components/List/Item.tsx
@@ -14,7 +14,7 @@ import {
   Tooltip,
   Typography,
 } from '@rango-dev/ui';
-import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core';
+import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core/legacy';
 import { useWallets } from '@rango-dev/wallets-react';
 import { detectInstallLink, Networks } from '@rango-dev/wallets-shared';
 import React, { useState } from 'react';

--- a/examples/wallets-demo/src/helper.ts
+++ b/examples/wallets-demo/src/helper.ts
@@ -1,7 +1,7 @@
 import type { Network } from '@rango-dev/wallets-shared';
 import type { BlockchainMeta } from 'rango-sdk';
 
-import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core';
+import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core/legacy';
 import { Networks } from '@rango-dev/wallets-shared';
 import { isEvmBlockchain } from 'rango-sdk';
 


### PR DESCRIPTION
# Summary

Fix import from '@rango-dev/wallets-core/legacy' instead of '@rango-dev/wallets-core'  in examples.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
