### PR TITLE
chore: set a resolution for protobufjs transitive package in wc2

### DIFF
--- a/wallets/provider-walletconnect-2/package.json
+++ b/wallets/provider-walletconnect-2/package.json
@@ -43,7 +43,8 @@
     "@walletconnect/types": "^2.11.2"
   },
   "resolutions": {
-    "protobufjs": "^6.11.4"
+    "protobufjs": "^6.11.4",
+    "@keplr-wallet/cosmos/@keplr-wallet/types/secretjs/protobufjs": "^6.14.4"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Resolution only works in one depth, for transitive packages we should set the whole path.