### PR TITLE
feat: storing network alongside namespace for hub localstorage

### DIFF
--- a/wallets/core/src/namespaces/evm/actions.ts
+++ b/wallets/core/src/namespaces/evm/actions.ts
@@ -57,8 +57,9 @@ export function changeAccountSubscriber(
 ): [Subscriber<EvmActions>, SubscriberCleanUp<EvmActions>] {
   let eventCallback: EIP1193EventMap['accountsChanged'];
 
+  // subscriber can be passed to `or`, it will get the error and should rethrow error to pass the error to next `or` or throw error.
   return [
-    (context) => {
+    (context, err) => {
       const evmInstance = instance();
 
       if (!evmInstance) {
@@ -85,12 +86,20 @@ export function changeAccountSubscriber(
         setState('accounts', formatAccounts);
       };
       evmInstance.on('accountsChanged', eventCallback);
+
+      if (err instanceof Error) {
+        throw err;
+      }
     },
-    () => {
+    (_, err) => {
       const evmInstance = instance();
 
       if (eventCallback && evmInstance) {
         evmInstance.removeListener('accountsChanged', eventCallback);
+      }
+
+      if (err instanceof Error) {
+        throw err;
       }
     },
   ];

--- a/wallets/react/src/hub/autoConnect.ts
+++ b/wallets/react/src/hub/autoConnect.ts
@@ -131,8 +131,8 @@ export async function autoConnect(deps: {
       const namespaces: LegacyNamespaceInputForConnect[] = lastConnectedWallets[
         providerName
       ].map((namespace) => ({
-        namespace: namespace as Namespace,
-        network: undefined,
+        namespace: namespace.namsepace,
+        network: namespace.network,
       }));
 
       const canEagerConnect = async () => {

--- a/wallets/react/src/hub/lastConnectedWallets.ts
+++ b/wallets/react/src/hub/lastConnectedWallets.ts
@@ -1,3 +1,5 @@
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+
 import { Persistor } from '@rango-dev/wallets-core/legacy';
 
 import {
@@ -5,8 +7,13 @@ import {
   LEGACY_LAST_CONNECTED_WALLETS,
 } from './constants.js';
 
+export interface NamespaceInput {
+  namsepace: Namespace;
+  network: string | undefined;
+}
+
 export interface LastConnectedWalletsStorage {
-  [providerId: string]: string[];
+  [providerId: string]: NamespaceInput[];
 }
 
 export type LegacyLastConnectedWalletsStorage = string[];
@@ -22,7 +29,7 @@ export class LastConnectedWalletsFromStorage {
     this.#storageKey = storageKey;
   }
 
-  addWallet(providerId: string, namespaces: string[]): void {
+  addWallet(providerId: string, namespaces: NamespaceInput[]): void {
     if (this.#storageKey === HUB_LAST_CONNECTED_WALLETS) {
       return this.#addWalletToHub(providerId, namespaces);
     } else if (this.#storageKey === LEGACY_LAST_CONNECTED_WALLETS) {
@@ -64,7 +71,7 @@ export class LastConnectedWalletsFromStorage {
       persistor.getItem(HUB_LAST_CONNECTED_WALLETS) || {};
     return lastConnectedWallets;
   }
-  #addWalletToHub(providerId: string, namespaces: string[]): void {
+  #addWalletToHub(providerId: string, namespaces: NamespaceInput[]): void {
     const storage = new Persistor<LastConnectedWalletsStorage>();
     const data = storage.getItem(this.#storageKey) || {};
 


### PR DESCRIPTION
# Summary

Keep full namespace input in storage.

Previously we've stored the wallet name only, for hub we extended it to store namespace name as well. But we need the full namespace input (namespace name and network) to be stored.

# How did you test this change?

You can take a look at localstorage data in your browser. Phantom is currently the only wallet that is using hub. 