### PR TITLE
fix: clean up old balances when switching account

### DIFF
--- a/wallets/core/src/namespaces/common/builders.ts
+++ b/wallets/core/src/namespaces/common/builders.ts
@@ -11,9 +11,4 @@ export const disconnect = <
 >() =>
   new ActionBuilder<AutoImplementedActionsByRecommended, 'disconnect'>(
     'disconnect'
-  )
-    .after((c) => {
-      c;
-      //
-    })
-    .action(disconnectAction) as unknown as ActionBuilder<T, 'disconnect'>;
+  ).action(disconnectAction) as unknown as ActionBuilder<T, 'disconnect'>;

--- a/wallets/core/src/namespaces/evm/actions.ts
+++ b/wallets/core/src/namespaces/evm/actions.ts
@@ -71,8 +71,18 @@ export function changeAccountSubscriber(
       const [, setState] = context.state();
 
       eventCallback = async (accounts) => {
-        const chainId = await evmInstance.request({ method: 'eth_chainId' });
+        /*
+         * In Phantom, when user is switching to an account which is not connected to dApp yet, it returns a null.
+         * So null means we don't have access to account and we need to disconnect and let the user connect the account.
+         *
+         * This assumption may not work for other wallets, if that the case, we need to consider a new approach.
+         */
+        if (!accounts || accounts.length === 0) {
+          context.action('disconnect');
+          return;
+        }
 
+        const chainId = await evmInstance.request({ method: 'eth_chainId' });
         const formatAccounts = accounts.map((account) =>
           AccountId.format({
             address: account,

--- a/widget/embedded/src/store/slices/wallets.ts
+++ b/widget/embedded/src/store/slices/wallets.ts
@@ -55,7 +55,12 @@ export interface WalletsSlice {
   setConnectedWalletAsRefetching: (walletType: string) => void;
   setConnectedWalletHasError: (walletType: string) => void;
   setConnectedWalletRetrievedData: (walletType: string) => void;
-  removeBalancesForWallet: (walletType: string) => void;
+  removeBalancesForWallet: (
+    walletType: string,
+    options?: {
+      chains?: string[];
+    }
+  ) => void;
   addConnectedWallet: (accounts: Wallet[]) => void;
   setWalletsAsSelected: (
     wallets: { walletType: string; chain: string }[]
@@ -254,7 +259,7 @@ export const createWalletsSlice: StateCreator<
 
     void get().fetchBalances(accounts);
   },
-  removeBalancesForWallet: (walletType) => {
+  removeBalancesForWallet: (walletType, options) => {
     let walletsNeedsToBeRemoved = get().connectedWallets.filter(
       (connectedWallet) => connectedWallet.walletType === walletType
     );
@@ -274,6 +279,12 @@ export const createWalletsSlice: StateCreator<
         });
       }
     });
+
+    if (!!options?.chains && options.chains.length > 0) {
+      walletsNeedsToBeRemoved = walletsNeedsToBeRemoved.filter((wallet) => {
+        return options.chains?.includes(wallet.chain);
+      });
+    }
 
     const nextBalancesState: BalanceState = {};
     let nextAggregatedBalanceState: AggregatedBalanceState =


### PR DESCRIPTION
# Summary

Fix updating balances when switching network in wallet.

We've changed how we store balances in our app, in our new approach we are caching the balances somehow. We need to clean up these cache when switching account for a wallet.

Fixes RF-2051


# How did you test this change?

Try to switch account in your wallets, balances should be updated correctly. This is not only related to Hub compatible wallets, legacy wallets have been affected. So please check with some of your installed wallets including Phantom and other wallets you may have. 


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
