### PR TITLE
fix: enabling trezor by removing bundling for @trezor/connect-web

### DIFF
--- a/wallets/provider-all/src/index.ts
+++ b/wallets/provider-all/src/index.ts
@@ -30,7 +30,7 @@ import * as solflareSnap from '@rango-dev/provider-solflare-snap';
 import * as taho from '@rango-dev/provider-taho';
 import * as tokenpocket from '@rango-dev/provider-tokenpocket';
 import * as tomo from '@rango-dev/provider-tomo';
-// import * as trezor from '@rango-dev/provider-trezor';
+import * as trezor from '@rango-dev/provider-trezor';
 import * as tronLink from '@rango-dev/provider-tron-link';
 import * as trustwallet from '@rango-dev/provider-trustwallet';
 import * as walletconnect2 from '@rango-dev/provider-walletconnect-2';
@@ -63,23 +63,16 @@ export const allProviders = (options?: Options) => {
     }
   }
 
-  /*
-   *  Considering that Trezor was showing unstable behavior in some environments,
-   *  we temporarily removed it, we will return the comments after correction.
-   */
-
-  /*
-   * if (
-   *   !isWalletExcluded(providers, {
-   *     type: WalletTypes.TREZOR,
-   *     name: 'Trezor',
-   *   })
-   * ) {
-   *   if (!!options?.trezor?.manifest) {
-   *     trezor.init(options.trezor);
-   *   }
-   * }
-   */
+  if (
+    !isWalletExcluded(providers, {
+      type: WalletTypes.TREZOR,
+      name: 'Trezor',
+    })
+  ) {
+    if (!!options?.trezor?.manifest) {
+      trezor.init(options.trezor);
+    }
+  }
 
   return [
     safe,
@@ -113,7 +106,7 @@ export const allProviders = (options?: Options) => {
     braavos,
     ledger,
     rabby,
-    // trezor,
+    trezor,
     solflare,
   ];
 };

--- a/wallets/provider-trezor/notes.md
+++ b/wallets/provider-trezor/notes.md
@@ -1,0 +1,11 @@
+## @trezor/connect-web is cjs
+
+Our packages should be ESM-only. One of our dependencies, `@trezor/connect-web` is CJS, We first tried to bundle a transpiled version of the `@trezor/connect-web` package, but it has some problems with `.default`-thing. you can add `--external-all-except @trezor/connect-web` to `build` and try to link to our dApp.
+
+There are two workaround for solving this:
+
+1. Consider user to have a bundler/tool to transpile it on host (e.g. Vite).
+2. Remove the provider from `provider-all` and add besides `privder-all` separately in our dApp. This way we ensure all the `provider-all` dependencies include only ESM packages and when some is using `embedded` there is no need to transpile CJS to ESM and our `embedded` can be used directly.
+
+We are going with the first one from the beginning so we will keep it for now.
+In future, we need to investigate and somehow figure out this problem and be ESM-only.

--- a/wallets/provider-trezor/package.json
+++ b/wallets/provider-trezor/package.json
@@ -17,7 +17,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-trezor --external ethers,@rango-dev/signer-evm,@rango-dev/wallets-shared,rango-types",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-trezor",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
# Summary

Our dApp goes throw an error and it shows an error regarding `provider-trezor` can't be initialized by an incorrect import (`.default`). you can take a look at RF-1838 for more context.

In this PR, we are removing bundling for `connect-web` package. Take a look at `notes.md` for more information.  


# How did you test this change?

Try to run `yarn build:all` and then link to our dApp. Trezor should be in the list and works correctly.


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
