### PR TITLE
fix: resolve issues with Trezor provider's sign message method

### DIFF
--- a/wallets/provider-trezor/src/signers/ethereum.ts
+++ b/wallets/provider-trezor/src/signers/ethereum.ts
@@ -27,7 +27,7 @@ export class EthereumSigner implements GenericSigner<EvmTransaction> {
   async signMessage(msg: string): Promise<string> {
     const TrezorConnect = await getTrezorModule();
 
-    const { success, payload } = await TrezorConnect.signMessage({
+    const { success, payload } = await TrezorConnect.ethereumSignMessage({
       message: msg,
       path: getDerivationPath(),
     });


### PR DESCRIPTION
# Summary

Currently, using the `Trezor` provider's `signMessage` method results in an error. We mistakenly used the `signMessage` method, but we should be using the `ethereumSignMessage` method instead.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
