### PR TITLE
chore: change Namespace enum to stirng

### DIFF
--- a/wallets/core/namespaces/common/package.json
+++ b/wallets/core/namespaces/common/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rango-dev/wallets-core/namespaces/common",
+  "type": "module",
+  "main": "../../dist/namespaces/common/mod.js",
+  "module": "../../dist/namespaces/common/mod.js",
+  "types": "../../dist/namespaces/common/mod.d.ts",
+  "sideEffects": false
+}

--- a/wallets/core/namespaces/evm/package.json
+++ b/wallets/core/namespaces/evm/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rango-dev/wallets-core/namespaces/evm",
+  "type": "module",
+  "main": "../../dist/namespaces/evm/mod.js",
+  "module": "../../dist/namespaces/evm/mod.js",
+  "types": "../../dist/namespaces/evm/mod.d.ts",
+  "sideEffects": false
+}

--- a/wallets/core/namespaces/solana/package.json
+++ b/wallets/core/namespaces/solana/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rango-dev/wallets-core/namespaces/solana",
+  "type": "module",
+  "main": "../../dist/namespaces/solana/mod.js",
+  "module": "../../dist/namespaces/solana/mod.js",
+  "types": "../../dist/namespaces/solana/mod.d.ts",
+  "sideEffects": false
+}

--- a/wallets/core/src/legacy/mod.ts
+++ b/wallets/core/src/legacy/mod.ts
@@ -27,11 +27,7 @@ export type {
   NamespaceInputWithDiscoverMode as LegacyNamespaceInputWithDiscoverMode,
 } from './types.js';
 
-export {
-  Events as LegacyEvents,
-  Namespace as LegacyNamespace,
-  Networks as LegacyNetworks,
-} from './types.js';
+export { Events as LegacyEvents, Networks as LegacyNetworks } from './types.js';
 
 export { Persistor } from './persistor.js';
 export {

--- a/wallets/core/src/legacy/types.ts
+++ b/wallets/core/src/legacy/types.ts
@@ -1,4 +1,5 @@
 import type { State as WalletState } from './wallet.js';
+import type { Namespace } from '../namespaces/common/mod.js';
 import type { BlockchainMeta, SignerFactory } from 'rango-types';
 
 export enum Networks {
@@ -62,15 +63,6 @@ export enum Networks {
 
   // Using instead of null
   Unknown = 'Unkown',
-}
-
-export enum Namespace {
-  Solana = 'Solana',
-  Evm = 'EVM',
-  Cosmos = 'Cosmos',
-  Utxo = 'UTXO',
-  Starknet = 'Starknet',
-  Tron = 'Tron',
 }
 
 export type NamespaceData = {
@@ -248,13 +240,6 @@ export type ProviderInterface = { config: WalletConfig } & WalletActions;
 // it comes from wallets.ts and `connect`
 type NetworkTypeFromLegacyConnect = Network | undefined;
 
-export type NetworkTypeForNamespace<T extends NamespacesWithDiscoverMode> =
-  T extends 'DISCOVER_MODE'
-    ? string
-    : T extends Namespace
-    ? NetworkTypeFromLegacyConnect
-    : never;
-
 export type NamespacesWithDiscoverMode = Namespace | 'DISCOVER_MODE';
 
 export type NamespaceInputWithDiscoverMode = {
@@ -273,7 +258,7 @@ export type NamespaceInputForConnect<T extends Namespace = Namespace> =
       /**
        * In some cases, we need to connect a specific network on a namespace. e.g. Polygon on EVM.
        */
-      network: NetworkTypeForNamespace<T>;
+      network: NetworkTypeFromLegacyConnect;
       derivationPath?: string;
     }
   | NamespaceInputWithDiscoverMode;

--- a/wallets/core/src/legacy/utils.ts
+++ b/wallets/core/src/legacy/utils.ts
@@ -3,8 +3,6 @@ import type {
   NamespaceInputWithDiscoverMode,
 } from './types.js';
 
-import { Namespace } from './types.js';
-
 export async function eagerConnectHandler<R = unknown>(params: {
   canEagerConnect: () => Promise<boolean>;
   connectHandler: () => Promise<R>;
@@ -26,6 +24,6 @@ export function isNamespaceDiscoverMode(
 
 export function isEvmNamespace(
   namespace: NamespaceInputForConnect
-): namespace is NamespaceInputForConnect<Namespace.Evm> {
-  return namespace.namespace === Namespace.Evm;
+): namespace is NamespaceInputForConnect<'EVM'> {
+  return namespace.namespace === 'EVM';
 }

--- a/wallets/core/src/namespaces/common/mod.ts
+++ b/wallets/core/src/namespaces/common/mod.ts
@@ -16,3 +16,5 @@ export type {
   Accounts,
   AccountsWithActiveChain,
 } from '../../types/accounts.js';
+
+export type { Namespace } from './types.js';

--- a/wallets/core/src/namespaces/common/types.ts
+++ b/wallets/core/src/namespaces/common/types.ts
@@ -1,3 +1,19 @@
+/*
+ * These are supported namespaces in Rango that we want to officially support.
+ * This should be private and don't make it public since core can support more namespaces and should be extendable.
+ */
+type RangoNamespace =
+  | 'EVM'
+  | 'Solana'
+  | 'Cosmos'
+  | 'UTXO'
+  | 'Starknet'
+  | 'Tron'
+  | 'Ton';
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type Namespace = RangoNamespace | (string & {});
+
 export interface CommonActions {
   init: () => void;
 }

--- a/wallets/provider-ledger/src/index.ts
+++ b/wallets/provider-ledger/src/index.ts
@@ -5,7 +5,7 @@ import type {
   WalletInfo,
 } from '@rango-dev/wallets-shared';
 
-import { Namespace, Networks, WalletTypes } from '@rango-dev/wallets-shared';
+import { Networks, WalletTypes } from '@rango-dev/wallets-shared';
 import { type BlockchainMeta, type SignerFactory } from 'rango-types';
 
 import {
@@ -26,10 +26,10 @@ export const connect: Connect = async ({ namespaces }) => {
   const results: ProviderConnectResult[] = [];
 
   const solanaNamespace = namespaces?.find(
-    (namespaceItem) => namespaceItem.namespace === Namespace.Solana
+    (namespaceItem) => namespaceItem.namespace === 'Solana'
   );
   const evmNamespace = namespaces?.find(
-    (namespaceItem) => namespaceItem.namespace === Namespace.Evm
+    (namespaceItem) => namespaceItem.namespace === 'EVM'
   );
 
   if (solanaNamespace) {
@@ -93,7 +93,7 @@ export const getWalletInfo: (allBlockChains: BlockchainMeta[]) => WalletInfo = (
     },
     color: 'black',
     supportedChains,
-    namespaces: [Namespace.Evm, Namespace.Solana],
+    namespaces: ['EVM', 'Solana'],
     singleNamespace: true,
     showOnMobile: false,
     needsDerivationPath: true,

--- a/wallets/provider-trezor/src/index.ts
+++ b/wallets/provider-trezor/src/index.ts
@@ -5,7 +5,7 @@ import type {
   WalletInfo,
 } from '@rango-dev/wallets-shared';
 
-import { Namespace, Networks, WalletTypes } from '@rango-dev/wallets-shared';
+import { Networks, WalletTypes } from '@rango-dev/wallets-shared';
 import { type BlockchainMeta, type SignerFactory } from 'rango-types';
 
 import {
@@ -40,7 +40,7 @@ export const connect: Connect = async ({ namespaces }) => {
   const TrezorConnect = await getTrezorModule();
 
   const evmNamespace = namespaces?.find(
-    (namespaceItem) => namespaceItem.namespace === Namespace.Evm
+    (namespaceItem) => namespaceItem.namespace === 'EVM'
   );
 
   if (evmNamespace) {
@@ -95,7 +95,7 @@ export const getWalletInfo: (allBlockChains: BlockchainMeta[]) => WalletInfo = (
     },
     color: 'black',
     supportedChains,
-    namespaces: [Namespace.Evm],
+    namespaces: ['EVM'],
     singleNamespace: true,
     showOnMobile: false,
     needsDerivationPath: true,

--- a/wallets/react/src/hub/autoConnect.ts
+++ b/wallets/react/src/hub/autoConnect.ts
@@ -4,8 +4,8 @@ import type { Hub } from '@rango-dev/wallets-core';
 import type {
   LegacyNamespaceInputForConnect,
   LegacyProviderInterface,
-  LegacyNamespace as Namespace,
 } from '@rango-dev/wallets-core/legacy';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 
 import {
   legacyEagerConnectHandler,

--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -1,10 +1,8 @@
 import type { AllProxiedNamespaces, ExtensionLink } from './types.js';
 import type { Providers } from '../index.js';
 import type { Provider } from '@rango-dev/wallets-core';
-import type {
-  LegacyNamespaceInputForConnect,
-  LegacyNamespace as Namespace,
-} from '@rango-dev/wallets-core/legacy';
+import type { LegacyNamespaceInputForConnect } from '@rango-dev/wallets-core/legacy';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 import type { VersionedProviders } from '@rango-dev/wallets-core/utils';
 
 import { legacyIsNamespaceDiscoverMode } from '@rango-dev/wallets-core/legacy';

--- a/wallets/react/src/hub/utils.ts
+++ b/wallets/react/src/hub/utils.ts
@@ -6,15 +6,13 @@ import type {
   LegacyProviderInterface,
   LegacyEventHandler as WalletEventHandler,
 } from '@rango-dev/wallets-core/legacy';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 
 import {
   guessProviderStateSelector,
   namespaceStateSelector,
 } from '@rango-dev/wallets-core';
-import {
-  LegacyEvents as Events,
-  LegacyNamespace as Namespace,
-} from '@rango-dev/wallets-core/legacy';
+import { LegacyEvents as Events } from '@rango-dev/wallets-core/legacy';
 import {
   generateStoreId,
   type VersionedProviders,
@@ -269,7 +267,7 @@ export function discoverNamespace(network: string): Namespace {
     case Networks.TERRA:
     case Networks.THORCHAIN:
     case Networks.UMEE:
-      return Namespace.Cosmos;
+      return 'Cosmos';
     case Networks.AVAX_CCHAIN:
     case Networks.ARBITRUM:
     case Networks.BOBA:
@@ -284,17 +282,18 @@ export function discoverNamespace(network: string): Namespace {
     case Networks.OPTIMISM:
     case Networks.POLYGON:
     case Networks.STARKNET:
-      return Namespace.Evm;
+      return 'Evm';
     case Networks.SOLANA:
-      return Namespace.Solana;
+      return 'Solana';
     case Networks.BTC:
     case Networks.BCH:
     case Networks.DOGE:
     case Networks.LTC:
     case Networks.TRON:
-      return Namespace.Utxo;
-    case Networks.POLKADOT:
+      return 'UTXO';
     case Networks.TON:
+      return 'Ton';
+    case Networks.POLKADOT:
     case Networks.AXELAR:
     case Networks.MARS:
     case Networks.MAYA:

--- a/wallets/shared/src/rango.ts
+++ b/wallets/shared/src/rango.ts
@@ -3,12 +3,10 @@ import type {
   LegacyWalletInfo as WalletInfo,
   LegacyWalletType as WalletType,
 } from '@rango-dev/wallets-core/legacy';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 import type { BlockchainMeta, EvmBlockchainMeta } from 'rango-types';
 
-import {
-  LegacyNamespace as Namespace,
-  LegacyNetworks as Networks,
-} from '@rango-dev/wallets-core/legacy';
+import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
 
 export type {
   LegacyNetwork as Network,
@@ -27,7 +25,6 @@ export type {
 
 export {
   LegacyNetworks as Networks,
-  LegacyNamespace as Namespace,
   legacyGetBlockChainNameFromId as getBlockChainNameFromId,
 } from '@rango-dev/wallets-core/legacy';
 
@@ -82,7 +79,7 @@ export const namespaces: Record<
   Namespace,
   { mainBlockchain: string; title: string; derivationPaths?: DerivationPath[] }
 > = {
-  [Namespace.Evm]: {
+  EVM: {
     mainBlockchain: 'ETH',
     title: 'Ethereum',
     derivationPaths: [
@@ -103,7 +100,7 @@ export const namespaces: Record<
       },
     ],
   },
-  [Namespace.Solana]: {
+  Solana: {
     mainBlockchain: 'SOLANA',
     title: 'Solana',
     derivationPaths: [
@@ -119,21 +116,25 @@ export const namespaces: Record<
       },
     ],
   },
-  [Namespace.Cosmos]: {
+  Cosmos: {
     mainBlockchain: 'COSMOS',
     title: 'Cosmos',
   },
-  [Namespace.Utxo]: {
+  UTXO: {
     mainBlockchain: 'BTC',
     title: 'Utxo',
   },
-  [Namespace.Starknet]: {
+  Starknet: {
     title: 'Starknet',
     mainBlockchain: 'STARKNET',
   },
-  [Namespace.Tron]: {
+  Tron: {
     title: 'Tron',
     mainBlockchain: 'TRON',
+  },
+  Ton: {
+    title: 'Ton',
+    mainBlockchain: 'TON',
   },
 };
 

--- a/widget/embedded/src/components/StatefulConnectModal/StatefulConnectModal.tsx
+++ b/widget/embedded/src/components/StatefulConnectModal/StatefulConnectModal.tsx
@@ -1,6 +1,6 @@
 import type { Result } from '../../hooks/useStatefulConnect';
 import type { WalletInfoWithExtra } from '../../types';
-import type { Namespace } from '@rango-dev/wallets-shared';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 
 import { Divider } from '@rango-dev/ui';
 import React, { useEffect, useRef, useState } from 'react';

--- a/widget/embedded/src/components/WalletStatefulConnect/DerivationPath.helpers.ts
+++ b/widget/embedded/src/components/WalletStatefulConnect/DerivationPath.helpers.ts
@@ -1,4 +1,5 @@
-import type { DerivationPath, Namespace } from '@rango-dev/wallets-shared';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { DerivationPath } from '@rango-dev/wallets-shared';
 
 import { namespaces } from '@rango-dev/wallets-shared';
 

--- a/widget/embedded/src/components/WalletStatefulConnect/Namespaces.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Namespaces.tsx
@@ -1,5 +1,5 @@
 import type { PropTypes } from './Namespaces.types';
-import type { Namespace } from '@rango-dev/wallets-shared';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 
 import { i18n } from '@lingui/core';
 import {

--- a/widget/embedded/src/components/WalletStatefulConnect/Namespaces.types.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Namespaces.types.tsx
@@ -1,5 +1,5 @@
 import type { NeedsNamespacesState } from '../../hooks/useStatefulConnect';
-import type { Namespace } from '@rango-dev/wallets-shared';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 
 export interface PropTypes {
   onConfirm: (namespaces: Namespace[]) => void;

--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
@@ -1,11 +1,8 @@
 import type { HandleConnectOptions, Result } from './useStatefulConnect.types';
 import type { WalletInfoWithExtra } from '../../types';
 import type { ExtendedModalWalletInfo } from '../../utils/wallets';
-import type {
-  Namespace,
-  NamespaceData,
-  WalletType,
-} from '@rango-dev/wallets-shared';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { NamespaceData, WalletType } from '@rango-dev/wallets-shared';
 
 import { WalletState } from '@rango-dev/ui';
 import { useWallets } from '@rango-dev/wallets-react';

--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.types.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.types.ts
@@ -1,4 +1,4 @@
-import type { Namespace } from '@rango-dev/wallets-shared';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 
 export interface HandleConnectOptions {
   // To have a switch between connect and disconnect when user is clicking on a button, this option can be helpful.

--- a/widget/embedded/src/types/wallets.ts
+++ b/widget/embedded/src/types/wallets.ts
@@ -1,5 +1,6 @@
 import type { WalletInfo } from '@rango-dev/ui';
-import type { Namespace, WalletType } from '@rango-dev/wallets-shared';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { WalletType } from '@rango-dev/wallets-shared';
 
 export interface Wallet {
   chain: string;

--- a/widget/embedded/src/utils/hub.ts
+++ b/widget/embedded/src/utils/hub.ts
@@ -1,6 +1,5 @@
 import type { CommonNamespaceKeys } from '@rango-dev/wallets-core';
-
-import { Namespace } from '@rango-dev/wallets-shared';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 
 export function convertCommonNamespacesKeysToLegacyNamespace(
   namespaces: CommonNamespaceKeys[]
@@ -8,15 +7,15 @@ export function convertCommonNamespacesKeysToLegacyNamespace(
   return namespaces.map((namespace) => {
     switch (namespace) {
       case 'evm':
-        return Namespace.Evm;
+        return 'EVM';
       case 'solana':
-        return Namespace.Solana;
+        return 'Solana';
       case 'cosmos':
-        return Namespace.Cosmos;
+        return 'Cosmos';
+      default:
+        throw new Error(
+          'Can not convert this common namespace key to a proper legacy key.'
+        );
     }
-
-    throw new Error(
-      'Can not convert this common namespace key to a proper legacy key.'
-    );
   });
 }


### PR DESCRIPTION
# Summary

Using a single source of truth for Namespace.

We need to use a single type for both legacy and hub implementation. To make it more general and don't needing to always keeping the namespace updated by what Rango currently support, I changed it to `string`, instead of enum. To have namespace suggestion while coding, I used a trick to suggest our supported namespaces alongside the fact that it can be any string.


Fixes # (issue)


# How did you test this change?

It should be compiled correctly, shouldn't affect the functionality of working with wallets.


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
