### PR TITLE
fix: resolve issues with the `signMessage` method for certain `Solana`

### DIFF
--- a/signers/signer-solana/src/signer.ts
+++ b/signers/signer-solana/src/signer.ts
@@ -7,16 +7,20 @@ import { SignerError, SignerErrorCode } from 'rango-types';
 import { executeSolanaTransaction } from './utils/main.js';
 
 export class DefaultSolanaSigner implements GenericSigner<SolanaTransaction> {
-  private provider: SolanaExternalProvider;
+  private _provider: SolanaExternalProvider;
 
   constructor(provider: SolanaExternalProvider) {
-    this.provider = provider;
+    this._provider = provider;
+  }
+
+  get provider(): SolanaExternalProvider {
+    return this._provider;
   }
 
   async signMessage(msg: string): Promise<string> {
     try {
       const encodedMessage = new TextEncoder().encode(msg);
-      const { signature } = await this.provider.request({
+      const { signature } = await this._provider.request({
         method: 'signMessage',
         params: {
           message: encodedMessage,
@@ -29,7 +33,7 @@ export class DefaultSolanaSigner implements GenericSigner<SolanaTransaction> {
   }
 
   async signAndSendTx(tx: SolanaTransaction): Promise<{ hash: string }> {
-    const hash = await executeSolanaTransaction(tx, this.provider);
+    const hash = await executeSolanaTransaction(tx, this._provider);
     return { hash };
   }
 }

--- a/signers/signer-solana/src/utils/types.ts
+++ b/signers/signer-solana/src/utils/types.ts
@@ -30,7 +30,7 @@ export interface SolanaExternalProvider {
     transaction: T,
     options?: SendOptions
   ): Promise<{ signature: TransactionSignature }>;
-  signMessage(message: Uint8Array): Promise<{ signature: Uint8Array }>;
+  signMessage(message: Uint8Array | string): Promise<{ signature: Uint8Array }>;
   request(...args: any[]): Promise<any>;
   connect(...args: any[]): Promise<any>;
   disconnect(): Promise<void>;

--- a/wallets/provider-brave/src/signer.ts
+++ b/wallets/provider-brave/src/signer.ts
@@ -10,8 +10,8 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
+  const { CustomSolanaSigner } = await import('./solana-signer.js');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
-  signers.registerSigner(TxType.SOLANA, new DefaultSolanaSigner(solProvider));
+  signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;
 }

--- a/wallets/provider-brave/src/solana-signer.ts
+++ b/wallets/provider-brave/src/solana-signer.ts
@@ -1,0 +1,26 @@
+import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
+import { SignerError, SignerErrorCode } from 'rango-types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SolanaExternalProvider = any;
+
+export class CustomSolanaSigner extends DefaultSolanaSigner {
+  constructor(provider: SolanaExternalProvider) {
+    super(provider);
+  }
+
+  async signMessage(msg: string): Promise<string> {
+    try {
+      const encodedMessage = new TextEncoder().encode(msg);
+      const { signature } = await this.provider.request({
+        method: 'signMessage',
+        params: {
+          message: encodedMessage,
+        },
+      });
+      return signature;
+    } catch (error) {
+      throw new SignerError(SignerErrorCode.SIGN_TX_ERROR, undefined, error);
+    }
+  }
+}

--- a/wallets/provider-clover/package.json
+++ b/wallets/provider-clover/package.json
@@ -24,6 +24,7 @@
     "@rango-dev/signer-evm": "^0.30.0",
     "@rango-dev/signer-solana": "^0.32.1-next.0",
     "@rango-dev/wallets-shared": "^0.37.1-next.3",
+    "bs58": "^5.0.0",
     "rango-types": "^0.1.69"
   },
   "publishConfig": {

--- a/wallets/provider-clover/src/signer.ts
+++ b/wallets/provider-clover/src/signer.ts
@@ -10,8 +10,8 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
+  const { CustomSolanaSigner } = await import('./solana-signer.js');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
-  signers.registerSigner(TxType.SOLANA, new DefaultSolanaSigner(solProvider));
+  signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;
 }

--- a/wallets/provider-clover/src/solana-signer.ts
+++ b/wallets/provider-clover/src/solana-signer.ts
@@ -1,0 +1,17 @@
+import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
+import base58 from 'bs58';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SolanaExternalProvider = any;
+
+export class CustomSolanaSigner extends DefaultSolanaSigner {
+  constructor(provider: SolanaExternalProvider) {
+    super(provider);
+  }
+
+  async signMessage(msg: string): Promise<string> {
+    const encodedMessage = new TextEncoder().encode(msg);
+    const { signature } = await this.provider.signMessage(encodedMessage);
+    return base58.encode(signature);
+  }
+}

--- a/wallets/provider-coinbase/package.json
+++ b/wallets/provider-coinbase/package.json
@@ -24,6 +24,7 @@
     "@rango-dev/signer-evm": "^0.30.0",
     "@rango-dev/signer-solana": "^0.32.1-next.0",
     "@rango-dev/wallets-shared": "^0.37.1-next.3",
+    "bs58": "^5.0.0",
     "rango-types": "^0.1.69"
   },
   "publishConfig": {

--- a/wallets/provider-coinbase/src/signer.ts
+++ b/wallets/provider-coinbase/src/signer.ts
@@ -10,8 +10,8 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
+  const { CustomSolanaSigner } = await import('./solana-signer.js');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
-  signers.registerSigner(TxType.SOLANA, new DefaultSolanaSigner(solProvider));
+  signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;
 }

--- a/wallets/provider-coinbase/src/solana-signer.ts
+++ b/wallets/provider-coinbase/src/solana-signer.ts
@@ -1,0 +1,16 @@
+import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
+import base58 from 'bs58';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SolanaExternalProvider = any;
+
+export class CustomSolanaSigner extends DefaultSolanaSigner {
+  constructor(provider: SolanaExternalProvider) {
+    super(provider);
+  }
+
+  async signMessage(msg: string): Promise<string> {
+    const { signature } = await this.provider.signMessage(msg);
+    return base58.encode(signature);
+  }
+}

--- a/wallets/provider-exodus/package.json
+++ b/wallets/provider-exodus/package.json
@@ -24,6 +24,7 @@
     "@rango-dev/signer-evm": "^0.30.0",
     "@rango-dev/signer-solana": "^0.32.1-next.0",
     "@rango-dev/wallets-shared": "^0.37.1-next.3",
+    "bs58": "^5.0.0",
     "rango-types": "^0.1.69"
   },
   "publishConfig": {

--- a/wallets/provider-exodus/src/signer.ts
+++ b/wallets/provider-exodus/src/signer.ts
@@ -10,8 +10,8 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
+  const { CustomSolanaSigner } = await import('./solana-signer.js');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
-  signers.registerSigner(TxType.COSMOS, new DefaultSolanaSigner(solProvider));
+  signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;
 }

--- a/wallets/provider-exodus/src/solana-signer.ts
+++ b/wallets/provider-exodus/src/solana-signer.ts
@@ -1,0 +1,16 @@
+import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
+import base58 from 'bs58';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SolanaExternalProvider = any;
+
+export class CustomSolanaSigner extends DefaultSolanaSigner {
+  constructor(provider: SolanaExternalProvider) {
+    super(provider);
+  }
+
+  async signMessage(msg: string): Promise<string> {
+    const { signature } = await this.provider.signMessage(msg);
+    return base58.encode(signature);
+  }
+}

--- a/wallets/provider-okx/src/signer.ts
+++ b/wallets/provider-okx/src/signer.ts
@@ -10,8 +10,8 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
+  const { CustomSolanaSigner } = await import('./solana-signer.js');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
-  signers.registerSigner(TxType.SOLANA, new DefaultSolanaSigner(solProvider));
+  signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;
 }

--- a/wallets/provider-okx/src/solana-signer.ts
+++ b/wallets/provider-okx/src/solana-signer.ts
@@ -1,0 +1,25 @@
+import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
+import { SignerError, SignerErrorCode } from 'rango-types';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SolanaExternalProvider = any;
+
+export class CustomSolanaSigner extends DefaultSolanaSigner {
+  constructor(provider: SolanaExternalProvider) {
+    super(provider);
+  }
+
+  async signMessage(msg: string): Promise<string> {
+    try {
+      const { signature } = await this.provider.request({
+        method: 'signMessage',
+        params: {
+          message: msg,
+        },
+      });
+      return signature;
+    } catch (error) {
+      throw new SignerError(SignerErrorCode.SIGN_TX_ERROR, undefined, error);
+    }
+  }
+}

--- a/wallets/provider-xdefi/package.json
+++ b/wallets/provider-xdefi/package.json
@@ -25,6 +25,7 @@
     "@rango-dev/signer-evm": "^0.30.0",
     "@rango-dev/signer-solana": "^0.32.1-next.0",
     "@rango-dev/wallets-shared": "^0.37.1-next.3",
+    "bs58": "^5.0.0",
     "rango-types": "^0.1.69"
   },
   "publishConfig": {

--- a/wallets/provider-xdefi/src/signer.ts
+++ b/wallets/provider-xdefi/src/signer.ts
@@ -11,12 +11,12 @@ export default async function getSigners(
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
+  const { CustomSolanaSigner } = await import('./solana-signer.js');
   const { CustomCosmosSigner } = await import('./cosmos-signer.js');
   const { CustomTransferSigner } = await import('./utxo-signer.js');
 
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
-  signers.registerSigner(TxType.SOLANA, new DefaultSolanaSigner(solProvider));
+  signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   // passed provider for transfer as it comprises several signers
   signers.registerSigner(TxType.COSMOS, new CustomCosmosSigner(provider));
   // passed provider for transfer as it comprises several signers

--- a/wallets/provider-xdefi/src/solana-signer.ts
+++ b/wallets/provider-xdefi/src/solana-signer.ts
@@ -1,0 +1,17 @@
+import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
+import base58 from 'bs58';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SolanaExternalProvider = any;
+
+export class CustomSolanaSigner extends DefaultSolanaSigner {
+  constructor(provider: SolanaExternalProvider) {
+    super(provider);
+  }
+
+  async signMessage(msg: string): Promise<string> {
+    const encodedMessage = new TextEncoder().encode(msg);
+    const { signature } = await this.provider.signMessage(encodedMessage);
+    return base58.encode(signature);
+  }
+}


### PR DESCRIPTION
# Summary

Some Solana providers use the default `Solana signer`, but when testing the `signMessage` method, it either throws an error or doesn't function correctly

# How did you test this change?

You can test this by running the `yarn dev:wallets` command and using the `signMessage` method in the `wallets-demo` UI. The `signMessage` method for the `Coinbase` provider doesn’t work correctly on localhost. To test it, you can copy and paste the code into the console on the live production site.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
