### PR TITLE
feat: add routing parameters to widget config

### DIFF
--- a/widget/embedded/src/hooks/useSwapInput.ts
+++ b/widget/embedded/src/hooks/useSwapInput.ts
@@ -15,7 +15,7 @@ import {
   getQuoteToTokenUsdPrice,
   sortQuotesBy,
 } from '../utils/quote';
-import { isFeatureEnabled } from '../utils/settings';
+import { isRoutingEnabled } from '../utils/settings';
 import { createQuoteRequestBody } from '../utils/swap';
 import { areTokensEqual } from '../utils/wallets';
 
@@ -48,11 +48,8 @@ export function useSwapInput({
   refetchQuote,
 }: UseSwapInputProps): UseSwapInput {
   const { fetch: fetchQuote, cancelFetch } = useFetchAllQuotes();
-  const {
-    excludeLiquiditySources: configExcludeLiquiditySources,
-    features,
-    enableCentralizedSwappers,
-  } = useAppStore().config;
+  const { excludeLiquiditySources: configExcludeLiquiditySources, routing } =
+    useAppStore().config;
   const connectedWallets = useWalletsStore.use.connectedWallets();
 
   const {
@@ -125,11 +122,23 @@ export function useSwapInput({
         affiliateRef,
         affiliatePercent,
         affiliateWallets,
-        enableCentralizedSwappers,
       });
-      if (isFeatureEnabled('experimentalRoute', features)) {
+      if (isRoutingEnabled('experimental', routing)) {
         requestBody.experimental = true;
       }
+
+      if (isRoutingEnabled('avoidNativeFee', routing)) {
+        requestBody.avoidNativeFee = true;
+      }
+
+      if (isRoutingEnabled('enableCentralizedSwappers', routing)) {
+        requestBody.enableCentralizedSwappers = true;
+      }
+
+      if (routing?.maxLength) {
+        requestBody.maxLength = routing.maxLength;
+      }
+
       fetchQuote(requestBody)
         .then((res) => {
           const sortQuotes = sortQuotesBy(sortStrategy, res.results);

--- a/widget/embedded/src/store/slices/data.ts
+++ b/widget/embedded/src/store/slices/data.ts
@@ -20,6 +20,7 @@ import { compareWithSearchFor, containsText } from '../../utils/common';
 import { createTokenHash, isTokenNative } from '../../utils/meta';
 import {
   addCustomTokensToSupportedTokens,
+  isRoutingEnabled,
   sortLiquiditySourcesByGroupTitle,
 } from '../../utils/settings';
 import { areTokensEqual, compareTokenBalance } from '../../utils/wallets';
@@ -324,7 +325,12 @@ export const createDataSlice: StateCreator<
   // Actions
   fetch: async () => {
     try {
-      const { enableCentralizedSwappers } = get().config;
+      const { routing } = get().config;
+      const enableCentralizedSwappers = isRoutingEnabled(
+        'enableCentralizedSwappers',
+        routing
+      );
+
       const response = await sdk().getAllMetadata({
         enableCentralizedSwappers,
       });

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -121,9 +121,6 @@ export type SignersConfig = {
  * @property {'visible' | 'hidden'} [language]
  * - The visibility state for the language feature. Optional property.
  *
- * @property {'disabled' | 'enabled'} [experimentalRoute]
- * - The enablement state for the experimental route feature. Optional property.
- *
  * @property {'visible' | 'hidden'} [connectWalletButton]
  * - The visibility state for the connect wallet button feature. Optional property.
  *
@@ -143,8 +140,30 @@ export type Features = Partial<
     | 'customTokens',
     'visible' | 'hidden'
   >
+>;
+
+/**
+ * `Routing`
+ *
+ * @property {'disabled' | 'enabled'} [avoidNativeFee]
+ * - If you want to exclude swappers that have native tokens as fee, for example when you are using an AA account, you could set this parameter.
+ *
+ * @property {number} [maxLength]
+ * - If you want to limit the maximum acceptable length of a route, you could set this parameter.
+ *
+ * @property {'disabled' | 'enabled'} [experimental]
+ * - Use this parameter to enable experimental routes. This settings shouldn't be used in your production environment.
+ *
+ * @property {'disabled' | 'enabled'} [enableCentralizedSwappers]
+ * - If you want to enable routing from the centralized protocols like XO Swap, you could set this parameter.
+ */
+export type Routing = Partial<
+  Record<
+    'experimental' | 'avoidNativeFee' | 'enableCentralizedSwappers',
+    'disabled' | 'enabled'
+  >
 > &
-  Partial<Record<'experimentalRoute', 'disabled' | 'enabled'>>;
+  Partial<Record<'maxLength', number>>;
 
 export type TrezorManifest = {
   appUrl: string;
@@ -192,7 +211,7 @@ export type TrezorManifest = {
  * If `externalWallets` is `true`, you should add `WidgetWallets` to your app.
  * @property {boolean} excludeLiquiditySources - The `excludeLiquiditySources` property is a boolean value that when you
  * set it to true, the list of liquidity sources provided in `liquiditySources` will be excluded; otherwise, they will be included.
- * @property {Features} features - An optional object for configuring the visibility or enablement of various features.
+ * @property {Features} features - An optional object for configuring the visibility of various features.
  *   Keys include:
  *   - 'notification': Visibility state for the notification icon.
  *   - 'theme': Visibility state for the theme.
@@ -200,14 +219,16 @@ export type TrezorManifest = {
  *   - 'connectWalletButton': Visibility state for the wallet connect icon.
  *   - 'language': Visibility state for the language.
  *   - 'customTokens': Visibility state for the custom tokens.
- *   - 'experimentalRoute': Enablement state for the experimental route.
- *
+ * @property {Routing} routing - An optional object for configuring the enablement or numeric of various features.
+ *   Keys include:
+ *   - 'maxLength': If you want to limit the maximum acceptable length of a route, you could set this parameter.
+ *   - 'avoidNativeFee': If you want to exclude swappers that have native tokens as fee, for example when you are using an AA account, you could set this parameter.
+ *   - 'experimental': Use this parameter to enable experimental routes. This settings shouldn't be used in your production environment.
+ *   - 'enableCentralizedSwappers': If you want to enable routing from the centralized protocols like XO Swap, you could set this parameter.
  * @property {WidgetVariant} variant
  *   If it is expanded, multiple routes will show up on the home page;
  *   If it is full-expanded, multiple routes will show up on the home page with full routes;
  *   if not, you will need to go to a different page to see the suggested routes.
- * @property {boolean} enableCentralizedSwappers
- * If you want to enable routing from the centralized protocols like XO Swap, you could set this parameter to true.
  */
 
 export type WidgetConfig = {
@@ -231,11 +252,11 @@ export type WidgetConfig = {
   excludeLiquiditySources?: boolean;
   features?: Features;
   variant?: WidgetVariant;
-  enableCentralizedSwappers?: boolean;
   signers?: SignersConfig;
   // These are likely to change or remove at anytime. Please use with a caution.
   __UNSTABLE_OR_INTERNAL__?: {
     walletConnectListedDesktopWalletLink?: string;
     autoUpdateSettings?: boolean; // If true, settings will be updated automatically based on the configuration.
   };
+  routing?: Routing;
 };

--- a/widget/embedded/src/utils/settings.ts
+++ b/widget/embedded/src/utils/settings.ts
@@ -1,4 +1,4 @@
-import type { Features } from '../types';
+import type { Features, Routing } from '../types';
 import type { SwapperMeta, SwapperType, Token } from 'rango-sdk';
 
 import { removeDuplicateFrom } from './common';
@@ -72,8 +72,8 @@ export function isFeatureHidden(feature: keyof Features, features?: Features) {
   return features?.[feature] === 'hidden';
 }
 
-export function isFeatureEnabled(feature: keyof Features, features?: Features) {
-  return features?.[feature] === 'enabled';
+export function isRoutingEnabled(item: keyof Routing, routing?: Routing) {
+  return routing?.[item] === 'enabled';
 }
 
 export const addCustomTokensToSupportedTokens = (

--- a/widget/embedded/src/utils/swap.ts
+++ b/widget/embedded/src/utils/swap.ts
@@ -445,7 +445,6 @@ export function createQuoteRequestBody(params: {
   affiliatePercent: number | null;
   affiliateWallets: { [key: string]: string } | null;
   destination?: string;
-  enableCentralizedSwappers?: boolean;
 }): BestRouteRequest {
   const {
     fromToken,
@@ -461,7 +460,6 @@ export function createQuoteRequestBody(params: {
     affiliatePercent,
     affiliateWallets,
     destination,
-    enableCentralizedSwappers,
   } = params;
   const selectedWalletsMap = selectedWallets?.reduce(
     (
@@ -513,7 +511,6 @@ export function createQuoteRequestBody(params: {
       ),
       swappersGroupsExclude: false,
     }),
-    enableCentralizedSwappers,
   };
   return requestBody;
 }


### PR DESCRIPTION
# Summary

We needed to add `avoidNativeFee` and `maxLength` to features, but after speaking with @RanGojo and @yeager-eren, we concluded that we should create a new parameter called `routing`. This parameter will contain `avoidNativeFee`, `maxLength`, and `experimental`.
