### PR TITLE
fix: fix error display for bad requests

### DIFF
--- a/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.helpers.ts
+++ b/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.helpers.ts
@@ -180,6 +180,17 @@ export function handleQuoteErrors(error: any): ConfirmSwapFetchResult {
     };
   }
 
+  if (error?.code === 'ERR_BAD_REQUEST') {
+    return {
+      swap: null,
+      error: {
+        type: QuoteErrorType.NO_RESULT,
+        diagnosisMessage: error.response.data.error,
+      },
+      warnings: null,
+    };
+  }
+
   return {
     swap: null,
     error: {


### PR DESCRIPTION
# Summary

When a 400 Bad Request error occurs during a swap attempt, the error message displayed to the user is "`Failed Network, Please retry your swap.`" This message is misleading as it implies a network issue rather than a client-side request error.
I handled these bad requests by using the error code `ERR_BAD_REQUEST` and typing `NO_RESULT`.

# How did you test this change?
You can create this bad request by setting the `slippage` above `30`.



# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
