### PR TITLE
fix: handle token not found error for custom tokens

### DIFF
--- a/widget/embedded/src/hooks/useFetchCustomToken.ts
+++ b/widget/embedded/src/hooks/useFetchCustomToken.ts
@@ -103,6 +103,11 @@ export function useFetchCustomToken(): UseFetchCustomToken {
 
       return token;
     } catch (error: any) {
+      if (error?.code === 'ERR_BAD_REQUEST') {
+        const errorMessage = produceErrorMessage('not-found', blockchain);
+        setError(errorMessage);
+        return undefined;
+      }
       setError(undefined);
       throw new Error(error.message);
     } finally {


### PR DESCRIPTION
# Summary

This PR resolves an issue where the error message wasn't displayed correctly when a `token not found` error was received from the server. The fix ensures that the appropriate error message is shown to the user.
