### PR TITLE
chore: update solana confirmation timeout

### DIFF
--- a/signers/signer-solana/src/utils/send.ts
+++ b/signers/signer-solana/src/utils/send.ts
@@ -13,7 +13,7 @@ const SEND_OPTIONS = {
   skipPreflight: true,
 };
 const TIME_OUT = 2_000;
-const CONFIRMATION_TIME_OUT = 30_000;
+const CONFIRMATION_TIME_OUT = 60_000;
 
 // https://github.com/jup-ag/jupiter-quote-api-node/blob/main/example/utils/transactionSender.ts
 export async function transactionSenderAndConfirmationWaiter({


### PR DESCRIPTION
# Summary

Update solana confirmation timeout from 30s to 60s.
(The maximum age of a transaction's blockhash is 150 blocks (~1 minute assuming 400ms block times). If a transaction's blockhash is 150 blocks older than the latest blockhash, it is considered expired. This means that transactions not processed within a specific timeframe will never be executed.)

# Checklist:

- [x] I have performed a self-review of my code
