### PR TITLE
feat: implement scrollable variant for Tabs component

### DIFF
--- a/widget/storybook/src/components/Tabs/Tabs.stories.tsx
+++ b/widget/storybook/src/components/Tabs/Tabs.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta } from '@storybook/react';
 import { Tabs } from '@rango-dev/ui';
 import React, { useState } from 'react';
 
-import { themes } from './mock';
+import { numbers, themes } from './mock';
 
 export default {
   title: 'Components/Tabs',
@@ -19,9 +19,9 @@ export default {
   argTypes: {
     type: {
       control: { type: 'select' },
-      options: ['primary', 'secondary'],
+      options: ['primary', 'secondary', 'bordered'],
       defaultValue: 'primary',
-      description: 'primary | secondary | undefined',
+      description: 'primary | secondary | bordered | undefined',
     },
     className: {
       control: { type: 'text' },
@@ -35,6 +35,14 @@ export default {
     },
     onChange: {
       type: 'function',
+    },
+    scrollable: {
+      defaultValue: false,
+      type: 'boolean',
+    },
+    scrollButtons: {
+      defaultValue: true,
+      type: 'boolean',
     },
   },
 } as Meta<typeof Tabs>;
@@ -51,6 +59,27 @@ export const Main = (args: TabsPropTypes) => {
       <Tabs
         {...args}
         value={value}
+        onChange={(item) => setValue(item.id as string)}
+      />
+    </div>
+  );
+};
+
+export const Scrollable = (args: TabsPropTypes) => {
+  const [value, setValue] = useState(numbers[0].id);
+
+  return (
+    <div
+      style={{
+        width: '250px',
+        height: '40px',
+      }}>
+      <Tabs
+        {...args}
+        items={numbers}
+        scrollable={true}
+        type="bordered"
+        value={value as string}
         onChange={(item) => setValue(item.id as string)}
       />
     </div>

--- a/widget/storybook/src/components/Tabs/mock.tsx
+++ b/widget/storybook/src/components/Tabs/mock.tsx
@@ -1,3 +1,5 @@
+import type { TabsPropTypes } from '@rango-dev/ui';
+
 import {
   AutoThemeIcon,
   DarkModeIcon,
@@ -31,6 +33,99 @@ export const themes = [
     tooltip: (
       <Typography size="xsmall" variant="body">
         Auto
+      </Typography>
+    ),
+  },
+];
+
+export const numbers: TabsPropTypes['items'] = [
+  {
+    id: 'one',
+    title: 'one',
+    tooltip: (
+      <Typography size="xsmall" variant="body">
+        1
+      </Typography>
+    ),
+  },
+  {
+    id: 'two',
+    title: 'two',
+    tooltip: (
+      <Typography size="xsmall" variant="body">
+        2
+      </Typography>
+    ),
+  },
+  {
+    id: 'three',
+    title: 'three',
+    tooltip: (
+      <Typography size="xsmall" variant="body">
+        3
+      </Typography>
+    ),
+  },
+  {
+    id: 'four',
+    title: 'four',
+    tooltip: (
+      <Typography size="xsmall" variant="body">
+        4
+      </Typography>
+    ),
+  },
+  {
+    id: 'five',
+    title: 'five',
+    tooltip: (
+      <Typography size="xsmall" variant="body">
+        5
+      </Typography>
+    ),
+  },
+  {
+    id: 'six',
+    title: 'six',
+    tooltip: (
+      <Typography size="xsmall" variant="body">
+        6
+      </Typography>
+    ),
+  },
+  {
+    id: 'seven',
+    title: 'seven',
+    tooltip: (
+      <Typography size="xsmall" variant="body">
+        7
+      </Typography>
+    ),
+  },
+  {
+    id: 'eight',
+    title: 'eight',
+    tooltip: (
+      <Typography size="xsmall" variant="body">
+        8
+      </Typography>
+    ),
+  },
+  {
+    id: 'nine',
+    title: 'nine',
+    tooltip: (
+      <Typography size="xsmall" variant="body">
+        9
+      </Typography>
+    ),
+  },
+  {
+    id: 'ten',
+    title: 'ten',
+    tooltip: (
+      <Typography size="xsmall" variant="body">
+        10
       </Typography>
     ),
   },

--- a/widget/ui/src/components/Tabs/Tabs.styles.tsx
+++ b/widget/ui/src/components/Tabs/Tabs.styles.tsx
@@ -1,5 +1,39 @@
 import { darkTheme, styled } from '../../theme.js';
 import { Button } from '../Button/index.js';
+import { IconButton } from '../IconButton/IconButton.js';
+
+export const Container = styled('div', {
+  position: 'relative',
+  variants: {
+    hasPadding: {
+      true: {
+        padding: '0 $32',
+      },
+    },
+  },
+});
+
+export const Arrow = styled(IconButton, {
+  position: 'absolute',
+  height: '100%',
+  zIndex: 20,
+  borderRadius: '$xs !important',
+  variants: {
+    hidden: {
+      true: {
+        visibility: 'hidden',
+      },
+    },
+  },
+});
+
+export const ArrowRight = styled(Arrow, {
+  right: 0,
+});
+
+export const ArrowLeft = styled(Arrow, {
+  left: 0,
+});
 
 export const Tabs = styled('div', {
   display: 'flex',
@@ -23,7 +57,7 @@ export const Tabs = styled('div', {
         borderStyle: 'solid',
         backgroundColor: '$$color',
       },
-      bordered: { backgroundColor: 'inherit' },
+      bordered: {},
     },
     borderRadius: {
       small: {
@@ -37,6 +71,16 @@ export const Tabs = styled('div', {
       },
       none: {
         borderRadius: 'unset',
+      },
+    },
+    scrollable: {
+      true: {
+        overflowX: 'auto',
+        scrollBehavior: 'smooth',
+        scrollbarWidth: 'none',
+        '&::webkit-scrollbar': {
+          display: 'none',
+        },
       },
     },
   },
@@ -75,7 +119,9 @@ export const Tab = styled(Button, {
         height: '100%',
       },
       secondary: {},
-      bordered: {},
+      bordered: {
+        padding: '$10 $20',
+      },
     },
     isActive: {
       true: {
@@ -154,6 +200,7 @@ export const Tab = styled(Button, {
 
 export const BackdropTab = styled('div', {
   padding: '$4',
+  boxSizing: 'border-box',
   position: 'absolute',
   inset: 0,
   transition: 'transform 0.2s cubic-bezier(0, 0, 0.86, 1.2)',
@@ -169,6 +216,7 @@ export const BackdropTab = styled('div', {
         backgroundColor: '$background',
       },
       bordered: {
+        borderRadius: '0 !important',
         borderBottom: '$secondary500 solid 2px',
       },
     },

--- a/widget/ui/src/components/Tabs/Tabs.tsx
+++ b/widget/ui/src/components/Tabs/Tabs.tsx
@@ -1,11 +1,19 @@
 import type { TabsPropTypes } from './Tabs.types.js';
 
 import React, { useEffect, useRef, useState } from 'react';
+import { ChevronLeftIcon, ChevronRightIcon } from 'src/icons/index.js';
 
 import { Divider } from '../Divider/index.js';
 import { Tooltip } from '../Tooltip/index.js';
 
-import { BackdropTab, Tab, Tabs } from './Tabs.styles.js';
+import {
+  ArrowLeft,
+  ArrowRight,
+  BackdropTab,
+  Container,
+  Tab,
+  Tabs,
+} from './Tabs.styles.js';
 
 const INITIAL_RENDER_DELAY = 100;
 export function TabsComponent(props: TabsPropTypes) {
@@ -16,34 +24,68 @@ export function TabsComponent(props: TabsPropTypes) {
     value,
     type,
     className,
+    scrollable,
+    scrollButtons = true,
   } = props;
   const [tabWidth, setTabWidth] = useState(0);
-  const tabRef: React.Ref<HTMLButtonElement> = useRef(null);
+  const tabRef = useRef<HTMLButtonElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const leftArrowRef = useRef<HTMLButtonElement | null>(null);
   const currentIndex = tabItems.findIndex((item) => item.id === value);
-
   // State variable to track the initial render
   const [initialRender, setInitialRender] = useState(true);
-  const transformPosition = currentIndex * tabWidth;
+  const [transformPosition, setTransformPosition] = useState(0);
+  const [leftArrowDisabled, setLeftArrowDisabled] = useState(true);
+  const [rightArrowDisabled, setRightArrowDisabled] = useState(false);
+  const [showArrows, setShowArrows] = useState(false);
+
   let borderRadius: TabsPropTypes['borderRadius'] = 'medium';
   if (type === 'bordered') {
     borderRadius = 'none';
-  } else if (props.borderRadius) {
+  } else if (type && props.borderRadius) {
     borderRadius = props.borderRadius;
   }
 
-  useEffect(() => {
-    const updateTabWidth = () => {
-      if (tabRef.current) {
-        const tabRect = tabRef.current.getBoundingClientRect();
-        setTabWidth(tabRect.width);
+  const handleScroll = (to: 'right' | 'left') => {
+    if (!containerRef.current) {
+      return;
+    }
+    const SCROLL_MULTIPLIER = 1.5;
+    const scrollWidth =
+      (containerRef.current.scrollWidth / tabItems.length) * SCROLL_MULTIPLIER;
+
+    if (to === 'right') {
+      containerRef.current.scrollLeft -= scrollWidth;
+    } else {
+      containerRef.current.scrollLeft += scrollWidth;
+    }
+  };
+
+  const updateIndicator = (currentIndex: number) => {
+    if (tabRef.current && containerRef.current) {
+      const tabRect = tabRef.current.getBoundingClientRect();
+      const containerRect = containerRef.current.getBoundingClientRect();
+      setTabWidth(tabRect.width);
+      setTransformPosition(
+        scrollable ? tabRef.current.offsetLeft : currentIndex * tabWidth
+      );
+      const itemPartiallyVisibleOnLeft = tabRect.left < containerRect.left;
+      const itemPartiallyVisibleOnRight = tabRect.right > containerRect.right;
+
+      if (itemPartiallyVisibleOnLeft) {
+        containerRef.current.scrollLeft = tabRef.current.offsetLeft;
+      } else if (itemPartiallyVisibleOnRight) {
+        const containerComputedStyles = window.getComputedStyle(
+          containerRef.current
+        );
+        containerRef.current.scrollLeft =
+          containerRef.current.scrollLeft +
+          tabRect.right -
+          containerRect.right +
+          parseFloat(containerComputedStyles.borderRightWidth);
       }
-    };
-    updateTabWidth();
-    window.addEventListener('resize', updateTabWidth);
-    return () => {
-      window.removeEventListener('resize', updateTabWidth);
-    };
-  }, []);
+    }
+  };
 
   useEffect(() => {
     // Set initialRender to false after a short delay
@@ -53,48 +95,126 @@ export function TabsComponent(props: TabsPropTypes) {
     }, INITIAL_RENDER_DELAY);
   }, []);
 
+  useEffect(() => {
+    updateIndicator(currentIndex);
+
+    const updateArrowsVisibility = () => {
+      if (scrollable && containerRef.current) {
+        const startOfTheScroll = containerRef.current.scrollLeft === 0;
+        const endOfTheScroll =
+          containerRef.current.scrollLeft + containerRef.current.clientWidth ===
+          containerRef.current.scrollWidth;
+
+        if (startOfTheScroll) {
+          setLeftArrowDisabled(true);
+        } else {
+          setLeftArrowDisabled(false);
+        }
+        if (endOfTheScroll) {
+          setRightArrowDisabled(true);
+        } else {
+          setRightArrowDisabled(false);
+        }
+      }
+    };
+
+    const resizeHandler: ResizeObserverCallback = (event) => {
+      if (scrollable && containerRef.current) {
+        const TOTAL_WIDTH_OF_ARROWS = 64;
+        updateIndicator(currentIndex);
+        updateArrowsVisibility();
+        const element = event[0].target;
+        if (showArrows) {
+          const tabsContainerOverflown =
+            element.scrollWidth - TOTAL_WIDTH_OF_ARROWS > element.clientWidth;
+          if (!tabsContainerOverflown) {
+            setShowArrows(false);
+          }
+        } else if (element.scrollWidth > element.clientWidth) {
+          setShowArrows(true);
+        }
+      }
+    };
+
+    containerRef.current?.addEventListener('scroll', updateArrowsVisibility);
+
+    const resizeObserver = new ResizeObserver(resizeHandler);
+    if (containerRef.current) {
+      resizeObserver.observe(containerRef.current);
+    }
+
+    return () => {
+      if (containerRef.current) {
+        resizeObserver.unobserve(containerRef.current);
+        containerRef.current.removeEventListener(
+          'scroll',
+          updateArrowsVisibility
+        );
+      }
+    };
+  }, [containerRef.current, showArrows, currentIndex]);
+
   return (
-    <Tabs
-      className={`_tabs ${className || ''}`}
-      type={type}
-      borderRadius={borderRadius}>
-      {tabItems.map((item, index) => (
-        <Tooltip
-          key={item.id}
-          styles={{ root: { width: '100%' } }}
-          container={container}
-          side="bottom"
-          sideOffset={2}
-          content={item.tooltip}
-          open={!item.tooltip ? false : undefined}>
-          <Tab
-            className="_tab"
-            ref={index === 0 ? tabRef : null} // Set ref on the first tab
-            type={type}
-            fullWidth
-            disableRipple={true}
-            borderRadius={borderRadius}
-            onClick={() => onChange(item)}
-            size="small"
-            isActive={item.id === value}
-            variant="default">
-            {item.icon}
-            {!!item.icon && !!item.title && (
-              <Divider direction="horizontal" size="2" />
-            )}
-            {item.title}
-          </Tab>
-        </Tooltip>
-      ))}
-      <BackdropTab
+    <Container hasPadding={scrollButtons && showArrows}>
+      {scrollable && showArrows && scrollButtons && (
+        <>
+          <ArrowLeft
+            ref={leftArrowRef}
+            hidden={leftArrowDisabled}
+            onClick={() => handleScroll('right')}>
+            <ChevronLeftIcon size={16} color="secondary" />
+          </ArrowLeft>
+          <ArrowRight
+            hidden={rightArrowDisabled}
+            onClick={() => handleScroll('left')}>
+            <ChevronRightIcon size={16} color="secondary" />
+          </ArrowRight>
+        </>
+      )}
+      <Tabs
+        ref={containerRef}
+        className={`_tabs ${className || ''}`}
         type={type}
         borderRadius={borderRadius}
-        className={`_backdrop-tab ${initialRender ? 'no-transition' : ''}`}
-        css={{
-          width: tabWidth,
-          transform: `translateX(${transformPosition}px)`,
-        }}
-      />
-    </Tabs>
+        scrollable={scrollable}>
+        {tabItems.map((item, index) => (
+          <Tooltip
+            key={item.id}
+            styles={{ root: { width: '100%' } }}
+            container={container}
+            side="bottom"
+            sideOffset={2}
+            content={item.tooltip}
+            open={!item.tooltip ? false : undefined}>
+            <Tab
+              className="_tab"
+              ref={index === currentIndex ? tabRef : null}
+              type={type}
+              fullWidth={scrollable ? false : true}
+              disableRipple={true}
+              borderRadius={borderRadius}
+              onClick={() => onChange(item)}
+              size="small"
+              isActive={item.id === value}
+              variant="default">
+              {item.icon}
+              {!!item.icon && !!item.title && (
+                <Divider direction="horizontal" size="2" />
+              )}
+              {item.title}
+            </Tab>
+          </Tooltip>
+        ))}
+        <BackdropTab
+          type={type}
+          borderRadius={borderRadius}
+          className={`_backdrop-tab ${initialRender ? 'no-transition' : ''}`}
+          css={{
+            width: tabWidth,
+            transform: `translateX(${transformPosition}px)`,
+          }}
+        />
+      </Tabs>
+    </Container>
   );
 }

--- a/widget/ui/src/components/Tabs/Tabs.types.tsx
+++ b/widget/ui/src/components/Tabs/Tabs.types.tsx
@@ -29,4 +29,6 @@ export interface TabsPropTypes {
   type: BaseType;
   borderRadius?: BaseBorderRadius;
   className?: string;
+  scrollable?: boolean;
+  scrollButtons?: boolean;
 }


### PR DESCRIPTION
# Summary

We need a scrollable variant for the Tabs component in the Dapp. I attempted to implement a solution similar to Material UI's scrollable tabs. You can check it out here:
https://mui.com/material-ui/react-tabs/#scrollable-tabs

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
