### PR TITLE
chore: include polyfills for walletconnect-2 provider

### DIFF
--- a/wallets/provider-walletconnect-2/readme.md
+++ b/wallets/provider-walletconnect-2/readme.md
@@ -6,4 +6,3 @@
 - Using Private key to import wallets other than `Ethereum` will be problematic. Because it imports only a single blockchain and we are by default asking for `Ethereum`.  
 - Signing a transaction on Metamask goes through an internal error.
 - We couldn't update exist session during a bug in `@walletconnect/utils`, so we are creating new session for accessing to new chains.
-


### PR DESCRIPTION
# Summary

We've had a change on our build scripts to include polyflls when needed. wc2 should be re-build to fix its issue `fs`. 



# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
