### PR TITLE
fix: ensure proper cleanup of the modal component after it is removed from the DOM

### DIFF
--- a/widget/ui/src/components/Modal/Modal.tsx
+++ b/widget/ui/src/components/Modal/Modal.tsx
@@ -94,6 +94,13 @@ export function Modal(props: PropsWithChildren<ModalPropTypes>) {
   }, [open]);
 
   useEffect(() => {
+    return () => {
+      //container might be null
+      container?.style.removeProperty('overflow');
+    };
+  }, []);
+
+  useEffect(() => {
     if (!!container && isMount) {
       if (modalContainerRef.current) {
         forceReflow(modalContainerRef.current);


### PR DESCRIPTION
# Summary

In certain cases, we want to conditionally remove the modal component from the DOM without using the close button or clicking the backdrop. Currently, the cleanup during the unmounting of the modal is not handled correctly. After the modal is removed from the DOM, the container's overflow remains set to "hidden," causing the scrollbar to stay hidden even after the modal is gone.

Fixes # (issue)

Removing the container's overflow property when the modal is unmounted.

# How did you test this change?

You can test this by linking the UI package in the Dapp. Go to the profile page and attempt to log in. After logging in and the login modal is removed from the DOM, you'll notice that the body's overflow is incorrectly handled.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
