### PR TITLE
fix: polyfill bundled dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "conventional-recommended-bump": "^6.1.0",
     "crypto-browserify": "^3.12.0",
     "esbuild": "^0.20.1",
+    "esbuild-plugins-node-modules-polyfill": "^1.6.6",
     "eslint": "^8.41.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-destructuring": "^2.2.1",

--- a/scripts/build/command.mjs
+++ b/scripts/build/command.mjs
@@ -3,6 +3,7 @@ import * as esbuild from 'esbuild';
 import { $ } from 'execa';
 import { join } from 'path';
 import process from 'process';
+import { nodeModulesPolyfillPlugin } from 'esbuild-plugins-node-modules-polyfill';
 import {
   packageJson,
   packageNameWithoutScope,
@@ -90,6 +91,13 @@ async function run() {
     outdir: `${pkgPath}/dist`,
     entryPoints: entryPoints,
     metafile: true,
+    plugins: [
+      nodeModulesPolyfillPlugin({
+        globals: {
+          fs: true,
+        },
+      }),
+    ],
     ...externalPackages,
   });
   const result = await Promise.all([typeCheckingTask, esbuildTask]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3996,6 +3996,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jspm/core@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@jspm/core/-/core-2.0.1.tgz#3f08c59c60a5f5e994523ed6b0b665ec80adc94e"
+  integrity sha512-Lg3PnLp0QXpxwLIAuuJboLeRaIhrgJjeuh797QADg3xz8wGLugQOS5DpsE8A6i6Adgzf+bacllkKZG3J0tGfDw==
+
 "@keplr-wallet/cosmos@^0.9.12":
   version "0.9.16"
   resolved "https://registry.yarnpkg.com/@keplr-wallet/cosmos/-/cosmos-0.9.16.tgz#bfd1968e32bf7108b213c82c7c36e650f9963ce9"
@@ -11783,6 +11788,15 @@ esbuild-plugin-alias@^0.2.1:
   resolved "https://registry.yarnpkg.com/esbuild-plugin-alias/-/esbuild-plugin-alias-0.2.1.tgz#45a86cb941e20e7c2bc68a2bea53562172494fcb"
   integrity sha512-jyfL/pwPqaFXyKnj8lP8iLk6Z0m099uXR45aSN8Av1XD4vhvQutxxPzgA2bTcAwQpa1zCXDcWOlhFgyP3GKqhQ==
 
+esbuild-plugins-node-modules-polyfill@^1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/esbuild-plugins-node-modules-polyfill/-/esbuild-plugins-node-modules-polyfill-1.6.6.tgz#acdfbd32443a1667a029b930b15a5ae767a7ed25"
+  integrity sha512-0wDvliv65SCaaGtmoITnmXqqiUzU+ggFupnOgkEo2B9cQ+CUt58ql2+EY6dYoEsoqiHRu2NuTrFUJGMJEgMmLw==
+  dependencies:
+    "@jspm/core" "^2.0.1"
+    local-pkg "^0.5.0"
+    resolve.exports "^2.0.2"
+
 esbuild-register@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/esbuild-register/-/esbuild-register-3.5.0.tgz#449613fb29ab94325c722f560f800dd946dc8ea8"
@@ -14867,6 +14881,14 @@ local-pkg@^0.4.3:
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.3.tgz#0ff361ab3ae7f1c19113d9bb97b98b905dbc4963"
   integrity sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==
 
+local-pkg@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.5.0.tgz#093d25a346bae59a99f80e75f6e9d36d7e8c925c"
+  integrity sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==
+  dependencies:
+    mlly "^1.4.2"
+    pkg-types "^1.0.3"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -17709,6 +17731,11 @@ resolve-global@1.0.0, resolve-global@^1.0.0:
   integrity sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==
   dependencies:
     global-dirs "^0.1.1"
+
+resolve.exports@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
+  integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
 resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.22.1, resolve@^1.22.4, resolve@^1.22.8:
   version "1.22.8"


### PR DESCRIPTION
# Summary

Polyfill esbuild outputs to ensure it won't need to be polyfilled in host machines.

We are bundling some of dependencies directly into `dist` files (e.g. wc2), they may using internal node modules like `fs`. Our target is browser so we need to ensure we don't put any node-related modules inside our output.


# How did you test this change?

You can make a local build and then `cd wallets/provider-walletconenct2 && yarn link` then in our dApp run `yarn link "@rango-dev/provider-walletconnect-2"` (next branch). Try to connect `Wallet Connect`, it should works.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
