### PR TITLE
feat: implement bordered variant for tabs component

### DIFF
--- a/widget/ui/src/components/Tabs/Tabs.styles.tsx
+++ b/widget/ui/src/components/Tabs/Tabs.styles.tsx
@@ -23,6 +23,7 @@ export const Tabs = styled('div', {
         borderStyle: 'solid',
         backgroundColor: '$$color',
       },
+      bordered: { backgroundColor: 'inherit' },
     },
     borderRadius: {
       small: {
@@ -34,12 +35,16 @@ export const Tabs = styled('div', {
       full: {
         borderRadius: '$xm',
       },
+      none: {
+        borderRadius: 'unset',
+      },
     },
   },
 });
 
 export const Tab = styled(Button, {
   color: '$neutral700',
+  flex: 1,
   backgroundColor: 'transparent',
   height: '100%',
   zIndex: 10,
@@ -60,6 +65,9 @@ export const Tab = styled(Button, {
       full: {
         borderRadius: '$xm',
       },
+      none: {
+        borderRadius: 'unset',
+      },
     },
     type: {
       primary: {
@@ -67,6 +75,7 @@ export const Tab = styled(Button, {
         height: '100%',
       },
       secondary: {},
+      bordered: {},
     },
     isActive: {
       true: {
@@ -122,6 +131,24 @@ export const Tab = styled(Button, {
         },
       },
     },
+    {
+      type: 'bordered',
+      isActive: true,
+      css: {
+        color: '$secondary500',
+      },
+    },
+    {
+      type: 'bordered',
+      isActive: false,
+      css: {
+        color: '$neutral600',
+        fontWeight: '$regular',
+        '&:hover': {
+          color: '$secondary550',
+        },
+      },
+    },
   ],
 });
 
@@ -141,6 +168,9 @@ export const BackdropTab = styled('div', {
       primary: {
         backgroundColor: '$background',
       },
+      bordered: {
+        borderBottom: '$secondary500 solid 2px',
+      },
     },
     borderRadius: {
       small: {
@@ -151,6 +181,9 @@ export const BackdropTab = styled('div', {
       },
       full: {
         borderRadius: '$xm',
+      },
+      none: {
+        borderRadius: 'unset',
       },
     },
   },

--- a/widget/ui/src/components/Tabs/Tabs.tsx
+++ b/widget/ui/src/components/Tabs/Tabs.tsx
@@ -15,7 +15,6 @@ export function TabsComponent(props: TabsPropTypes) {
     container = document.body,
     value,
     type,
-    borderRadius = 'medium',
     className,
   } = props;
   const [tabWidth, setTabWidth] = useState(0);
@@ -25,6 +24,12 @@ export function TabsComponent(props: TabsPropTypes) {
   // State variable to track the initial render
   const [initialRender, setInitialRender] = useState(true);
   const transformPosition = currentIndex * tabWidth;
+  let borderRadius: TabsPropTypes['borderRadius'] = 'medium';
+  if (type === 'bordered') {
+    borderRadius = 'none';
+  } else if (props.borderRadius) {
+    borderRadius = props.borderRadius;
+  }
 
   useEffect(() => {
     const updateTabWidth = () => {


### PR DESCRIPTION
# Summary

We need a different variant for the tabs component, similar to the one shown in this image: 
![1](https://github.com/user-attachments/assets/d98205a4-9e4d-4405-af71-1902b6288fdd)

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
