### PR TITLE
fix: remove null memo from utxo transactions

### DIFF
--- a/wallets/provider-xdefi/src/cosmos-signer.ts
+++ b/wallets/provider-xdefi/src/cosmos-signer.ts
@@ -58,7 +58,7 @@ export class CustomCosmosSigner implements GenericSigner<CosmosTransaction> {
       recipient,
       binanceProvider,
       method,
-      memo
+      memo ?? undefined
     );
     return { hash };
   }

--- a/wallets/provider-xdefi/src/helpers.ts
+++ b/wallets/provider-xdefi/src/helpers.ts
@@ -105,7 +105,7 @@ export async function xdefiTransfer(
   recipientAddress: string | null,
   provider: any,
   method: string,
-  memo: string | null
+  memo?: string
 ): Promise<string> {
   return new Promise(function (resolve, reject) {
     const params = {

--- a/wallets/provider-xdefi/src/utxo-signer.ts
+++ b/wallets/provider-xdefi/src/utxo-signer.ts
@@ -57,7 +57,7 @@ export class CustomTransferSigner implements GenericSigner<Transfer> {
       recipientAddress,
       transferProvider,
       method,
-      memo
+      memo ?? undefined
     );
     return { hash };
   }


### PR DESCRIPTION
# Summary

Null memo is removed from utxo transactions and undefined will be passed instead of that.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
