### PR TITLE
chore: deprecate bep2 support

### DIFF
--- a/wallets/provider-exodus/src/helpers.ts
+++ b/wallets/provider-exodus/src/helpers.ts
@@ -44,5 +44,4 @@ export const EXODUS_WALLET_SUPPORTED_CHAINS = [
   Networks.BSC,
   Networks.POLYGON,
   Networks.AVAX_CCHAIN,
-  Networks.BINANCE,
 ];

--- a/wallets/provider-taho/src/helpers.ts
+++ b/wallets/provider-taho/src/helpers.ts
@@ -3,7 +3,9 @@ import { Networks } from '@rango-dev/wallets-shared';
 export function taho() {
   const { tally } = window;
 
-  if (!tally) return null;
+  if (!tally) {
+    return null;
+  }
 
   return tally;
 }
@@ -14,5 +16,5 @@ export const TAHO_WALLET_SUPPORTED_CHAINS = [
   Networks.OPTIMISM,
   Networks.ARBITRUM,
   Networks.AVAX_CCHAIN,
-  Networks.BINANCE,
+  Networks.BSC,
 ];

--- a/wallets/provider-xdefi/src/cosmos-signer.ts
+++ b/wallets/provider-xdefi/src/cosmos-signer.ts
@@ -4,8 +4,6 @@ import { executeCosmosTransaction } from '@rango-dev/signer-cosmos';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { SignerError, SignerErrorCode } from 'rango-types';
 
-import { xdefiTransfer } from './helpers.js';
-
 /*
  * TODO - replace with real type
  * tslint:disable-next-line: no-any
@@ -43,23 +41,6 @@ export class CustomCosmosSigner implements GenericSigner<CosmosTransaction> {
       const hash = await executeCosmosTransaction(tx, cosmosProvider);
       return { hash };
     }
-
-    const binanceProvider = getNetworkInstance(this.provider, Networks.BINANCE);
-
-    const from = tx.fromWalletAddress;
-    const { method, memo, recipient, decimals, amount, asset } = tx.rawTransfer;
-    const blockchain = tx.blockChain;
-    const hash = await xdefiTransfer(
-      blockchain,
-      asset.ticker,
-      from,
-      amount,
-      decimals,
-      recipient,
-      binanceProvider,
-      method,
-      memo
-    );
-    return { hash };
+    throw Error('raw transfer is not null for cosmos transactions');
   }
 }

--- a/wallets/provider-xdefi/src/helpers.ts
+++ b/wallets/provider-xdefi/src/helpers.ts
@@ -27,9 +27,6 @@ export function xdefi() {
   if (xfi.bitcoincash) {
     instances.set(Networks.BCH, xfi.bitcoincash);
   }
-  if (xfi.binance) {
-    instances.set(Networks.BINANCE, xfi.binance);
-  }
   if (xfi.ethereum) {
     instances.set(Networks.ETHEREUM, xfi.ethereum);
   }
@@ -64,8 +61,13 @@ export async function getNonEvmAccounts(
   const nonEvmNetworks = SUPPORTED_NETWORKS.filter(
     (net: Network) => net !== Networks.ETHEREUM
   );
-  const promises: Promise<ProviderConnectResult>[] = nonEvmNetworks.map(
-    async (network: Network) => {
+  const promises: Promise<ProviderConnectResult>[] = nonEvmNetworks
+    .filter(
+      (network: Network) =>
+        // Ensure the instance is defined
+        instances.get(network) !== undefined
+    )
+    .map(async (network: Network) => {
       return new Promise((resolve, reject) => {
         const instance = instances.get(network);
         instance.request(
@@ -88,8 +90,7 @@ export async function getNonEvmAccounts(
           }
         );
       });
-    }
-  );
+    });
 
   const results = await Promise.all(promises);
 
@@ -113,7 +114,6 @@ export async function xdefiTransfer(
       from: from,
       amount: { amount: amount, decimals: decimals },
       memo: memo,
-      // recipient: to,
     } as any;
     if (recipientAddress) {
       params.recipient = recipientAddress;

--- a/wallets/shared/src/rango.ts
+++ b/wallets/shared/src/rango.ts
@@ -147,7 +147,6 @@ export const XDEFI_WALLET_SUPPORTED_NATIVE_CHAINS: string[] = [
   Networks.LTC,
   Networks.THORCHAIN,
   Networks.BCH,
-  Networks.BINANCE,
   Networks.MAYA,
   Networks.DOGE,
 ];


### PR DESCRIPTION
# Summary


RF-1900: Bep2 network is deprecated. We should deprecate supporting it gradually. I've removed its supprot in XDEFI wallet.

# How did you test this change?

- [x] By testing XDefi, Exodus and Taho


# Checklist:

- [x] I have performed a self-review of my code
