### PR TITLE
chore: add extract translations job to check workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -19,6 +19,9 @@ jobs:
         env:
           REF: ${{ github.ref }}
 
+      - name: Extract new translations to check if any error exists
+        run: node ./scripts/lingui/command.js extract --clean
+
       - name: Test
         run: |
           node ./scripts/build-libs/command.mjs

--- a/scripts/lingui/command.js
+++ b/scripts/lingui/command.js
@@ -1,0 +1,20 @@
+// Wrapper around lingui command that exits with a non zero value if an error is detected. Lingui commands do not fail with a non-zero exit code in some cases. There is an open issue here: https://github.com/lingui/js-lingui/issues/1419
+const { exec } = require('child_process');
+
+const args = process.argv.splice(2);
+const command = `yarn lingui ${args.join(' ')}`;
+
+const handleLinguiCommand = function (error, stdout, stderr) {
+  if (error) {
+    // Handle exec command error (lingui command not found?)
+    console.log(`error: ${error}`);
+    throw error;
+  }
+  // Display command standard output
+  console.log(`stdout: ${stdout}`);
+  // Display command standard error
+  console.log(`stderr: ${stderr}`);
+  const errorExists = stderr?.trim() !== '✔';
+  process.exit(errorExists ? 1 : 0);
+};
+exec(command, handleLinguiCommand);


### PR DESCRIPTION
# Summary

Added extract translations job to check workflow. Also added a wrapper on extract translations in check workflow to exit if there is an error in extract flow which does not force workflow to fail.

Fixes # 1873


# How did you test this change?

Ran Github workflow.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
