### PR TITLE
chore: let legacy folder be included in wallets-core publish flow on npm

### DIFF
--- a/wallets/core/package.json
+++ b/wallets/core/package.json
@@ -18,7 +18,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "legacy"
   ],
   "scripts": {
     "build": "node ../../scripts/build/command.mjs --path wallets/core --inputs src/mod.ts,src/legacy/mod.ts",


### PR DESCRIPTION
# Summary

Include `legacy` folder on `core` publish.

We should allow `legacy` folder to be included in npm publish. you can take a look at [the original PR](https://github.com/rango-exchange/rango-client/pull/838) and more context on why we needed this at first place. 


# How did you test this change?

After publishing `wallets-core` we can take a look at npm and see `legacy` exist or not.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
