### PR TITLE
feat: add a prop to the tooltip component for collision padding

### DIFF
--- a/widget/ui/src/components/Tooltip/Tooltip.tsx
+++ b/widget/ui/src/components/Tooltip/Tooltip.tsx
@@ -22,6 +22,7 @@ export function Tooltip(props: PropsWithChildren<TooltipPropTypes>) {
     styles,
     align,
     alignOffset,
+    collisionPadding,
   } = props;
 
   return (
@@ -36,6 +37,7 @@ export function Tooltip(props: PropsWithChildren<TooltipPropTypes>) {
             align={align}
             side={side}
             sideOffset={sideOffset}
+            collisionPadding={collisionPadding}
             collisionBoundary={container}>
             <TooltipTypography
               css={styles?.content}

--- a/widget/ui/src/components/Tooltip/Tooltip.types.ts
+++ b/widget/ui/src/components/Tooltip/Tooltip.types.ts
@@ -18,4 +18,5 @@ export interface TooltipPropTypes {
   };
   align?: RadixTooltipContentProps['align'];
   alignOffset?: RadixTooltipContentProps['alignOffset'];
+  collisionPadding?: RadixTooltipContentProps['collisionPadding'];
 }


### PR DESCRIPTION
# Summary

Collision padding refers to the space that is added around the tooltip to ensure that it does not collide with the edges of its container or other UI elements. This padding helps to prevent the tooltip from being positioned too close to the boundaries of the viewport or overlapping with other components, which can enhance usability and visibility.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
