### PR TITLE
chore: improve and document code splitting

### DIFF
--- a/docs/code-splitting.md
+++ b/docs/code-splitting.md
@@ -1,0 +1,31 @@
+# Code Splitting
+
+As explained in [this link](https://legacy.reactjs.org/docs/code-splitting.html), Code-Splitting is a feature supported by some bundlers that allows the creation of multiple bundles that can be loaded dynamically at runtime. This technique enables us to "lazily-load" only the necessary components for the user's current needs, significantly enhancing the performance of the application.
+
+
+## What we did
+
+- Splitting Signers from initial bundle
+
+
+## What we are going to do
+
+Currently, we've achieved a good initial bundle size based on analyses conducted using tools like `lighthouse`. Some potential future works that could contribute to the journey ahead are listed below:
+
+- Implement retry mechanisms for dynamic imports to address issues with failing to import certain chunks.
+- Maintain the applied changes to prevent future modifications from undoing the achieved results.
+- Identify potential areas that can be dynamically imported.
+- Attempt to enhance clients that have integrated widgets (like dapp) to improve overall performance.
+
+
+## Technical Consideration
+
+- Avoid small chunks, they don't add any value to user. they will have network overhead as well.
+- Chunks will be built using esbuild's [splitting](https://esbuild.github.io/api/#splitting) option.
+- Code splitting for libraries is off by default. To enable the option, add the "--splitting" parameter to the "build" script of that package.
+
+
+## Notes
+
+The `@rango-dev/signer-solana` package is not dynamically imported because it has a major dependency ("@solana/web3.js") that is also a dependency in `@solflare-wallet/sdk`, which is used in `provider-solflare`. This dependency cannot be dynamically imported, so importing `@rango-dev/signer-solana` dynamically would only result in a very small reduction in the bundle size.
+

--- a/wallets/provider-argentx/src/signer.ts
+++ b/wallets/provider-argentx/src/signer.ts
@@ -1,12 +1,12 @@
 import type { SignerFactory } from 'rango-types';
 
+import { DefaultStarknetSigner } from '@rango-dev/signer-starknet';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: any
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { DefaultStarknetSigner } = await import('@rango-dev/signer-starknet');
   signers.registerSigner(TxType.STARKNET, new DefaultStarknetSigner(provider));
   return signers;
 }

--- a/wallets/provider-bitget/src/signer.ts
+++ b/wallets/provider-bitget/src/signer.ts
@@ -1,5 +1,6 @@
 import type { SignerFactory } from 'rango-types';
 
+import { DefaultTronSigner } from '@rango-dev/signer-tron';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -10,7 +11,6 @@ export default async function getSigners(
   const tronProvider = getNetworkInstance(provider, Networks.TRON);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { DefaultTronSigner } = await import('@rango-dev/signer-tron');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.TRON, new DefaultTronSigner(tronProvider));
   return signers;

--- a/wallets/provider-braavos/src/signer.ts
+++ b/wallets/provider-braavos/src/signer.ts
@@ -1,12 +1,12 @@
 import type { SignerFactory } from 'rango-types';
 
+import { DefaultStarknetSigner } from '@rango-dev/signer-starknet';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: any
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { DefaultStarknetSigner } = await import('@rango-dev/signer-starknet');
   signers.registerSigner(TxType.STARKNET, new DefaultStarknetSigner(provider));
   return signers;
 }

--- a/wallets/provider-brave/src/signer.ts
+++ b/wallets/provider-brave/src/signer.ts
@@ -3,6 +3,8 @@ import type { SignerFactory } from 'rango-types';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
+import { CustomSolanaSigner } from './solana-signer.js';
+
 export default async function getSigners(
   provider: any
 ): Promise<SignerFactory> {
@@ -10,7 +12,6 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { CustomSolanaSigner } = await import('./solana-signer.js');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-clover/src/signer.ts
+++ b/wallets/provider-clover/src/signer.ts
@@ -3,6 +3,8 @@ import type { SignerFactory } from 'rango-types';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
+import { CustomSolanaSigner } from './solana-signer.js';
+
 export default async function getSigners(
   provider: any
 ): Promise<SignerFactory> {
@@ -10,7 +12,6 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { CustomSolanaSigner } = await import('./solana-signer.js');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-coin98/package.json
+++ b/wallets/provider-coin98/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-coin98 --splitting",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-coin98",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/provider-coin98/src/signer.ts
+++ b/wallets/provider-coin98/src/signer.ts
@@ -3,6 +3,8 @@ import type { SignerFactory } from 'rango-types';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
+import { CustomSolanaSigner } from './solana-signer.js';
+
 export default async function getSigners(
   provider: any
 ): Promise<SignerFactory> {
@@ -10,7 +12,6 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { CustomSolanaSigner } = await import('./solana-signer.js');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-coinbase/src/signer.ts
+++ b/wallets/provider-coinbase/src/signer.ts
@@ -3,6 +3,8 @@ import type { SignerFactory } from 'rango-types';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
+import { CustomSolanaSigner } from './solana-signer.js';
+
 export default async function getSigners(
   provider: any
 ): Promise<SignerFactory> {
@@ -10,7 +12,6 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { CustomSolanaSigner } = await import('./solana-signer.js');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-exodus/src/signer.ts
+++ b/wallets/provider-exodus/src/signer.ts
@@ -3,6 +3,8 @@ import type { SignerFactory } from 'rango-types';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
+import { CustomSolanaSigner } from './solana-signer.js';
+
 export default async function getSigners(
   provider: any
 ): Promise<SignerFactory> {
@@ -10,7 +12,6 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { CustomSolanaSigner } = await import('./solana-signer.js');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-frontier/src/signer.ts
+++ b/wallets/provider-frontier/src/signer.ts
@@ -1,5 +1,6 @@
 import type { SignerFactory } from 'rango-types';
 
+import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -10,7 +11,6 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new DefaultSolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-ledger/src/signers/ethereum.ts
+++ b/wallets/provider-ledger/src/signers/ethereum.ts
@@ -2,6 +2,7 @@ import type { TransactionLike } from 'ethers';
 import type { GenericSigner } from 'rango-types';
 import type { EvmTransaction } from 'rango-types/mainApi';
 
+import Eth, { ledgerService } from '@ledgerhq/hw-app-eth';
 import { DEFAULT_ETHEREUM_RPC_URL } from '@rango-dev/wallets-shared';
 import { JsonRpcProvider, Transaction } from 'ethers';
 import { SignerError, SignerErrorCode } from 'rango-types';
@@ -18,7 +19,7 @@ export class EthereumSigner implements GenericSigner<EvmTransaction> {
     try {
       const transport = await transportConnect();
 
-      const eth = new (await import('@ledgerhq/hw-app-eth')).default(transport);
+      const eth = new Eth(transport);
       const result = await eth.signPersonalMessage(
         getDerivationPath(),
         Buffer.from(msg).toString('hex')
@@ -59,13 +60,15 @@ export class EthereumSigner implements GenericSigner<EvmTransaction> {
       const unsignedTx =
         Transaction.from(transaction).unsignedSerialized.substring(2); // Create unsigned transaction
 
-      const resolution = await (
-        await import('@ledgerhq/hw-app-eth')
-      ).ledgerService.resolveTransaction(unsignedTx, {}, {}); // metadata necessary to allow the device to clear sign information
+      const resolution = await ledgerService.resolveTransaction(
+        unsignedTx,
+        {},
+        {}
+      ); // metadata necessary to allow the device to clear sign information
 
       const transport = await transportConnect();
 
-      const eth = new (await import('@ledgerhq/hw-app-eth')).default(transport);
+      const eth = new Eth(transport);
 
       const signature = await eth.signTransaction(
         getDerivationPath(),

--- a/wallets/provider-ledger/src/signers/solana.ts
+++ b/wallets/provider-ledger/src/signers/solana.ts
@@ -2,6 +2,7 @@ import type { SolanaWeb3Signer } from '@rango-dev/signer-solana';
 import type { Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { GenericSigner, SolanaTransaction } from 'rango-types';
 
+import Solana from '@ledgerhq/hw-app-solana';
 import { generalSolanaTransactionExecutor } from '@rango-dev/signer-solana';
 import { PublicKey } from '@solana/web3.js';
 import { SignerError, SignerErrorCode } from 'rango-types';
@@ -24,9 +25,7 @@ export class SolanaSigner implements GenericSigner<SolanaTransaction> {
     try {
       const transport = await transportConnect();
 
-      const solana = new (await import('@ledgerhq/hw-app-solana')).default(
-        transport
-      );
+      const solana = new Solana(transport);
 
       const result = await solana.signOffchainMessage(
         getDerivationPath(),
@@ -44,9 +43,7 @@ export class SolanaSigner implements GenericSigner<SolanaTransaction> {
         solanaWeb3Transaction: Transaction | VersionedTransaction
       ) => {
         const transport = await transportConnect();
-        const solana = new (await import('@ledgerhq/hw-app-solana')).default(
-          transport
-        );
+        const solana = new Solana(transport);
 
         let signResult;
         if (isVersionedTransaction(solanaWeb3Transaction)) {

--- a/wallets/provider-math-wallet/src/signer.ts
+++ b/wallets/provider-math-wallet/src/signer.ts
@@ -1,5 +1,6 @@
 import type { SignerFactory } from 'rango-types';
 
+import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -12,7 +13,6 @@ export default async function getSigners(
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
   const { MathWalletCosmosSigner } = await import('./signers/cosmosSigner.js');
 
   if (!!ethProvider) {

--- a/wallets/provider-mytonwallet/src/signer.ts
+++ b/wallets/provider-mytonwallet/src/signer.ts
@@ -1,13 +1,13 @@
 import type { TonProvider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
+import { DefaultTonSigner } from '@rango-dev/signer-ton';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: TonProvider
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { DefaultTonSigner } = await import('@rango-dev/signer-ton');
   signers.registerSigner(TxType.TON, new DefaultTonSigner(provider));
   return signers;
 }

--- a/wallets/provider-okx/src/signer.ts
+++ b/wallets/provider-okx/src/signer.ts
@@ -3,6 +3,8 @@ import type { SignerFactory } from 'rango-types';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
+import { CustomSolanaSigner } from './solana-signer.js';
+
 export default async function getSigners(
   provider: any
 ): Promise<SignerFactory> {
@@ -10,7 +12,6 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { CustomSolanaSigner } = await import('./solana-signer.js');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-phantom/src/signer.ts
+++ b/wallets/provider-phantom/src/signer.ts
@@ -1,5 +1,6 @@
 import type { SignerFactory } from 'rango-types';
 
+import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -8,7 +9,6 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
-  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
   signers.registerSigner(TxType.SOLANA, new DefaultSolanaSigner(solProvider));
   return signers;
 }

--- a/wallets/provider-safepal/src/signer.ts
+++ b/wallets/provider-safepal/src/signer.ts
@@ -1,5 +1,6 @@
 import type { SignerFactory } from 'rango-types';
 
+import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -10,7 +11,6 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new DefaultSolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-solflare-snap/package.json
+++ b/wallets/provider-solflare-snap/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-solflare-snap --splitting",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-solflare-snap",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/provider-solflare-snap/src/signer.ts
+++ b/wallets/provider-solflare-snap/src/signer.ts
@@ -2,13 +2,12 @@ import type { SignerFactory } from 'rango-types';
 
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
+import { SolflareSnapSolanaSigner } from './signers/solanaSigner.js';
+
 export default async function getSigners(
   provider: any
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { SolflareSnapSolanaSigner } = await import(
-    './signers/solanaSigner.js'
-  );
   signers.registerSigner(TxType.SOLANA, new SolflareSnapSolanaSigner(provider));
   return signers;
 }

--- a/wallets/provider-solflare/package.json
+++ b/wallets/provider-solflare/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/provider-solflare --splitting",
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-solflare",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/provider-solflare/src/signer.ts
+++ b/wallets/provider-solflare/src/signer.ts
@@ -3,11 +3,12 @@ import type { SignerFactory } from 'rango-types';
 
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
+import { CustomSolanaSigner } from './signers/solanaSigner.js';
+
 export default async function getSigners(
   provider: Solflare
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { CustomSolanaSigner } = await import('./signers/solanaSigner.js');
   signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(provider));
   return signers;
 }

--- a/wallets/provider-tron-link/src/signer.ts
+++ b/wallets/provider-tron-link/src/signer.ts
@@ -1,12 +1,12 @@
 import type { SignerFactory } from 'rango-types';
 
+import { DefaultTronSigner } from '@rango-dev/signer-tron';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: any
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { DefaultTronSigner } = await import('@rango-dev/signer-tron');
   signers.registerSigner(TxType.TRON, new DefaultTronSigner(provider));
   return signers;
 }

--- a/wallets/provider-xdefi/src/cosmos-signer.ts
+++ b/wallets/provider-xdefi/src/cosmos-signer.ts
@@ -1,6 +1,5 @@
 import type { CosmosTransaction, GenericSigner } from 'rango-types';
 
-import { executeCosmosTransaction } from '@rango-dev/signer-cosmos';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { SignerError, SignerErrorCode } from 'rango-types';
 
@@ -36,6 +35,10 @@ export class CustomCosmosSigner implements GenericSigner<CosmosTransaction> {
     }
   }
   async signAndSendTx(tx: CosmosTransaction): Promise<{ hash: string }> {
+    const { executeCosmosTransaction } = await import(
+      '@rango-dev/signer-cosmos'
+    );
+
     if (tx.rawTransfer === null) {
       const cosmosProvider = getNetworkInstance(this.provider, Networks.COSMOS);
       const hash = await executeCosmosTransaction(tx, cosmosProvider);

--- a/wallets/provider-xdefi/src/signer.ts
+++ b/wallets/provider-xdefi/src/signer.ts
@@ -3,6 +3,10 @@ import type { SignerFactory } from 'rango-types';
 import { getNetworkInstance, Networks } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
+import { CustomCosmosSigner } from './cosmos-signer.js';
+import { CustomSolanaSigner } from './solana-signer.js';
+import { CustomTransferSigner } from './utxo-signer.js';
+
 export default async function getSigners(
   provider: any
 ): Promise<SignerFactory> {
@@ -11,9 +15,6 @@ export default async function getSigners(
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { CustomSolanaSigner } = await import('./solana-signer.js');
-  const { CustomCosmosSigner } = await import('./cosmos-signer.js');
-  const { CustomTransferSigner } = await import('./utxo-signer.js');
 
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));


### PR DESCRIPTION
# Summary

Added a document for `code-splitting` and also detected some dynamic imports which result in small chunks and reverted such dynamic imports. I've added list of files resulted in build process in `widget-examples\vite`


Build result before code splitting:
```
dist/index.html                              0.46 kB │ gzip:     0.30 kB
dist/assets/index-a2801db4.css               0.04 kB │ gzip:     0.06 kB
dist/assets/index-992cec4c.js                0.98 kB │ gzip:     0.46 kB
dist/assets/index-206c2777.js                3.23 kB │ gzip:     1.29 kB
dist/assets/Solana-91a6328d.js               3.78 kB │ gzip:     1.64 kB
dist/assets/TransportWebHID-b0074475.js     33.78 kB │ gzip:    11.55 kB
dist/assets/index-096a66d2.js              139.07 kB │ gzip:    44.07 kB
dist/assets/index-21326ca8.js              378.53 kB │ gzip:    97.50 kB
dist/assets/Eth-c861653d.js              2,798.27 kB │ gzip: 1,799.48 kB
dist/assets/index-14ac80d0.js            8,624.36 kB │ gzip: 2,325.93 kB
```

Build result before changes:
```
dist/index.html                                       0.46 kB │ gzip:     0.30 kB
dist/assets/index-a2801db4.css                        0.04 kB │ gzip:     0.06 kB
dist/assets/solana-signer-774Z76QJ-30e49877.js        0.30 kB │ gzip:     0.23 kB
dist/assets/solanaSigner-WXZ5A3PQ-040b21ac.js         0.54 kB │ gzip:     0.36 kB
dist/assets/index-a678dfd2.js                         0.68 kB │ gzip:     0.44 kB
dist/assets/utxo-signer-ZB6Q3UPL-16d5eb83.js          0.75 kB │ gzip:     0.49 kB
dist/assets/solana-signer-3UBVUDC7-a5ccc07e.js        0.77 kB │ gzip:     0.49 kB
dist/assets/cosmos-signer-EU3BOHAU-691e5178.js        0.86 kB │ gzip:     0.54 kB
dist/assets/solanaSigner-SGKBR5AJ-8d080a21.js         0.89 kB │ gzip:     0.54 kB
dist/assets/evm-TZ6OXXGG-ef4c559b.js                  1.07 kB │ gzip:     0.62 kB
dist/assets/index-b565f6e5.js                         1.09 kB │ gzip:     0.57 kB
dist/assets/chunk-5QSDSOWH-27d0b967.js                1.09 kB │ gzip:     0.54 kB
dist/assets/solana-WN75Y76H-a0ccb629.js               1.13 kB │ gzip:     0.54 kB
dist/assets/ethereum-UW5V3C7D-7af6fac8.js             1.53 kB │ gzip:     0.79 kB
dist/assets/ethereum-NHQEXUSA-76928f7e.js             1.62 kB │ gzip:     0.74 kB
dist/assets/cosmosSigner-ECZAR6TO-d13dce9e.js         1.79 kB │ gzip:     0.91 kB
dist/assets/solana-35I33VLX-82168a4f.js               1.93 kB │ gzip:     0.94 kB
dist/assets/evm-MYSQOTV5-1871abe9.js                  2.96 kB │ gzip:     1.30 kB
dist/assets/index-206c2777.js                         3.23 kB │ gzip:     1.29 kB
dist/assets/Solana-UB4SGWQ3-3a7061e5.js               3.86 kB │ gzip:     1.70 kB
dist/assets/index-1308aa2d.js                         5.77 kB │ gzip:     2.46 kB
dist/assets/index-0b0262fa.js                         6.83 kB │ gzip:     2.67 kB
dist/assets/sha512-4b420ae9.js                       10.54 kB │ gzip:     4.81 kB
dist/assets/TransportWebHID-JLT4ETY3-52f21ff4.js     49.59 kB │ gzip:    15.98 kB
dist/assets/dist-6GI3ECE5-600e2f8c.js               144.43 kB │ gzip:    45.86 kB
dist/assets/provider-jsonrpc-02c3a7b0.js            234.29 kB │ gzip:    86.04 kB
dist/assets/cosmos-I3Z34UI3-fb2b5c97.js             334.08 kB │ gzip:    70.64 kB
dist/assets/index-efbf2212.js                       384.85 kB │ gzip:   103.82 kB
dist/assets/index-d12f88e0.js                     1,530.18 kB │ gzip:   480.90 kB
dist/assets/index-a08231f9.js                     2,580.62 kB │ gzip:   611.47 kB
dist/assets/index-f8e574b9.js                     2,728.16 kB │ gzip:   830.71 kB
dist/assets/Eth-Y5JFGVQA-6e4e8dbd.js              2,828.77 kB │ gzip: 1,777.91 kB
```

Build result after changes:
```
dist/index.html                                       0.46 kB │ gzip:     0.30 kB
dist/assets/index-a2801db4.css                        0.04 kB │ gzip:     0.06 kB
dist/assets/Solana-NJS3LWGA-d7be3030.js               0.10 kB │ gzip:     0.11 kB
dist/assets/Eth-5PCPPYSI-c99b10b2.js                  0.52 kB │ gzip:     0.33 kB
dist/assets/solana-GJWCIU6R-3b5ead1f.js               0.87 kB │ gzip:     0.49 kB
dist/assets/evm-TZ6OXXGG-6f50ce6e.js                  1.07 kB │ gzip:     0.62 kB
dist/assets/chunk-5QSDSOWH-f3d9e845.js                1.09 kB │ gzip:     0.54 kB
dist/assets/ethereum-V2WNWA6L-9cdd6b51.js             1.13 kB │ gzip:     0.68 kB
dist/assets/ethereum-UW5V3C7D-753ef0aa.js             1.53 kB │ gzip:     0.79 kB
dist/assets/cosmosSigner-ECZAR6TO-09736e70.js         1.79 kB │ gzip:     0.91 kB
dist/assets/solana-35I33VLX-55d68393.js               1.93 kB │ gzip:     0.94 kB
dist/assets/evm-MYSQOTV5-2656dc29.js                  2.96 kB │ gzip:     1.30 kB
dist/assets/index-206c2777.js                         3.23 kB │ gzip:     1.29 kB
dist/assets/chunk-OOX2UCLJ-05fa13a2.js                3.86 kB │ gzip:     1.70 kB
dist/assets/index-e9fd5399.js                         5.77 kB │ gzip:     2.46 kB
dist/assets/index-0b0262fa.js                         6.83 kB │ gzip:     2.67 kB
dist/assets/sha512-8c4d43f6.js                       10.54 kB │ gzip:     4.80 kB
dist/assets/TransportWebHID-JLT4ETY3-4cbf0824.js     49.58 kB │ gzip:    15.98 kB
dist/assets/dist-6GI3ECE5-f72a4b5f.js               144.43 kB │ gzip:    45.86 kB
dist/assets/provider-jsonrpc-ec78a6e3.js            234.31 kB │ gzip:    86.05 kB
dist/assets/cosmos-I3Z34UI3-1934cdfc.js             334.08 kB │ gzip:    70.64 kB
dist/assets/index-b21430cf.js                       384.85 kB │ gzip:   103.82 kB
dist/assets/index-c28ecaf7.js                     1,530.22 kB │ gzip:   480.89 kB
dist/assets/index-4ff21993.js                     2,580.62 kB │ gzip:   611.47 kB
dist/assets/index-4b2798e3.js                     2,729.74 kB │ gzip:   831.32 kB
dist/assets/chunk-HLLU77MH-05ef82b2.js            2,828.56 kB │ gzip: 1,777.82 kB
```


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
