### PR TITLE
fix: fix solana signer by migrating confirm transaction to get signature statuses

### DIFF
--- a/signers/signer-solana/readme.md
+++ b/signers/signer-solana/readme.md
@@ -47,13 +47,9 @@ Currecntly all Rango Solana transactions are Versioned (and serialized), only So
 
 5. Send and confirm the transaction (similar to [jupiter suggested code](https://github.com/jup-ag/jupiter-quote-api-node/blob/main/example/utils/transactionSender.ts))
 
-   ````ts
+   ```ts
    const { txId, txResponse } = await transactionSenderAndConfirmationWaiter({
-    connection,
-    serializedTransaction,
-    blockhashWithExpiryBlockHeight: {
-      blockhash: latestBlock.blockhash,
-      lastValidBlockHeight: latestBlock.lastValidBlockHeight,
-    },
-   });   ```
-   ````
+     connection,
+     serializedTransaction,
+   });
+   ```

--- a/signers/signer-solana/src/utils/main.ts
+++ b/signers/signer-solana/src/utils/main.ts
@@ -20,19 +20,14 @@ export const generalSolanaTransactionExecutor = async (
   const latestBlock = await connection.getLatestBlockhash('confirmed');
 
   const finalTx = prepareTransaction(tx, latestBlock.blockhash);
-  const raw = await DefaultSolanaSigner(finalTx);
+  const serializedTransaction = await DefaultSolanaSigner(finalTx);
 
   // We first simulate whether the transaction would be successful
   await simulateTransaction(finalTx, tx.txType);
 
-  const serializedTransaction = Buffer.from(raw);
   const { txId, txResponse } = await transactionSenderAndConfirmationWaiter({
     connection,
     serializedTransaction,
-    blockhashWithExpiryBlockHeight: {
-      blockhash: latestBlock.blockhash,
-      lastValidBlockHeight: latestBlock.lastValidBlockHeight,
-    },
   });
   if (!txId || !txResponse) {
     throw new SignerError(

--- a/signers/signer-solana/src/utils/types.ts
+++ b/signers/signer-solana/src/utils/types.ts
@@ -1,5 +1,4 @@
 import type {
-  BlockhashWithExpiryBlockHeight,
   Connection,
   PublicKey,
   SendOptions,
@@ -39,8 +38,7 @@ export interface SolanaExternalProvider {
 
 export type TransactionSenderAndConfirmationWaiterArgs = {
   connection: Connection;
-  serializedTransaction: Buffer;
-  blockhashWithExpiryBlockHeight: BlockhashWithExpiryBlockHeight;
+  serializedTransaction: SerializedTransaction;
 };
 
 export type TransactionSenderAndConfirmationWaiterResponse = {


### PR DESCRIPTION
# Summary

The `connection.confirmTransaction` is deprecated now and we should use `connection.getSignatureStatuses` now. Please check this document for more details:
https://www.quicknode.com/guides/solana-development/tooling/agave-upgrade


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Swap on Solana


# Checklist:

- [x] I have performed a self-review of my code
