### PR TITLE
chore: set a resolution for protobufjs transitive package

### DIFF
--- a/wallets/provider-keplr/package.json
+++ b/wallets/provider-keplr/package.json
@@ -28,6 +28,9 @@
   "devDependencies": {
     "@keplr-wallet/types": "^0.11.21"
   },
+  "resolutions": {
+    "@keplr-wallet/types/secretjs/protobufjs": "^6.11.4"
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Resolution only works in one depth, for transitive packages we should set the whole path.