### PR TITLE
chore: remove discover mode from hub adapter

### DIFF
--- a/queue-manager/rango-preset/src/actions/checkStatus.ts
+++ b/queue-manager/rango-preset/src/actions/checkStatus.ts
@@ -17,7 +17,7 @@ import {
 import { httpService } from '../services';
 import { notifier } from '../services/eventEmitter';
 import {
-  getCurrentBlockchainOf,
+  getCurrentNamespaceOf,
   getNextStep,
   getRelatedWallet,
   getScannerUrl,
@@ -90,13 +90,13 @@ async function checkTransactionStatus({
       if (updatedTxHash !== txId) {
         currentStep.executedTransactionId =
           updatedTxHash || currentStep.executedTransactionId;
-        const currentStepBlockchain = getCurrentBlockchainOf(swap, currentStep);
+        const currentStepNamespace = getCurrentNamespaceOf(swap, currentStep);
         let explorerUrl: string | undefined;
         const blockchainsMetaNotEmpty = !!Object.keys(meta.blockchains).length;
         if (blockchainsMetaNotEmpty) {
           explorerUrl = getScannerUrl(
             currentStep.executedTransactionId,
-            currentStepBlockchain,
+            currentStepNamespace.network,
             meta.blockchains
           );
         }
@@ -314,13 +314,13 @@ async function checkApprovalStatus({
       if (updatedTxHash !== txId) {
         currentStep.executedTransactionId =
           updatedTxHash || currentStep.executedTransactionId;
-        const currentStepBlockchain = getCurrentBlockchainOf(swap, currentStep);
+        const currentStepNamespace = getCurrentNamespaceOf(swap, currentStep);
         let explorerUrl: string | undefined;
         const blockchainsMetaNotEmpty = !!Object.keys(meta.blockchains).length;
         if (blockchainsMetaNotEmpty) {
           explorerUrl = getScannerUrl(
             currentStep.executedTransactionId,
-            currentStepBlockchain,
+            currentStepNamespace.network,
             meta.blockchains
           );
         }

--- a/queue-manager/rango-preset/src/actions/executeTransaction.ts
+++ b/queue-manager/rango-preset/src/actions/executeTransaction.ts
@@ -21,7 +21,7 @@ import {
   signTransaction,
   updateNetworkStatus,
 } from '../helpers';
-import { getCurrentBlockchainOf } from '../shared';
+import { getCurrentNamespaceOf } from '../shared';
 import { BlockReason } from '../types';
 
 /**
@@ -95,8 +95,10 @@ export async function executeTransaction(
     requestBlock(blockedFor);
     return;
   } else if (!networkMatched) {
-    const fromBlockchain = getCurrentBlockchainOf(swap, currentStep);
-    const details = ERROR_MESSAGE_WAIT_FOR_CHANGE_NETWORK(fromBlockchain);
+    const fromNamespace = getCurrentNamespaceOf(swap, currentStep);
+    const details = ERROR_MESSAGE_WAIT_FOR_CHANGE_NETWORK(
+      fromNamespace.network
+    );
 
     const blockedFor = {
       reason: BlockReason.WAIT_FOR_NETWORK_CHANGE,

--- a/queue-manager/rango-preset/src/index.ts
+++ b/queue-manager/rango-preset/src/index.ts
@@ -35,9 +35,13 @@ export {
   StepExecutionBlockedEventStatus,
   EventSeverity,
 } from './types';
-export type { PendingSwapWithQueueID, EventType } from './shared';
+export type {
+  PendingSwapWithQueueID,
+  EventType,
+  TargetNamespace,
+} from './shared';
 export {
-  getCurrentBlockchainOfOrNull,
+  getCurrentNamespaceOfOrNull,
   getRelatedWalletOrNull,
   getRelatedWallet,
   MessageSeverity,

--- a/queue-manager/rango-preset/src/services/eventEmitter.ts
+++ b/queue-manager/rango-preset/src/services/eventEmitter.ts
@@ -14,7 +14,7 @@ import {
   getLastSuccessfulStep,
   isApprovalCurrentStepTx,
 } from '../helpers';
-import { getCurrentBlockchainOfOrNull } from '../shared';
+import { getCurrentNamespaceOfOrNull } from '../shared';
 import {
   EventSeverity,
   RouteEventType,
@@ -179,7 +179,7 @@ export function notifier(params: NotifierParams) {
   const toAsset = `${step.toBlockchain}.${step.toSymbol}`;
   const outputAmount = step.outputAmount ?? '';
   const currentFromBlockchain = !!params.step
-    ? getCurrentBlockchainOfOrNull(params.swap, params.step)
+    ? getCurrentNamespaceOfOrNull(params.swap, params.step)
     : null;
   let message = '';
   let messageSeverity: StepEvent['messageSeverity'] = EventSeverity.INFO;

--- a/queue-manager/rango-preset/src/services/eventEmitter.ts
+++ b/queue-manager/rango-preset/src/services/eventEmitter.ts
@@ -178,7 +178,7 @@ export function notifier(params: NotifierParams) {
   const fromAsset = `${step.fromBlockchain}.${step.fromSymbol}`;
   const toAsset = `${step.toBlockchain}.${step.toSymbol}`;
   const outputAmount = step.outputAmount ?? '';
-  const currentFromBlockchain = !!params.step
+  const currentFromNamespace = !!params.step
     ? getCurrentNamespaceOfOrNull(params.swap, params.step)
     : null;
   let message = '';
@@ -254,7 +254,7 @@ export function notifier(params: NotifierParams) {
         event.status ===
         StepExecutionBlockedEventStatus.WAITING_FOR_NETWORK_CHANGE
       ) {
-        message = `Please change your wallet network to ${currentFromBlockchain}.`;
+        message = `Please change your wallet network to ${currentFromNamespace?.network}.`;
         messageSeverity = EventSeverity.WARNING;
       }
       break;

--- a/queue-manager/rango-preset/src/types.ts
+++ b/queue-manager/rango-preset/src/types.ts
@@ -1,4 +1,4 @@
-import type { Wallet } from './shared';
+import type { TargetNamespace, Wallet } from './shared';
 import type {
   QueueContext,
   QueueDef,
@@ -70,7 +70,7 @@ export interface SwapQueueContext extends QueueContext {
   getSigners: (type: WalletType) => Promise<SignerFactory>;
   switchNetwork: (
     wallet: WalletType,
-    network: Network
+    namespaces: TargetNamespace
   ) => Promise<ConnectResult | ConnectResult[] | undefined> | undefined;
   canSwitchNetworkTo: (type: WalletType, network: Network) => boolean;
   state: (type: WalletType) => WalletState;

--- a/wallets/core/src/legacy/mod.ts
+++ b/wallets/core/src/legacy/mod.ts
@@ -24,7 +24,6 @@ export type {
   WalletInfo as LegacyWalletInfo,
   ConnectResult as LegacyConnectResult,
   NamespaceInputForConnect as LegacyNamespaceInputForConnect,
-  NamespaceInputWithDiscoverMode as LegacyNamespaceInputWithDiscoverMode,
 } from './types.js';
 
 export { Events as LegacyEvents, Networks as LegacyNetworks } from './types.js';
@@ -39,6 +38,5 @@ export { default as LegacyWallet } from './wallet.js';
 
 export {
   eagerConnectHandler as legacyEagerConnectHandler,
-  isNamespaceDiscoverMode as legacyIsNamespaceDiscoverMode,
   isEvmNamespace as legacyIsEvmNamespace,
 } from './utils.js';

--- a/wallets/core/src/legacy/types.ts
+++ b/wallets/core/src/legacy/types.ts
@@ -240,25 +240,14 @@ export type ProviderInterface = { config: WalletConfig } & WalletActions;
 // it comes from wallets.ts and `connect`
 type NetworkTypeFromLegacyConnect = Network | undefined;
 
-export type NamespacesWithDiscoverMode = Namespace | 'DISCOVER_MODE';
-
-export type NamespaceInputWithDiscoverMode = {
-  namespace: 'DISCOVER_MODE';
-  network: string;
+export type NamespaceInputForConnect<T extends Namespace = Namespace> = {
+  /**
+   * By default, you should specify namespace (e.g. evm).
+   */
+  namespace: T;
+  /**
+   * In some cases, we need to connect a specific network on a namespace. e.g. Polygon on EVM.
+   */
+  network: NetworkTypeFromLegacyConnect;
   derivationPath?: string;
 };
-
-export type NamespaceInputForConnect<T extends Namespace = Namespace> =
-  | {
-      /**
-       * By default, you should specify namespace (e.g. evm).
-       * For backward compatibility with legacy implementation, DISCOVER_MODE will try to map a list of known (and hardcoded) networks to a namespace.
-       */
-      namespace: T;
-      /**
-       * In some cases, we need to connect a specific network on a namespace. e.g. Polygon on EVM.
-       */
-      network: NetworkTypeFromLegacyConnect;
-      derivationPath?: string;
-    }
-  | NamespaceInputWithDiscoverMode;

--- a/wallets/core/src/legacy/utils.ts
+++ b/wallets/core/src/legacy/utils.ts
@@ -1,7 +1,4 @@
-import type {
-  NamespaceInputForConnect,
-  NamespaceInputWithDiscoverMode,
-} from './types.js';
+import type { NamespaceInputForConnect } from './types.js';
 
 export async function eagerConnectHandler<R = unknown>(params: {
   canEagerConnect: () => Promise<boolean>;
@@ -14,12 +11,6 @@ export async function eagerConnectHandler<R = unknown>(params: {
     return await params.connectHandler();
   }
   throw new Error(`can't restore connection for ${params.providerName}.`);
-}
-
-export function isNamespaceDiscoverMode(
-  namespace: NamespaceInputForConnect
-): namespace is NamespaceInputWithDiscoverMode {
-  return namespace.namespace === 'DISCOVER_MODE';
 }
 
 export function isEvmNamespace(

--- a/wallets/react/src/hub/autoConnect.ts
+++ b/wallets/react/src/hub/autoConnect.ts
@@ -10,17 +10,13 @@ import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 import {
   legacyEagerConnectHandler,
   legacyIsEvmNamespace,
-  legacyIsNamespaceDiscoverMode,
 } from '@rango-dev/wallets-core/legacy';
 
 import { HUB_LAST_CONNECTED_WALLETS } from '../legacy/mod.js';
 
 import { sequentiallyRun } from './helpers.js';
 import { LastConnectedWalletsFromStorage } from './lastConnectedWallets.js';
-import {
-  convertNamespaceNetworkToEvmChainId,
-  discoverNamespace,
-} from './utils.js';
+import { convertNamespaceNetworkToEvmChainId } from './utils.js';
 
 /**
  * Run `.connect` action on some selected namespaces (passed as param) for a provider.
@@ -42,9 +38,7 @@ async function eagerConnect(
   }
 
   if (!namespacesInput) {
-    throw new Error(
-      'Passing namespace to `connect` is required. you can pass DISCOVERY_MODE for legacy.'
-    );
+    throw new Error('Passing namespace to `connect` is required. ');
   }
 
   const targetNamespaces: [
@@ -52,12 +46,7 @@ async function eagerConnect(
     AllProxiedNamespaces
   ][] = [];
   namespacesInput.forEach((namespaceInput) => {
-    let targetNamespace: Namespace;
-    if (legacyIsNamespaceDiscoverMode(namespaceInput)) {
-      targetNamespace = discoverNamespace(namespaceInput.network);
-    } else {
-      targetNamespace = namespaceInput.namespace;
-    }
+    const targetNamespace: Namespace = namespaceInput.namespace;
 
     const result = wallet.findByNamespace(targetNamespace);
 

--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -2,10 +2,8 @@ import type { AllProxiedNamespaces, ExtensionLink } from './types.js';
 import type { Providers } from '../index.js';
 import type { Provider } from '@rango-dev/wallets-core';
 import type { LegacyNamespaceInputForConnect } from '@rango-dev/wallets-core/legacy';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 import type { VersionedProviders } from '@rango-dev/wallets-core/utils';
 
-import { legacyIsNamespaceDiscoverMode } from '@rango-dev/wallets-core/legacy';
 import { type WalletInfo } from '@rango-dev/wallets-shared';
 import { useEffect, useRef, useState } from 'react';
 
@@ -26,7 +24,6 @@ import {
 import { useHubRefs } from './useHubRefs.js';
 import {
   checkHubStateAndTriggerEvents,
-  discoverNamespace,
   getLegacyProvider,
   transformHubResultToLegacyResult,
   tryConvertNamespaceNetworkToChainInfo,
@@ -146,9 +143,7 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
       }
 
       if (!namespaces) {
-        throw new Error(
-          'Passing namespace to `connect` is required. you can pass DISCOVERY_MODE for legacy.'
-        );
+        throw new Error('Passing namespace to `connect` is required.');
       }
 
       // Check `namespace` and look into hub to see how it can match given namespace to hub namespace.
@@ -157,12 +152,7 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
         AllProxiedNamespaces
       ][] = [];
       namespaces.forEach((namespace) => {
-        let targetNamespace: Namespace;
-        if (legacyIsNamespaceDiscoverMode(namespace)) {
-          targetNamespace = discoverNamespace(namespace.network);
-        } else {
-          targetNamespace = namespace.namespace;
-        }
+        const targetNamespace = namespace.namespace;
 
         const result = wallet.findByNamespace(targetNamespace);
 

--- a/wallets/react/src/hub/utils.ts
+++ b/wallets/react/src/hub/utils.ts
@@ -6,7 +6,6 @@ import type {
   LegacyProviderInterface,
   LegacyEventHandler as WalletEventHandler,
 } from '@rango-dev/wallets-core/legacy';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 
 import {
   guessProviderStateSelector,
@@ -21,7 +20,6 @@ import { pickVersion } from '@rango-dev/wallets-core/utils';
 import {
   type AddEthereumChainParameter,
   convertEvmBlockchainMetaToEvmChainInfo,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { type BlockchainMeta, isEvmBlockchain } from 'rango-types';
 
@@ -225,87 +223,6 @@ export function checkHubStateAndTriggerEvents(
       );
     }
   });
-}
-
-/**
- * For backward compatibility, there is an special namespace called DISCOVER_MODE.
- * Alongside `DISCOVER_MODE`, `network` will be set as well. here we are manually matching networks to namespaces.
- * This will help us keep the legacy interface and have what hub needs as well.
- */
-export function discoverNamespace(network: string): Namespace {
-  // This trick is using for enforcing exhaustiveness check.
-  network = network as unknown as Networks;
-  switch (network) {
-    case Networks.AKASH:
-    case Networks.BANDCHAIN:
-    case Networks.BITCANNA:
-    case Networks.BITSONG:
-    case Networks.BINANCE:
-    case Networks.CRYPTO_ORG:
-    case Networks.CHIHUAHUA:
-    case Networks.COMDEX:
-    case Networks.COSMOS:
-    case Networks.CRONOS:
-    case Networks.DESMOS:
-    case Networks.EMONEY:
-    case Networks.INJECTIVE:
-    case Networks.IRIS:
-    case Networks.JUNO:
-    case Networks.KI:
-    case Networks.KONSTELLATION:
-    case Networks.KUJIRA:
-    case Networks.LUMNETWORK:
-    case Networks.MEDIBLOC:
-    case Networks.OSMOSIS:
-    case Networks.PERSISTENCE:
-    case Networks.REGEN:
-    case Networks.SECRET:
-    case Networks.SENTINEL:
-    case Networks.SIF:
-    case Networks.STARGAZE:
-    case Networks.STARNAME:
-    case Networks.TERRA:
-    case Networks.THORCHAIN:
-    case Networks.UMEE:
-      return 'Cosmos';
-    case Networks.AVAX_CCHAIN:
-    case Networks.ARBITRUM:
-    case Networks.BOBA:
-    case Networks.BSC:
-    case Networks.FANTOM:
-    case Networks.ETHEREUM:
-    case Networks.FUSE:
-    case Networks.GNOSIS:
-    case Networks.HARMONY:
-    case Networks.MOONBEAM:
-    case Networks.MOONRIVER:
-    case Networks.OPTIMISM:
-    case Networks.POLYGON:
-    case Networks.STARKNET:
-      return 'Evm';
-    case Networks.SOLANA:
-      return 'Solana';
-    case Networks.BTC:
-    case Networks.BCH:
-    case Networks.DOGE:
-    case Networks.LTC:
-    case Networks.TRON:
-      return 'UTXO';
-    case Networks.TON:
-      return 'Ton';
-    case Networks.POLKADOT:
-    case Networks.AXELAR:
-    case Networks.MARS:
-    case Networks.MAYA:
-    case Networks.STRIDE:
-    case Networks.Unknown:
-      throw new Error("Namespace isn't supported. network: " + network);
-  }
-
-  throw new Error(
-    "Couldn't matched network with any namespace. it's not discoverable. network: " +
-      network
-  );
 }
 
 export function getLegacyProvider(

--- a/wallets/react/src/legacy/useLegacyProviders.ts
+++ b/wallets/react/src/legacy/useLegacyProviders.ts
@@ -1,9 +1,5 @@
 import type { ProviderContext, ProviderProps } from './types.js';
-import type {
-  LegacyNamespaceInputForConnect,
-  LegacyNamespaceInputWithDiscoverMode,
-  LegacyProviderInterface,
-} from '@rango-dev/wallets-core/legacy';
+import type { LegacyProviderInterface } from '@rango-dev/wallets-core/legacy';
 import type { WalletType } from '@rango-dev/wallets-shared';
 
 import { useEffect, useReducer } from 'react';
@@ -55,20 +51,6 @@ export function useLegacyProviders(
         throw new Error(`You should add ${type} to provider first.`);
       }
 
-      /**
-       * Discover mode has a meaning in hub, so we are considering whenever a namespace with DISCOVER_MODE reaches here,
-       * we can ignore it and don't pass it to provider.
-       */
-      const namespacesForConnect = namespaces?.filter(
-        (
-          ns
-        ): ns is Exclude<
-          LegacyNamespaceInputForConnect,
-          LegacyNamespaceInputWithDiscoverMode
-        > => {
-          return ns.namespace !== 'DISCOVER_MODE';
-        }
-      );
       // Legacy providers doesn't implemented multiple namespaces, so it will always be one value.
       let network = undefined;
       if (namespaces && namespaces.length > 0) {
@@ -80,10 +62,7 @@ export function useLegacyProviders(
       }
 
       const walletInstance = getWalletInstance(wallet);
-      const result = await walletInstance.connect(
-        network,
-        namespacesForConnect
-      );
+      const result = await walletInstance.connect(network, namespaces);
       if (props.autoConnect) {
         void tryPersistWallet({
           type,

--- a/widget/embedded/src/QueueManager.tsx
+++ b/widget/embedded/src/QueueManager.tsx
@@ -1,5 +1,8 @@
-import type { SwapQueueContext } from '@rango-dev/queue-manager-rango-preset';
-import type { Network, WalletType } from '@rango-dev/wallets-shared';
+import type {
+  SwapQueueContext,
+  TargetNamespace,
+} from '@rango-dev/queue-manager-rango-preset';
+import type { WalletType } from '@rango-dev/wallets-shared';
 import type { PropsWithChildren } from 'react';
 
 import {
@@ -48,16 +51,14 @@ function QueueManager(props: PropsWithChildren<{ apiKey?: string }>) {
     })),
   };
 
-  const switchNetwork = async (wallet: WalletType, network: Network) => {
-    if (!canSwitchNetworkTo(wallet, network)) {
+  const switchNetwork = async (
+    wallet: WalletType,
+    namespace: TargetNamespace
+  ) => {
+    if (!canSwitchNetworkTo(wallet, namespace.network)) {
       return undefined;
     }
-    const result = await connect(wallet, [
-      {
-        namespace: 'DISCOVER_MODE',
-        network,
-      },
-    ]);
+    const result = await connect(wallet, [namespace]);
 
     return result;
   };

--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -3,7 +3,7 @@ import type { ModalState } from '../SwapDetailsModal';
 
 import { i18n } from '@lingui/core';
 import {
-  getCurrentBlockchainOfOrNull,
+  getCurrentNamespaceOfOrNull,
   getCurrentStep,
   getRelatedWalletOrNull,
 } from '@rango-dev/queue-manager-rango-preset';
@@ -138,8 +138,8 @@ export function SwapDetails(props: SwapDetailsProps) {
   const lastConvertedTokenInFailedSwap =
     getLastConvertedTokenInFailedSwap(swap);
 
-  const currentStepBlockchain = currentStep
-    ? getCurrentBlockchainOfOrNull(swap, currentStep)
+  const currentStepNamespace = currentStep
+    ? getCurrentNamespaceOfOrNull(swap, currentStep)
     : null;
   const currentStepWallet = currentStep
     ? getRelatedWalletOrNull(swap, currentStep)
@@ -154,16 +154,19 @@ export function SwapDetails(props: SwapDetailsProps) {
   const showSwitchNetwork =
     currentStepNetworkStatus ===
       PendingSwapNetworkStatus.WaitingForNetworkChange &&
-    !!currentStepBlockchain &&
+    !!currentStepNamespace &&
     !!currentStepWallet?.walletType &&
     (isMobileWallet(currentStepWallet.walletType) ||
-      canSwitchNetworkTo(currentStepWallet.walletType, currentStepBlockchain));
+      canSwitchNetworkTo(
+        currentStepWallet.walletType,
+        currentStepNamespace.network
+      ));
 
   const switchNetwork = showSwitchNetwork
     ? connect.bind(null, currentStepWallet.walletType, [
         {
-          namespace: 'DISCOVER_MODE',
-          network: currentStepBlockchain,
+          namespace: currentStepNamespace.namespace,
+          network: currentStepNamespace.network,
         },
       ])
     : undefined;

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.helpers.ts
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.helpers.ts
@@ -5,7 +5,7 @@ import type { PendingSwap } from 'rango-types/lib';
 
 import {
   cancelSwap,
-  getCurrentBlockchainOfOrNull,
+  getCurrentNamespaceOfOrNull,
   getCurrentStep,
   getRelatedWalletOrNull,
 } from '@rango-dev/queue-manager-rango-preset';
@@ -66,7 +66,7 @@ export class WidgetHistory {
       step: currentStep,
       wallet: currentStep ? getRelatedWalletOrNull(swap, currentStep) : null,
       network: currentStep
-        ? getCurrentBlockchainOfOrNull(swap, currentStep)
+        ? getCurrentNamespaceOfOrNull(swap, currentStep)?.network
         : null,
     };
   }


### PR DESCRIPTION
# Summary

Remove DISCOVER_MODE from hub's adapter.

Originally, I didn't want to change the usage of `wallets-core` in `embedded` but there is a difference between legacy and hub and that is hub needs to pass `namespace` for connecting. legacy didn't have the namespace concept at all and you could connect using `network`. To make these compatible with each other, I created a hardcoded `network` -> `namespace` map in adapter.
This works but it's not and ideal way to use and keep. In this PR I removed this mode from hub and did the necessary changes to `embedded` code (specifically, `rango-preset`) to have namespace and pass it to hub. 

Fixes RF-1967

# More notes for reviewer

There are two commits, first commit removed the DISCOVER_MODE from our wallet management. The second commit introduced the concept of `namespace` to `rango-preset` so we have both `namespace` and `network` from now on.
Then, I directly used whatever `rango-preset` is returning.

In second commit, you see `blockchain` has been renamed to `namespace` and the function signature has been updated accordingly. Also the rest of changes are updating the usage of those functions. `embedded` also updated to use the namespace returned by `rango-preset`. 


# How did you test this change?

This code affected the `connect` only. There are two types of `connect`:

1. Connect the whole wallet (in Wallets page).
2. Switch network

You can test these changes by try to connect you wallets and also try to test switch network in swap flow. Don't forget to switch network has two scenarios, one, you trying to do a swap and your active network is something else, you will be asked to switch network. The other one is when you are refreshing page on the middle of you swap and swap will reach an state that wants to do you swap and your active network is something else.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
