### PR TITLE
feat: add id property to buttons

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,8 @@
     "import",
     "react",
     "react-hooks",
-    "destructuring"
+    "destructuring",
+    "jsx-id-attribute-enforcement"
   ],
   "extends": [
     "eslint:recommended",
@@ -107,7 +108,14 @@
     "@typescript-eslint/no-unnecessary-type-assertion": "error",
     "@typescript-eslint/prefer-enum-initializers": "error",
     "@typescript-eslint/promise-function-async": "error",
-    "@typescript-eslint/switch-exhaustiveness-check": "error"
+    "@typescript-eslint/switch-exhaustiveness-check": "error",
+    "jsx-id-attribute-enforcement/missing-ids": [
+      "error",
+      {
+        "targetCustom": ["Button", "IconButton"]
+      }
+    ]
+
     // "@typescript-eslint/explicit-function-return-type": "error",
     // "@typescript-eslint/naming-convention": [
     //   "error",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-destructuring": "^2.2.1",
     "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jsx-id-attribute-enforcement": "^1.0.2",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/widget/embedded/src/components/BlockchainList/BlockchainList.tsx
+++ b/widget/embedded/src/components/BlockchainList/BlockchainList.tsx
@@ -48,6 +48,7 @@ export function BlockchainList(props: PropTypes) {
         {blockchains.map((item) => (
           <ListItemButton
             key={`${item.name}-${item.chainId}`}
+            className={`widget-blockchain-list-item-btn`}
             hasDivider
             onClick={() => onChange(item)}
             start={<Image src={item.logo} size={30} />}
@@ -56,7 +57,7 @@ export function BlockchainList(props: PropTypes) {
                 {item.displayName}
               </Typography>
             }
-            id={item.chainId as string}
+            id={item.name}
           />
         ))}
       </List>

--- a/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
@@ -331,6 +331,7 @@ export function ConfirmWalletsModal(props: PropTypes) {
         footer: (
           <ConfirmButton>
             <Button
+              id="widget-confirm-wallet-modal-confirm-btn"
               loading={loading}
               disabled={isConfirmSwapDisabled(
                 loading,
@@ -355,6 +356,7 @@ export function ConfirmWalletsModal(props: PropTypes) {
         header: (
           <ShowMoreHeader>
             <NavigateBack
+              id="widget-confirm-wallet-modal-navigate-back-icon-btn"
               variant="ghost"
               onClick={setShowMoreWalletFor.bind(null, '')}>
               <ChevronLeftIcon size={16} />
@@ -383,6 +385,7 @@ export function ConfirmWalletsModal(props: PropTypes) {
           type="error"
           description={<BalanceErrors messages={balanceWarnings ?? []} />}>
           <Button
+            id="widget-confirm-wallet-modal-proceed-anyway-btn"
             variant="outlined"
             size="large"
             type="primary"

--- a/widget/embedded/src/components/CustomDestination/CustomDestination.tsx
+++ b/widget/embedded/src/components/CustomDestination/CustomDestination.tsx
@@ -63,13 +63,19 @@ export function CustomDestination(props: PropTypes) {
   const renderSuffix = () => {
     if (customDestination) {
       return (
-        <IconButton onClick={handleClear} variant="ghost">
+        <IconButton
+          id="widget-custom-destination-close-icon-btn"
+          onClick={handleClear}
+          variant="ghost">
           <CloseIcon size={12} color="gray" />
         </IconButton>
       );
     } else if (!isFirefox) {
       return (
-        <IconButton onClick={handlePaste} variant="ghost">
+        <IconButton
+          id="widget-custom-destination-paste-icon-btn"
+          onClick={handlePaste}
+          variant="ghost">
           <PasteIcon size={16} />
         </IconButton>
       );

--- a/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.tsx
+++ b/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.tsx
@@ -80,6 +80,7 @@ export function CustomTokenModal(props: PropTypes) {
       <Divider size={10} />
 
       <Button
+        id="widget-custom-token-modal-import-btn"
         variant="contained"
         size="large"
         type="primary"

--- a/widget/embedded/src/components/FilterSelector/FilterSelector.tsx
+++ b/widget/embedded/src/components/FilterSelector/FilterSelector.tsx
@@ -28,6 +28,7 @@ export function FilterSelector(props: FilterSelectorPropTypes) {
           />
         }>
         <FilterButton
+          id="widget-filter-selector-filter-icon-btn"
           variant="default"
           isSelect={!!filterBy}
           onClick={() => onOpenChange(!props.open)}>

--- a/widget/embedded/src/components/FilterSelector/FilterSelectorContent.tsx
+++ b/widget/embedded/src/components/FilterSelector/FilterSelectorContent.tsx
@@ -25,7 +25,11 @@ export function FilterSelectorContent(props: PropTypes) {
         <Typography size="small" variant="body">
           {i18n.t('Status')}
         </Typography>
-        <Button variant="ghost" size="xxsmall" onClick={() => onClickItem('')}>
+        <Button
+          id="widget-filter-selector-reset-btn"
+          variant="ghost"
+          size="xxsmall"
+          onClick={() => onClickItem('')}>
           {i18n.t('Reset')}
         </Button>
       </div>

--- a/widget/embedded/src/components/HeaderButtons/BackButton.tsx
+++ b/widget/embedded/src/components/HeaderButtons/BackButton.tsx
@@ -7,7 +7,11 @@ import { HeaderButton } from './HeaderButtons.styles';
 
 function BackButton(props: PropTypes) {
   return (
-    <HeaderButton variant="ghost" size="small" onClick={props.onClick}>
+    <HeaderButton
+      id="widget-header-back-icon-btn"
+      variant="ghost"
+      size="small"
+      onClick={props.onClick}>
       <ChevronLeftIcon color="black" size={16} />
     </HeaderButton>
   );

--- a/widget/embedded/src/components/HeaderButtons/CancelButton.tsx
+++ b/widget/embedded/src/components/HeaderButtons/CancelButton.tsx
@@ -9,7 +9,11 @@ import { SuffixContainer } from './HeaderButtons.styles';
 function CancelButton(props: PropTypes) {
   return (
     <SuffixContainer>
-      <Button variant="ghost" onClick={props.onClick} size="xsmall">
+      <Button
+        id="widget-header-cancel-btn"
+        variant="ghost"
+        onClick={props.onClick}
+        size="xsmall">
         <Typography variant="label" size="medium" color="error500">
           {i18n.t('Cancel')}
         </Typography>

--- a/widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx
+++ b/widget/embedded/src/components/HeaderButtons/HeaderButtons.tsx
@@ -61,7 +61,10 @@ export function HeaderButtons(props: HeaderButtonsPropTypes) {
               container={getContainer()}
               side="top"
               content={i18n.t('Notifications')}>
-              <HeaderButton size="small" variant="ghost">
+              <HeaderButton
+                id="widget-header-notification-icon-btn"
+                size="small"
+                variant="ghost">
                 <NotificationsIcon size={18} color="black" />
                 <NotificationsBadge />
               </HeaderButton>
@@ -74,7 +77,11 @@ export function HeaderButtons(props: HeaderButtonsPropTypes) {
           container={getContainer()}
           side="top"
           content={i18n.t('Settings')}>
-          <HeaderButton size="small" variant="ghost" onClick={onClickSettings}>
+          <HeaderButton
+            id="widget-header-setting-icon-btn"
+            size="small"
+            variant="ghost"
+            onClick={onClickSettings}>
             <SettingsIcon size={18} color="black" />
           </HeaderButton>
         </Tooltip>
@@ -84,7 +91,11 @@ export function HeaderButtons(props: HeaderButtonsPropTypes) {
           container={getContainer()}
           side="top"
           content={i18n.t('History')}>
-          <HeaderButton size="small" variant="ghost" onClick={onClickHistory}>
+          <HeaderButton
+            id="widget-header-history-icon-btn"
+            size="small"
+            variant="ghost"
+            onClick={onClickHistory}>
             <TransactionIcon size={18} color="black" />
             <InProgressTransactionBadge />
           </HeaderButton>

--- a/widget/embedded/src/components/HeaderButtons/RefreshButton.tsx
+++ b/widget/embedded/src/components/HeaderButtons/RefreshButton.tsx
@@ -61,6 +61,7 @@ function RefreshButton({ onClick }: { onClick: (() => void) | undefined }) {
 
   return (
     <HeaderButton
+      id="widget-header-refresh-icon-btn"
       variant="ghost"
       size="small"
       style={{ paddingTop: 0, paddingBottom: 0 }}

--- a/widget/embedded/src/components/HeaderButtons/WalletButton.tsx
+++ b/widget/embedded/src/components/HeaderButtons/WalletButton.tsx
@@ -32,7 +32,11 @@ function WalletButton(props: PropTypes) {
 
   return (
     <Tooltip container={props.container} side="bottom" content={content}>
-      <HeaderButton variant="ghost" size="small" onClick={props.onClick}>
+      <HeaderButton
+        id="widget-header-wallet-icon-btn"
+        variant="ghost"
+        size="small"
+        onClick={props.onClick}>
         {props.isConnected && <ConnectedIcon />}
         <WalletIcon size={18} color="black" />
       </HeaderButton>

--- a/widget/embedded/src/components/NoResult/NoResult.tsx
+++ b/widget/embedded/src/components/NoResult/NoResult.tsx
@@ -68,6 +68,7 @@ export function NoResult(props: PropTypes) {
               info.alert.action && (
                 <Button
                   size="xsmall"
+                  id="widget-no-result-alert-btn"
                   type={info.alert.type}
                   prefix={
                     <PrefixIcon>

--- a/widget/embedded/src/components/Quote/QuoteCostDetails.tsx
+++ b/widget/embedded/src/components/Quote/QuoteCostDetails.tsx
@@ -91,7 +91,10 @@ export function QuoteCostDetails(props: QuoteCostDetailsProps) {
               {i18n.t('Gas & Fee Explanation')}
             </Typography>
 
-            <IconButton onClick={() => setOpen(false)} variant="ghost">
+            <IconButton
+              id="widget-quote-cost-details-modal-close-icon-btn"
+              onClick={() => setOpen(false)}
+              variant="ghost">
               <CloseIcon color="gray" size={14} />
             </IconButton>
           </ModalHeader>

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx
@@ -78,6 +78,7 @@ export function HighValueLossWarningModal(props: Props) {
     <WatermarkedModal
       footer={
         <Button
+          id="widget-high-value-loss-warning-modal-confirm-btn"
           type="primary"
           size="large"
           prefix={<WarningIcon />}

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.tsx
@@ -71,6 +71,7 @@ export function QuoteWarningsAndErrors(props: PropTypes) {
             {...(alertInfo.action === 'change-settings' && {
               action: (
                 <Button
+                  id="widget-quote-warning-error-change-settings-btn"
                   size="xxsmall"
                   type={alertInfo.alertType}
                   onClick={onChangeSettings}>

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx
@@ -35,6 +35,7 @@ export function SlippageWarningModal(props: PropsTypes) {
       prefix={
         <Button
           size="small"
+          id="widget-slippage-warning-modal-change-settings-btn"
           variant="ghost"
           onClick={() => navigate('../' + navigationRoutes.settings)}>
           <Typography variant="label" size="medium" color="$neutral900">
@@ -67,6 +68,7 @@ export function SlippageWarningModal(props: PropsTypes) {
         <Divider size={18} />
         <Divider size={32} />
         <Button
+          id="widget-slippage-warning-modal-confirm-anyway-btn"
           size="large"
           type="primary"
           variant="contained"

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/UnknownPriceWarningModal.tsx
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/UnknownPriceWarningModal.tsx
@@ -21,6 +21,7 @@ export function UnknownPriceWarningModal(props: Props) {
     <WatermarkedModal
       footer={
         <Button
+          id="widget-unknown-price-warning-modal-confirm-btn"
           type="primary"
           size="large"
           prefix={<WarningIcon />}

--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -272,6 +272,7 @@ export function SwapDetails(props: SwapDetailsProps) {
         suffix: swap.status !== 'running' && (
           <SuffixContainer>
             <Button
+              id="widget-swap-details-delete-btn"
               variant="ghost"
               type="error"
               size="xsmall"
@@ -288,6 +289,7 @@ export function SwapDetails(props: SwapDetailsProps) {
         !showCompletedModal && (
           <Button
             fullWidth
+            id="widget-swap-details-try-again-btn"
             variant="contained"
             type="primary"
             size="large"
@@ -325,6 +327,7 @@ export function SwapDetails(props: SwapDetailsProps) {
                 alignOffset={-16}
                 align="end">
                 <IconButton
+                  id="widget-swap-details-done-copy-icon-btn"
                   variant="ghost"
                   onClick={handleCopy.bind(null, requestId || '')}>
                   {isCopied ? (

--- a/widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx
+++ b/widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx
@@ -14,6 +14,7 @@ export function WarningAlert(props: WaningAlertsProps) {
         title={message.shortMessage}
         action={
           <Button
+            id="widget-swap-details-warning-alert-change-network-btn"
             size="xxsmall"
             type="warning"
             onClick={() => {
@@ -37,6 +38,7 @@ export function WarningAlert(props: WaningAlertsProps) {
         title={message.shortMessage}
         action={
           <Button
+            id="widget-swap-details-warning-alert-connect-wallet-btn"
             size="xxsmall"
             type="warning"
             onClick={() => {

--- a/widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx
+++ b/widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx
@@ -53,6 +53,7 @@ export function SwapDetailsAlerts(props: SwapAlertsProps) {
               action={
                 explorerUrl.url && (
                   <IconButton
+                    id="widget-swap-details-tx-link-icon-btn"
                     variant="ghost"
                     size="xsmall"
                     onClick={() => window.open(explorerUrl.url, '_blank')}>

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx
@@ -75,6 +75,7 @@ export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
       <Divider size={32} />
       {status === 'success' && (
         <Button
+          id="widget-swap-details-modal-done-btn"
           variant="contained"
           type="primary"
           size="large"
@@ -92,6 +93,7 @@ export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
         <>
           <Button
             variant="contained"
+            id="widget-swap-detail-modal-diagnosis-btn"
             type="primary"
             size="large"
             onClick={() => window.open(diagnosisUrl, '_blank')}>
@@ -100,7 +102,12 @@ export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
           <Divider size={12} />
         </>
       )}
-      <Button variant="outlined" type="primary" size="large" onClick={onClose}>
+      <Button
+        id="widget-swap-details-modal-see-details-btn"
+        variant="outlined"
+        type="primary"
+        size="large"
+        onClick={onClose}>
         <Typography variant="title" size="medium" color="primary">
           {i18n.t('See Details')}
         </Typography>

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Cancel.tsx
@@ -16,13 +16,19 @@ export const CancelContent = ({ onCancel, onClose }: CancelContentProps) => {
       <Divider size={32} />
       <Button
         variant="contained"
+        id="widget-swap-details-modal-cancel-swap-yes-btn"
         type="primary"
         size="large"
         onClick={onCancel}>
         {i18n.t('Yes, Cancel it')}
       </Button>
       <Divider size={12} />
-      <Button variant="outlined" type="primary" size="large" onClick={onClose}>
+      <Button
+        id="widget-swap-details-modal-cancel-swap-no-btn"
+        variant="outlined"
+        type="primary"
+        size="large"
+        onClick={onClose}>
         {i18n.t('No, Continue')}
       </Button>
     </>

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.Delete.tsx
@@ -15,6 +15,7 @@ export const DeleteContent = ({ onDelete, onClose }: DeleteContentProps) => {
       />
       <Divider size={32} />
       <Button
+        id="widget-swap-details-modal-delete-swap-yes-btn"
         variant="contained"
         type="primary"
         size="large"
@@ -22,7 +23,12 @@ export const DeleteContent = ({ onDelete, onClose }: DeleteContentProps) => {
         {i18n.t('Yes, Delete it')}
       </Button>
       <Divider size={12} />
-      <Button variant="outlined" type="primary" size="large" onClick={onClose}>
+      <Button
+        id="widget-swap-details-modal-delete-swap-no-btn"
+        variant="outlined"
+        type="primary"
+        size="large"
+        onClick={onClose}>
         <Typography variant="title" size="medium" color="primary">
           {i18n.t('No, Cancel')}
         </Typography>

--- a/widget/embedded/src/components/TokenList/TokenList.tsx
+++ b/widget/embedded/src/components/TokenList/TokenList.tsx
@@ -202,6 +202,7 @@ export function TokenList(props: PropTypes) {
                 tab-index={index}
                 key={`${token.symbol}${token.address}`}
                 id={`${token.symbol}${token.address}`}
+                className={`widget-token-list-item-btn`}
                 hasDivider
                 onClick={() => onChange && onChange(tokens[index])}
                 start={

--- a/widget/embedded/src/components/WalletStatefulConnect/DerivationPath.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/DerivationPath.tsx
@@ -143,6 +143,7 @@ export function DerivationPath(props: PropTypes) {
       </InputsContainer>
 
       <Button
+        id="widget-derivation-path-confirm-btn"
         type="primary"
         onClick={handleConfirm}
         disabled={

--- a/widget/embedded/src/components/WalletStatefulConnect/ExperimentalChain.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/ExperimentalChain.tsx
@@ -24,6 +24,7 @@ export function ExperimentalChain(props: PropTypes) {
       <Divider size={18} />
       <Divider size={32} />
       <Button
+        id="widget-experimental-chain-confirm-btn"
         onClick={onConfirm}
         variant="outlined"
         type="primary"

--- a/widget/embedded/src/components/WalletStatefulConnect/Namespaces.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Namespaces.tsx
@@ -109,6 +109,7 @@ export function Namespaces(props: PropTypes) {
         )}
       </NamespaceList>
       <Button
+        id="widget-name-space-confirm-btn"
         type="primary"
         disabled={!selectedNamespaces.length}
         onClick={() => props.onConfirm(selectedNamespaces)}>

--- a/widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx
+++ b/widget/embedded/src/components/common/ActivateTabAlert/ActivateTabAlert.tsx
@@ -9,6 +9,7 @@ export function ActivateTabAlert(props: PropTypes) {
     <Alert
       action={
         <Button
+          id="widget-active-tab-btn"
           onClick={props.onActivateTab}
           variant="contained"
           size="xxsmall"

--- a/widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx
+++ b/widget/embedded/src/components/common/ActivateTabModal/ActivateTabModal.tsx
@@ -24,6 +24,7 @@ export function ActivateTabModal(props: PropTypes) {
         )}>
         <Divider size={20} />
         <Button
+          id="widget-modal-confirm-activate-tab-btn"
           variant="contained"
           size="large"
           type="primary"

--- a/widget/embedded/src/containers/Settings/Lists.tsx
+++ b/widget/embedded/src/containers/Settings/Lists.tsx
@@ -150,7 +150,7 @@ export function SettingsLists() {
   };
 
   const bridgeItem = {
-    id: 'bridge-item',
+    id: 'widget-setting-bridge-item-btn',
     title: (
       <Typography variant="title" size="xmedium">
         {i18n.t('Bridges')}
@@ -168,7 +168,7 @@ export function SettingsLists() {
   };
 
   const exchangeItem = {
-    id: 'exchange-item',
+    id: 'widget-setting-exchange-item-btn',
     title: (
       <Typography variant="title" size="xmedium">
         {i18n.t('Exchanges')}
@@ -189,7 +189,7 @@ export function SettingsLists() {
   };
 
   const customTokensItem = {
-    id: 'custom-tokens-item',
+    id: 'widget-setting-custom-tokens-item-btn',
     title: (
       <Typography variant="title" size="xmedium">
         {i18n.t('Custom Tokens')}
@@ -208,7 +208,7 @@ export function SettingsLists() {
     onClick: () => navigate(navigationRoutes.customTokens),
   };
   const languageItem = {
-    id: 'language-item',
+    id: 'widget-setting-language-item-btn',
     title: (
       <Typography variant="title" size="xmedium">
         {i18n.t('Language')}
@@ -228,7 +228,7 @@ export function SettingsLists() {
   };
 
   const infiniteApprovalItem = {
-    id: 'infinite-approval-item',
+    id: 'widget-setting-infinite-approval-item-btn',
     title: (
       <>
         <Typography variant="title" size="xmedium">
@@ -259,7 +259,7 @@ export function SettingsLists() {
   };
 
   const themeItem = {
-    id: 'theme-item',
+    id: 'widget-setting-theme-item-btn',
     type: <ListItem />,
     title: (
       <Typography variant="title" size="xmedium">

--- a/widget/embedded/src/pages/AddCustomTokenPage.tsx
+++ b/widget/embedded/src/pages/AddCustomTokenPage.tsx
@@ -154,6 +154,7 @@ export function AddCustomTokenPage() {
           </div>
 
           <Button
+            id="widget-add-custom-token-import-btn"
             disabled={isImportDisabled}
             type="primary"
             variant="contained"
@@ -176,8 +177,11 @@ export function AddCustomTokenPage() {
             }>
             <Divider size={40} />
             <Divider size={10} />
-
+            {/* eslint-disable-next-line jsx-id-attribute-enforcement/missing-ids */}
             <Button
+              id={`widget-add-custom-token-${
+                networkError ? 'retry' : 'add-another'
+              }-btn`}
               variant="contained"
               size="large"
               type="primary"

--- a/widget/embedded/src/pages/ConfirmSwapPage.tsx
+++ b/widget/embedded/src/pages/ConfirmSwapPage.tsx
@@ -243,6 +243,7 @@ export function ConfirmSwapPage() {
         <Buttons>
           <div className={confirmBtnStyles()}>
             <Button
+              id="widget-confirm-swap-start-btn"
               variant="contained"
               type="primary"
               size="large"
@@ -254,6 +255,7 @@ export function ConfirmSwapPage() {
             </Button>
           </div>
           <IconButton
+            id="widget-confirm-swap-wallet-icon-btn"
             variant="contained"
             type="primary"
             size="large"

--- a/widget/embedded/src/pages/CustomTokensPage.tsx
+++ b/widget/embedded/src/pages/CustomTokensPage.tsx
@@ -110,6 +110,7 @@ export function CustomTokensPage() {
                 showTitle={false}
                 action={(token) => (
                   <DeleteIconButton
+                    id="widget-custom-token-delete-icon-btn"
                     variant="ghost"
                     onClick={() => {
                       setIsDeleteModalOpen(true);
@@ -140,6 +141,7 @@ export function CustomTokensPage() {
           <Divider size={20} />
 
           <Button
+            id="widget-custom-token-add-btn"
             type="primary"
             variant="contained"
             size="large"
@@ -161,6 +163,7 @@ export function CustomTokensPage() {
 
             <Button
               fullWidth
+              id="widget-custom-token-delete-modal-yes-btn"
               variant="contained"
               type="primary"
               size="large"
@@ -169,6 +172,7 @@ export function CustomTokensPage() {
             </Button>
             <Divider size={12} />
             <Button
+              id="widget-custom-token-delete-modal-no-btn"
               fullWidth
               variant="outlined"
               type="primary"

--- a/widget/embedded/src/pages/HistoryPage.tsx
+++ b/widget/embedded/src/pages/HistoryPage.tsx
@@ -140,6 +140,7 @@ export function HistoryPage() {
         suffix: (
           <SuffixContainer>
             <Button
+              id="widget-history-clear-btn"
               disabled={isClearButtonDisabled}
               variant="ghost"
               size="xsmall"
@@ -234,6 +235,7 @@ export function HistoryPage() {
         />
         <Divider size={30} />
         <Button
+          id="widget-history-clear-modal-yes-btn"
           variant="contained"
           type="primary"
           size="large"
@@ -242,6 +244,7 @@ export function HistoryPage() {
         </Button>
         <Divider size={10} />
         <Button
+          id="widget-history-clear-modal-no-btn"
           variant="outlined"
           type="primary"
           size="large"

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -128,7 +128,9 @@ export function Home() {
       <Layout
         height="auto"
         footer={
+          // eslint-disable-next-line jsx-id-attribute-enforcement/missing-ids
           <Button
+            id={`widget-swap-${swapButtonState.action}-btn`}
             type="primary"
             size="large"
             disabled={swapButtonState.disabled || !isActiveTab}

--- a/widget/embedded/src/pages/LanguagePage.tsx
+++ b/widget/embedded/src/pages/LanguagePage.tsx
@@ -21,7 +21,7 @@ export function LanguagePage() {
   const languageList = languages.map((languageItem) => {
     const { local, label, SVGFlag } = languageItem;
     return {
-      id: local,
+      id: `widget-setting-languages-${local}-item-btn`,
       value: local,
       title: (
         <Typography variant="title" size="xmedium">

--- a/widget/embedded/src/pages/LiquiditySourcePage.tsx
+++ b/widget/embedded/src/pages/LiquiditySourcePage.tsx
@@ -68,8 +68,11 @@ export function LiquiditySourcePage({ sourceType }: PropTypes) {
   };
 
   const list = liquiditySources.map((sourceItem) => {
-    const { selected, groupTitle, logo } = sourceItem;
+    const { selected, groupTitle, logo, id, ...restSourceItem } = sourceItem;
     return {
+      id: `widget-setting-liquidity-source-${id
+        .toLowerCase()
+        .replace(/\s+/g, '-')}-item-btn`,
       start: <Image src={logo} size={22} type="circular" />,
       onClick: () => {
         if (!campaignMode) {
@@ -82,7 +85,10 @@ export function LiquiditySourcePage({ sourceType }: PropTypes) {
           {i18n.t(groupTitle)}
         </Typography>
       ),
-      ...sourceItem,
+      selected,
+      groupTitle,
+      logo,
+      ...restSourceItem,
     };
   });
 
@@ -104,7 +110,14 @@ export function LiquiditySourcePage({ sourceType }: PropTypes) {
         title: i18n.t(sourceType),
         suffix: (
           <LiquiditySourceSuffix>
-            <Button variant="ghost" size="xsmall" onClick={toggleAllSources}>
+            {/* eslint-disable-next-line jsx-id-attribute-enforcement/missing-ids */}
+            <Button
+              id={`widget-liquidity-source-${
+                hasSelectAll ? 'deselect-all' : 'select-all'
+              }-btn`}
+              variant="ghost"
+              size="xsmall"
+              onClick={toggleAllSources}>
               {hasSelectAll ? i18n.t('Deselect all') : i18n.t('Select all')}
             </Button>
           </LiquiditySourceSuffix>

--- a/widget/embedded/src/pages/SettingsPage.tsx
+++ b/widget/embedded/src/pages/SettingsPage.tsx
@@ -47,7 +47,11 @@ export function SettingsPage() {
             )}
             action={
               <ResetAction>
-                <Button type="secondary" size="small" onClick={onClick}>
+                <Button
+                  id="widget-setting-exit-campaign-mode-btn"
+                  type="secondary"
+                  size="small"
+                  onClick={onClick}>
                   {i18n.t('Reset')}
                 </Button>
               </ResetAction>

--- a/widget/ui/src/components/IconButton/IconButton.types.ts
+++ b/widget/ui/src/components/IconButton/IconButton.types.ts
@@ -2,6 +2,7 @@ import type { ButtonPropTypes } from '../Button/Button.types.js';
 import type { CSSProperties } from 'react';
 
 export type IconButtonPropTypes = {
+  id?: ButtonPropTypes['id'];
   size?: ButtonPropTypes['size'];
   type?: ButtonPropTypes['type'];
   variant?: ButtonPropTypes['variant'];

--- a/widget/ui/src/components/List/List.tsx
+++ b/widget/ui/src/components/List/List.tsx
@@ -20,7 +20,7 @@ function List(props: ListPropTypes) {
             id,
           });
         }
-        return <ListItem key={id} {...itemProps} />;
+        return <ListItem key={id} id={id} {...itemProps} />;
       })}
     </BaseList>
   );

--- a/widget/ui/src/components/ListItem/ListItem.types.ts
+++ b/widget/ui/src/components/ListItem/ListItem.types.ts
@@ -1,4 +1,5 @@
 export type ListItemPropTypes = {
+  id?: string;
   title?: string | React.ReactElement;
   description?: string | React.ReactElement;
   start?: React.ReactNode;
@@ -8,4 +9,5 @@ export type ListItemPropTypes = {
   onKeyUp?: React.KeyboardEventHandler<HTMLLIElement>;
   hasDivider?: boolean;
   tabIndex?: number;
+  className?: string;
 };

--- a/widget/ui/src/components/ListItemButton/ListItemButton.tsx
+++ b/widget/ui/src/components/ListItemButton/ListItemButton.tsx
@@ -15,6 +15,7 @@ function ListItemButton(props: ListItemButtonProps) {
   return (
     <BaseListItemButton
       onClick={onClickWithKey}
+      id={id}
       aria-label="button"
       selected={selected}
       onKeyUp={(e: { key: string }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11859,6 +11859,13 @@ eslint-plugin-import@^2.27.5:
     semver "^6.3.1"
     tsconfig-paths "^3.14.2"
 
+eslint-plugin-jsx-id-attribute-enforcement@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-id-attribute-enforcement/-/eslint-plugin-jsx-id-attribute-enforcement-1.0.2.tgz#eb72009ef1c2d150bf7466be2b1d0008fe6de61b"
+  integrity sha512-xWg5lJ+z1/+WByCdtIAepKRx8J8GAeYGw4MmlAkEfdyCpj/UMEb+FVCmEVOJbXdyvTPq8xNfhIW/43eInykHPg==
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-plugin-prettier@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
@@ -17231,6 +17238,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==
 
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
# Summary

In the cases where the **`Button`**, **`IconButton`**, and **`ListItemButton`** were used in the widget, I added the **`id`** property to them according to our agreement.

The type of **`ListItemButton`** and type of **`IconButton`** needed an **` id`** property, which I added to their type.
I also used **`jsx-id-attribute-enforcement`** plugin to force ID for **`Buttons`** and **`IconButtons`**.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
