### PR TITLE
feat: add fee details modal in widget full-expanded mode

### DIFF
--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -329,7 +329,17 @@ export function Quote(props: QuoteProps) {
       tooltipContainer={getExpanded()}
       steps={steps}
       tags={sortedQuoteTags}
-      feeWarning={feeWarning}
+      quoteCost={
+        <QuoteCostDetails
+          quote={quote}
+          fullExpandedMode
+          time={totalTime}
+          fee={fee}
+          feeWarning={feeWarning}
+          showModalFee={showModalFee}
+          steps={numberOfSteps}
+        />
+      }
       percentageChange={percentageChange}
       warningLevel={priceImpactWarningLevel}
       outputPrice={{

--- a/widget/embedded/src/components/Quote/Quote.types.ts
+++ b/widget/embedded/src/components/Quote/Quote.types.ts
@@ -49,4 +49,5 @@ export type QuoteCostDetailsProps = {
   time: string;
   feeWarning?: boolean;
   showModalFee: boolean;
+  fullExpandedMode?: boolean;
 };

--- a/widget/embedded/src/components/Quote/QuoteCostDetails.styles.ts
+++ b/widget/embedded/src/components/Quote/QuoteCostDetails.styles.ts
@@ -28,7 +28,6 @@ export const ModalContainer = styled('div', {
 
 export const ModalHeader = styled('div', {
   padding: '$20 $20 $10',
-  textAlign: 'center',
   position: 'relative',
   '._icon-button': {
     position: 'absolute',

--- a/widget/embedded/src/components/Quote/QuoteCostDetails.tsx
+++ b/widget/embedded/src/components/Quote/QuoteCostDetails.tsx
@@ -21,7 +21,7 @@ import {
   USD_VALUE_MAX_DECIMALS,
   USD_VALUE_MIN_DECIMALS,
 } from '../../constants/routing';
-import { getContainer } from '../../utils/common';
+import { getContainer, getExpanded } from '../../utils/common';
 import { numberToString } from '../../utils/numbers';
 import { getFeesGroup, getTotalFeesInUsd, getUsdFee } from '../../utils/swap';
 import { WatermarkedModal } from '../common/WatermarkedModal';
@@ -57,9 +57,17 @@ const NonPayableFee = (props: { fee: BigNumber; label: string }) => {
 export function QuoteCostDetails(props: QuoteCostDetailsProps) {
   const [open, setOpen] = useState<boolean>(false);
   const [openCollapse, setOpenCollapse] = useState<boolean>(false);
-  const { steps, quote, fee, time, feeWarning, showModalFee } = props;
+  const {
+    steps,
+    quote,
+    fee,
+    time,
+    feeWarning,
+    showModalFee,
+    fullExpandedMode = false,
+  } = props;
   const swaps = quote?.swaps ?? [];
-  const container = getContainer();
+  const container = fullExpandedMode ? getExpanded() : getContainer();
 
   const feesGroup = getFeesGroup(swaps);
 
@@ -85,8 +93,17 @@ export function QuoteCostDetails(props: QuoteCostDetailsProps) {
       <WatermarkedModal
         container={container}
         open={open}
+        anchor={fullExpandedMode ? 'center' : 'bottom'}
+        styles={{
+          container: {
+            maxWidth: fullExpandedMode ? '484px' : 'unset',
+          },
+        }}
         header={
-          <ModalHeader>
+          <ModalHeader
+            style={{
+              textAlign: fullExpandedMode ? 'left' : 'center',
+            }}>
             <Typography variant="title" size="medium">
               {i18n.t('Gas & Fee Explanation')}
             </Typography>

--- a/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.styles.ts
+++ b/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.styles.ts
@@ -4,6 +4,7 @@ export const Container = styled('div', {
   transition: 'width 0.2s, opacity 0.2s, margin-left 0.2s',
   height: '700px',
   width: '390px',
+  position: 'relative',
   opacity: 1,
   marginLeft: '$16',
   backgroundColor: '$neutral100',

--- a/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx
+++ b/widget/embedded/src/containers/ExpandedQuotes/ExpandedQuotes.tsx
@@ -64,7 +64,7 @@ export function ExpandedQuotes(props: PropTypes) {
       />
       <Content>
         <Quotes
-          showModalFee={false}
+          showModalFee={true}
           fetch={fetch}
           hasSort={false}
           loading={loading}

--- a/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.tsx
+++ b/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.tsx
@@ -8,7 +8,6 @@ import { ErrorIcon, WarningIcon } from '../../icons/index.js';
 import { ChainToken } from '../ChainToken/index.js';
 import { Image } from '../common/index.js';
 import { Divider } from '../Divider/index.js';
-import { QuoteCost } from '../QuoteCost/index.js';
 import { QuoteTag } from '../QuoteTag/index.js';
 import { NumericTooltip, Tooltip } from '../Tooltip/index.js';
 import { Typography } from '../Typography/index.js';
@@ -54,7 +53,6 @@ export function FullExpandedQuote(props: PropTypes) {
     warningLevel,
     tooltipContainer,
     onClick,
-    feeWarning,
     selected = false,
   } = props;
   const [hoveredItemIndex, setHoveredItemIndex] = useState<number | null>(null);
@@ -74,12 +72,7 @@ export function FullExpandedQuote(props: PropTypes) {
           <SkeletonHeader />
         ) : (
           <>
-            <QuoteCost
-              fee={props.fee}
-              time={props.time}
-              steps={numberOfSteps}
-              feeWarning={feeWarning}
-            />
+            {props.quoteCost}
             <TagsContainer>
               {props.tags.map((tag) => (
                 <QuoteTag

--- a/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.types.ts
+++ b/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.types.ts
@@ -16,7 +16,6 @@ type BaseProps = {
   tooltipContainer?: HTMLElement;
   onClick?: () => void;
   selected?: boolean;
-  feeWarning?: boolean;
 };
 
 export type DataLoadedProps = {
@@ -26,6 +25,7 @@ export type DataLoadedProps = {
   fee: QuoteCostProps['fee'];
   outputPrice: SwapInputPropTypes['price'];
   loading?: false;
+  quoteCost: React.ReactElement;
 };
 type LoadingProps = {
   loading: true;


### PR DESCRIPTION
# Summary

Display the fee details modal in the widget's full expanded mode

Fixes # (issue)

# Checklist:

- [ ] I have performed a self-review of my code
