### PR TITLE
chore: remove ledgerhq dependencies from internal packages

### DIFF
--- a/wallets/provider-ledger/package.json
+++ b/wallets/provider-ledger/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-ledger --external-all-except @ledgerhq/errors,@ledgerhq/hw-app-eth,@ledgerhq/hw-app-solana,@ledgerhq/hw-transport-webhid,@ledgerhq/types-cryptoassets,@ledgerhq/types-devices,",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-ledger",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
# Summary

Making ledgerhq dependencies internal made bundle size to increase about 2MBs. So we decided to remove them from internal packages.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
