### PR TITLE
fix: improve handling of disabled swappers in widget

### DIFF
--- a/widget/embedded/src/store/slices/data.ts
+++ b/widget/embedded/src/store/slices/data.ts
@@ -348,8 +348,9 @@ export const createDataSlice: StateCreator<
         {};
       const tokens: Token[] = [];
       const popularTokens: Token[] = response.popularTokens;
-      const swappers: SwapperMeta[] = response.swappers;
-
+      const swappers: SwapperMeta[] = response.swappers.filter(
+        (swapper) => swapper.enabled
+      );
       const blockchainsWithAtLeastOneToken = new Set();
 
       response.tokens.forEach((token) => {

--- a/widget/playground/src/store/meta.ts
+++ b/widget/playground/src/store/meta.ts
@@ -29,7 +29,11 @@ export const useMetaStore = createSelectors(
             chain.enabled &&
             chainThatHasTokenInMetaResponse.includes(chain.name)
         );
+        const enabledSwappers = response.swappers.filter(
+          (swapper) => swapper.enabled
+        );
         response.blockchains = enabledChains.sort((a, b) => a.sort - b.sort);
+        response.swappers = enabledSwappers;
         set({ meta: response, loadingStatus: 'success' });
       } catch (error) {
         set({ loadingStatus: 'failed' });


### PR DESCRIPTION
# Summary

Currently, disabled swappers are visible in widget settings, which could lead to unintended usage in various sections of the application. This update ensures that disabled swappers are:

- Not displayed to users in the widget interface.
- Prevented from being used in any functionality.

Fixes # (issue)


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
