### PR TITLE
fix: fix hub bugs with wallet list

### DIFF
--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -111,6 +111,7 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
         ),
         allBlockChains: params.allBlockChains,
         getHub,
+        wallets: params.configs?.wallets,
       });
     },
   });

--- a/wallets/react/src/legacy/types.ts
+++ b/wallets/react/src/legacy/types.ts
@@ -1,6 +1,7 @@
 import type { ProviderInfo, VersionedProviders } from '@rango-dev/wallets-core';
 import type {
   LegacyNamespaceInputForConnect,
+  LegacyProviderInterface,
   LegacyNetwork as Network,
   LegacyEventHandler as WalletEventHandler,
   LegacyWalletInfo as WalletInfo,
@@ -56,6 +57,7 @@ export type ProviderProps = PropsWithChildren<{
   providers: VersionedProviders[];
   configs?: {
     isExperimentalEnabled?: boolean;
+    wallets?: (WalletType | LegacyProviderInterface)[];
   };
 }>;
 

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -149,6 +149,7 @@ function Main(props: PropsWithChildren<PropTypes>) {
         onUpdateState={onUpdateState}
         autoConnect={!!isActiveTab}
         configs={{
+          wallets: config.wallets,
           isExperimentalEnabled: isFeatureEnabled(
             'experimentalWallet',
             config.features


### PR DESCRIPTION
# Summary

1. When hub attempts to auto connect some wallets which are removed from widget config, it results in crashing the app. This problem is resolved in this PR by checking wallets config before performing auto connect.
2. If list of wallets is given as config to widget which includes a wallet with version "1", it fails to pick both versions for that provider and results in app crash. This problem is fixed in the second commit.

Fixes # (issue)


# How did you test this change?

1. Tested by connecting a wallet which supports auto connect and then remove that wallet from wallets config and refreshing the page. By doing this no crash should happen.
2. Tested by including 'phantom' in widget config wallets.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
