### PR TITLE
feat: export StatefulConnect components and helpers

### DIFF
--- a/scripts/build/command.mjs
+++ b/scripts/build/command.mjs
@@ -85,7 +85,7 @@ async function run() {
     minify: true,
     keepNames: true,
     sourcemap: true,
-    platform: 'node',
+    platform: 'browser',
     format: 'esm',
     outdir: `${pkgPath}/dist`,
     entryPoints: entryPoints,

--- a/widget/embedded/src/components/StatefulConnectModal/index.ts
+++ b/widget/embedded/src/components/StatefulConnectModal/index.ts
@@ -1,1 +1,2 @@
 export { StatefulConnectModal } from './StatefulConnectModal';
+export { isOnNamespace, isOnDerivationPath } from './helpers';

--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.state.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.state.ts
@@ -34,11 +34,14 @@ export function reducer(state: State, action: Actions): State {
     case 'reset':
       return initState;
     case 'resetDerivation':
-      return {
-        ...state,
-        derivationPath: null,
-        status: 'namespace',
-      };
+      if (state.namespace) {
+        return {
+          ...state,
+          derivationPath: null,
+          status: 'namespace',
+        };
+      }
+      return initState;
     default:
       throw new Error(`Action hasn't been defined.`);
   }

--- a/widget/embedded/src/index.ts
+++ b/widget/embedded/src/index.ts
@@ -57,6 +57,11 @@ import { useWallets, Events as WalletEvents } from '@rango-dev/wallets-react';
 import { Networks, WalletTypes } from '@rango-dev/wallets-shared';
 import { PendingSwapNetworkStatus } from 'rango-types';
 
+import {
+  isOnDerivationPath,
+  isOnNamespace,
+} from './components/StatefulConnectModal';
+import { DerivationPath, Namespaces } from './components/WalletStatefulConnect';
 import { WIDGET_UI_ID as UI_ID } from './constants';
 import { SUPPORTED_FONTS } from './constants/fonts';
 import { WidgetWallets } from './containers/Wallets';
@@ -75,6 +80,13 @@ import {
   WidgetEvents,
 } from './types';
 import { customizedThemeTokens } from './utils/ui';
+
+export const StatefulConnect = {
+  DerivationPath,
+  Namespaces,
+  isOnDerivationPath,
+  isOnNamespace,
+};
 
 export type {
   WidgetConfig,


### PR DESCRIPTION
# Summary

Export StatefulConnect components to share the logic between `embedded` and `dApp`.

It includes exporting required components for our dApp and one infrastructure change for our bundled libs (wc2, ledger and trezor) to make sure transforming dynamic `require`s to proper esm format. 

# How did you test this change?

It will only affect the compilation and producing output.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
