### PR TITLE
perf: enable code splitting in build process

### DIFF
--- a/scripts/build/command.mjs
+++ b/scripts/build/command.mjs
@@ -24,6 +24,8 @@ async function run() {
     // When you want to make all the packages external, and only include some specific packages as your library bundle, this will be usefull.
     // Comma separated.
     { name: 'external-all-except', type: String },
+    // Enable code splitting
+    { name: 'splitting', type: Boolean },
   ];
 
   const {
@@ -31,6 +33,7 @@ async function run() {
     inputs,
     external,
     'external-all-except': externalAllExcept,
+    splitting,
   } = commandLineArgs(optionDefinitions);
 
   if (!path) {
@@ -84,6 +87,7 @@ async function run() {
   const esbuildTask = esbuild.build({
     bundle: true,
     minify: true,
+    splitting: !!splitting,
     keepNames: true,
     sourcemap: true,
     platform: 'browser',

--- a/wallets/provider-coin98/package.json
+++ b/wallets/provider-coin98/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-coin98",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-coin98 --splitting",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/provider-ledger/package.json
+++ b/wallets/provider-ledger/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-ledger --external-all-except @ledgerhq/errors,@ledgerhq/hw-app-eth,@ledgerhq/hw-app-solana,@ledgerhq/hw-transport-webhid,@ledgerhq/types-cryptoassets,@ledgerhq/types-devices,",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-ledger --splitting --external-all-except @ledgerhq/errors,@ledgerhq/hw-app-eth,@ledgerhq/hw-app-solana,@ledgerhq/hw-transport-webhid,@ledgerhq/types-cryptoassets,@ledgerhq/types-devices,",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/provider-math-wallet/package.json
+++ b/wallets/provider-math-wallet/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-math-wallet",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-math-wallet --splitting",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/provider-safe/package.json
+++ b/wallets/provider-safe/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-safe",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-safe --splitting",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/provider-solflare-snap/package.json
+++ b/wallets/provider-solflare-snap/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-solflare-snap",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-solflare-snap --splitting",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/provider-solflare/package.json
+++ b/wallets/provider-solflare/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-solflare",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-solflare --splitting",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/provider-trezor/package.json
+++ b/wallets/provider-trezor/package.json
@@ -17,7 +17,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-trezor",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-trezor --splitting",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/provider-walletconnect-2/package.json
+++ b/wallets/provider-walletconnect-2/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-walletconnect-2 --external-all-except @walletconnect/modal",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-walletconnect-2 --splitting --external-all-except @walletconnect/modal",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/provider-xdefi/package.json
+++ b/wallets/provider-xdefi/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-xdefi",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-xdefi --splitting",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",


### PR DESCRIPTION
# Summary

Enabled code splitting in build options of esbuild. Code splitting is still a work in progress in [esbuild docs](https://esbuild.github.io/api/#splitting) because it only works with `esm` output format (which we currently use) and it has a [known ordering issue](https://github.com/evanw/esbuild/issues/399). I'm not sure if we may encounter that issue but the is a [workaround](https://github.com/evanw/esbuild/issues/399#issuecomment-1458680887) introduced to prevent that. You can follow [the tracking issue](https://github.com/evanw/esbuild/issues/16) for updates about this feature. 

After applying this change and testing it through linking `widget-embedded` package in `app` repo, I observed that bundle size is reduced to 1.4MBs.

![image](https://github.com/user-attachments/assets/87b772fc-fafa-492c-bbde-12bb648c33b1)


Fixes # 1905


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
