### PR TITLE
feat: implement lazy loading for some rango-client dependencies

### DIFF
--- a/signers/signer-solana/src/utils/helpers.ts
+++ b/signers/signer-solana/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { Connection } from '@solana/web3.js';
+import type { Connection } from '@solana/web3.js';
 
 import { getSolanaSignerConfig } from '../config.js';
 
@@ -7,8 +7,9 @@ const SOLANA_RPC_URL = !IS_DEV
   ? 'https://purple-practical-friday.solana-mainnet.quiknode.pro/d94ab067f793d48c81354c78c86ae908d9fc1582/'
   : 'https://fluent-still-scion.solana-mainnet.discover.quiknode.pro/fc8be9b8ac7aea382ec591359628e16d8c52ef6a/';
 
-export function getSolanaConnection(): Connection {
+export async function getSolanaConnection(): Promise<Connection> {
   const customRPC = getSolanaSignerConfig('customRPC');
+  const { Connection } = await import('@solana/web3.js');
 
   return new Connection(customRPC || SOLANA_RPC_URL, {
     commitment: 'confirmed',

--- a/signers/signer-solana/src/utils/main.ts
+++ b/signers/signer-solana/src/utils/main.ts
@@ -16,10 +16,10 @@ export const generalSolanaTransactionExecutor = async (
   tx: SolanaTransaction,
   DefaultSolanaSigner: SolanaWeb3Signer
 ): Promise<string> => {
-  const connection = getSolanaConnection();
+  const connection = await getSolanaConnection();
   const latestBlock = await connection.getLatestBlockhash('confirmed');
 
-  const finalTx = prepareTransaction(tx, latestBlock.blockhash);
+  const finalTx = await prepareTransaction(tx, latestBlock.blockhash);
   const raw = await DefaultSolanaSigner(finalTx);
 
   // We first simulate whether the transaction would be successful

--- a/signers/signer-solana/src/utils/prepare.ts
+++ b/signers/signer-solana/src/utils/prepare.ts
@@ -1,16 +1,12 @@
+import type { Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { SolanaTransaction } from 'rango-types';
 
-import {
-  PublicKey,
-  Transaction,
-  TransactionInstruction,
-  VersionedTransaction,
-} from '@solana/web3.js';
-
-export const prepareTransaction = (
+export const prepareTransaction = async (
   tx: SolanaTransaction,
   recentBlockhash: string
-): Transaction | VersionedTransaction => {
+): Promise<Transaction | VersionedTransaction> => {
+  const { VersionedTransaction } = await import('@solana/web3.js');
+
   let versionedTransaction: VersionedTransaction | undefined = undefined;
   let legacyTransaction: Transaction | undefined = undefined;
 
@@ -20,7 +16,7 @@ export const prepareTransaction = (
     );
     versionedTransaction.message.recentBlockhash = recentBlockhash;
   } else {
-    legacyTransaction = prepareLegacyTransaction(tx, recentBlockhash);
+    legacyTransaction = await prepareLegacyTransaction(tx, recentBlockhash);
   }
   const finalTx = versionedTransaction || legacyTransaction;
 
@@ -30,10 +26,14 @@ export const prepareTransaction = (
   return finalTx;
 };
 
-export function prepareLegacyTransaction(
+export async function prepareLegacyTransaction(
   tx: SolanaTransaction,
   recentBlockhash: string
-): Transaction {
+): Promise<Transaction> {
+  const { Transaction, TransactionInstruction, PublicKey } = await import(
+    '@solana/web3.js'
+  );
+
   const transaction = new Transaction();
   transaction.feePayer = new PublicKey(tx.from);
   transaction.recentBlockhash =

--- a/signers/signer-solana/src/utils/send.ts
+++ b/signers/signer-solana/src/utils/send.ts
@@ -3,7 +3,6 @@ import type {
   TransactionSenderAndConfirmationWaiterResponse,
 } from './types.js';
 
-import { TransactionExpiredBlockheightExceededError } from '@solana/web3.js';
 import promiseRetry from 'promise-retry';
 
 import { wait } from './helpers.js';
@@ -77,6 +76,10 @@ export async function transactionSenderAndConfirmationWaiter({
       }),
     ]);
   } catch (e) {
+    const { TransactionExpiredBlockheightExceededError } = await import(
+      '@solana/web3.js'
+    );
+
     if (e instanceof TransactionExpiredBlockheightExceededError) {
       // we consume this error and getTransaction would return null
       return { txId, txResponse: null };

--- a/signers/signer-solana/src/utils/simulate.ts
+++ b/signers/signer-solana/src/utils/simulate.ts
@@ -14,7 +14,7 @@ export async function simulateTransaction(
   type: 'VERSIONED' | 'LEGACY'
 ) {
   if (type === 'VERSIONED') {
-    const connection = getSolanaConnection();
+    const connection = await getSolanaConnection();
 
     // We first simulate whether the transaction would be successful
     const { value: simulatedTransactionResponse } =

--- a/signers/signer-terra/src/helpers.ts
+++ b/signers/signer-terra/src/helpers.ts
@@ -1,17 +1,17 @@
 import type { CreateTxOptions, Msg as TerraMsg } from '@terra-money/terra.js';
+import type { Fee } from '@terra-money/terra.js/dist/core/index.js';
 import type { CosmosTransaction } from 'rango-types';
 
-import { Coin } from '@terra-money/terra.js';
-import { Fee } from '@terra-money/terra.js/dist/core/index.js';
 import { JSONSerializable } from '@terra-money/terra.js/dist/util/json.js';
 
 export const executeTerraTransaction = async (
   cosmosTx: CosmosTransaction,
   provider: any
 ): Promise<string> => {
+  const txOptions = await cosmosTxToTerraTx(cosmosTx);
   return new Promise<string>((resolve, reject) => {
     provider
-      .post(cosmosTxToTerraTx(cosmosTx))
+      .post(txOptions)
       .then((result: { result: { txhash: string | PromiseLike<string> } }) =>
         resolve(result?.result?.txhash)
       )
@@ -22,9 +22,14 @@ export const executeTerraTransaction = async (
   });
 };
 
-function cosmosTxToTerraTx(tx: CosmosTransaction): CreateTxOptions {
+async function cosmosTxToTerraTx(
+  tx: CosmosTransaction
+): Promise<CreateTxOptions> {
   let tmpStdFee: Fee | undefined = undefined;
   if (tx.data.fee) {
+    const { Coin } = await import('@terra-money/terra.js');
+    const { Fee } = await import('@terra-money/terra.js/dist/core/index.js');
+
     const tmpCoinsFee = tx.data.fee.amount.map(
       (item) => new Coin(item.denom, item.amount)
     );

--- a/wallets/provider-coin98/src/solana-signer.ts
+++ b/wallets/provider-coin98/src/solana-signer.ts
@@ -3,7 +3,6 @@ import type { Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { GenericSigner, SolanaTransaction } from 'rango-types';
 
 import { generalSolanaTransactionExecutor } from '@rango-dev/signer-solana';
-import { PublicKey } from '@solana/web3.js';
 import bs58 from 'bs58';
 import { SignerError, SignerErrorCode } from 'rango-types';
 
@@ -37,6 +36,8 @@ export class CustomSolanaSigner implements GenericSigner<SolanaTransaction> {
           method: 'sol_sign',
           params: [solanaWeb3Transaction],
         });
+      const { PublicKey } = await import('@solana/web3.js');
+
       const publicKey = new PublicKey(response.publicKey);
       const sign = bs58.decode(response.signature);
 

--- a/wallets/provider-ledger/src/signers/solana.ts
+++ b/wallets/provider-ledger/src/signers/solana.ts
@@ -3,7 +3,6 @@ import type { Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { GenericSigner, SolanaTransaction } from 'rango-types';
 
 import { generalSolanaTransactionExecutor } from '@rango-dev/signer-solana';
-import { PublicKey } from '@solana/web3.js';
 import { SignerError, SignerErrorCode } from 'rango-types';
 
 import {
@@ -62,6 +61,7 @@ export class SolanaSigner implements GenericSigner<SolanaTransaction> {
         }
 
         const addressResult = await solana.getAddress(getDerivationPath());
+        const { PublicKey } = await import('@solana/web3.js');
 
         const publicKey = new PublicKey(addressResult.address);
 

--- a/wallets/provider-solflare-snap/src/signers/solanaSigner.ts
+++ b/wallets/provider-solflare-snap/src/signers/solanaSigner.ts
@@ -31,10 +31,10 @@ export class SolflareSnapSolanaSigner
 
   async signAndSendTx(tx: SolanaTransaction): Promise<{ hash: string }> {
     try {
-      const connection = getSolanaConnection();
+      const connection = await getSolanaConnection();
       const latestBlock = await connection.getLatestBlockhash('confirmed');
 
-      const finalTx = prepareTransaction(tx, latestBlock.blockhash);
+      const finalTx = await prepareTransaction(tx, latestBlock.blockhash);
 
       await simulateTransaction(finalTx, tx.txType);
 

--- a/wallets/provider-walletconnect-2/src/signers/cosmos.ts
+++ b/wallets/provider-walletconnect-2/src/signers/cosmos.ts
@@ -103,7 +103,7 @@ class COSMOSSigner implements GenericSigner<CosmosTransaction> {
           throw new SignerError(SignerErrorCode.SIGN_TX_ERROR, undefined, err);
         }
 
-        const signedTx = getsignedTx(tx, signResponse);
+        const signedTx = await getsignedTx(tx, signResponse);
         const result = await sendTx(
           chainId,
           signedTx,

--- a/wallets/provider-walletconnect-2/src/signers/helper.ts
+++ b/wallets/provider-walletconnect-2/src/signers/helper.ts
@@ -1,7 +1,5 @@
 import type { BlockchainMeta } from 'rango-types';
 
-import { TendermintTxTracer } from '@keplr-wallet/cosmos';
-import { simpleFetch } from '@keplr-wallet/simple-fetch';
 import { cosmosBlockchains } from 'rango-types';
 
 export async function sendTx(
@@ -10,13 +8,9 @@ export async function sendTx(
   mode: 'async' | 'sync' | 'block',
   supportedChains: BlockchainMeta[]
 ): Promise<Uint8Array> {
-  console.log({ chainId, tx, mode });
-
   const cosmos = cosmosBlockchains(supportedChains);
   const chainInfo = cosmos.find((item) => item.chainId === chainId)?.info;
   const isProtoTx = Buffer.isBuffer(tx) || tx instanceof Uint8Array;
-
-  console.log({ chainInfo, isProtoTx });
 
   if (!chainInfo) {
     throw new Error('Chain info is undefined from server');
@@ -43,6 +37,7 @@ export async function sendTx(
       };
 
   try {
+    const { simpleFetch } = await import('@keplr-wallet/simple-fetch');
     const result = await simpleFetch<any>(
       chainInfo.rest,
       isProtoTx ? '/cosmos/tx/v1beta1/txs' : '/txs',
@@ -62,7 +57,7 @@ export async function sendTx(
     }
 
     const txHash = Buffer.from(txResponse.txhash, 'hex');
-
+    const { TendermintTxTracer } = await import('@keplr-wallet/cosmos');
     const txTracer = new TendermintTxTracer(chainInfo.rpc, '/websocket');
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     txTracer.traceTx(txHash).then(() => {

--- a/wallets/provider-walletconnect-2/src/signers/solana.ts
+++ b/wallets/provider-walletconnect-2/src/signers/solana.ts
@@ -5,7 +5,6 @@ import type { SessionTypes } from '@walletconnect/types';
 import type { GenericSigner, SolanaTransaction } from 'rango-types';
 
 import { generalSolanaTransactionExecutor } from '@rango-dev/signer-solana';
-import { PublicKey } from '@solana/web3.js';
 import base58 from 'bs58';
 import { AccountId, ChainId } from 'caip';
 import { SignerError, SignerErrorCode } from 'rango-types';
@@ -39,6 +38,8 @@ class SOLANASigner implements GenericSigner<SolanaTransaction> {
 
     try {
       const message = base58.encode(new TextEncoder().encode(msg));
+      const { PublicKey } = await import('@solana/web3.js');
+
       const pubkey = new PublicKey(address);
       const { signature } = await this.client.request<{
         signature: string;
@@ -80,7 +81,7 @@ class SOLANASigner implements GenericSigner<SolanaTransaction> {
           params: solanaWeb3Transaction,
         },
       });
-
+      const { PublicKey } = await import('@solana/web3.js');
       const publicKey = new PublicKey(tx.from);
       const sign = base58.decode(response.signature);
 


### PR DESCRIPTION
# Summary

This PR implements lazy loading for certain dependencies within the rango-client to optimize the bundle size and improve application performance. By dynamically importing modules only when needed, we can reduce the initial load time and enhance the overall user experience, especially for users who may not require all features immediately.

Fixes # (issue)
The difference in bundle size before and after:

before

![Screenshot from 2024-08-27 14-34-28](https://github.com/user-attachments/assets/22de0753-b0a1-42e7-ba25-9d652a39c8b7)


after


![Screenshot from 2024-08-27 14-58-26](https://github.com/user-attachments/assets/8422cc4c-bc7b-48ea-aa6c-faacb50f284c)


# How did you test this change?
 
 Because most of the changes have happened in Cosmos and Solana and Terra wallets and Signers, please test the wallets and Signers.

Packages that are lazily loaded: 
- @terra-money/terra.js
- @cosmjs/launchpad
- @cosmjs/stargate
- @keplr-wallet/cosmos
- @solana/web3.js
- cosmos-wallet
- @keplr-wallet/simple-fetch

# Checklist:

- [x] I have performed a self-review of my code
  