### PR TITLE
fix: when host is using cjs, fallback to .default() for solfare sdk

### DIFF
--- a/wallets/provider-solflare/src/index.ts
+++ b/wallets/provider-solflare/src/index.ts
@@ -17,8 +17,18 @@ const WALLET = WalletTypes.SOLFLARE;
 export const config = {
   type: WALLET,
 };
-
-const walletInstance = new Solflare();
+/*
+ * Solflare is a transpiling ESM to CJS as well. It causes interop issues which is normally will be fixed using following code
+ */
+let SDK = Solflare;
+if (
+  typeof Solflare !== 'function' &&
+  // @ts-expect-error This import error is not visible to TypeScript
+  typeof Solflare.default === 'function'
+) {
+  SDK = (Solflare as unknown as { default: typeof Solflare }).default;
+}
+const walletInstance = new SDK();
 
 export const getInstance = () => (window.solflare ? walletInstance : null);
 export const connect: Connect = async ({


### PR DESCRIPTION
# Summary

Get correct instance for CJS hosts.

We've got a report regarding `next@13` and `module: esnext`, `moduleResolution: node` can not be run and throwing an error on `provider-solflare`.
