### PR TITLE
feat: add profile banner to widget success modal

### DIFF
--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { WIDGET_UI_ID } from '../../constants';
+import { useUiStore } from '../../store/ui';
 import { getContainer } from '../../utils/common';
 import { WatermarkedModal } from '../common/WatermarkedModal';
 
@@ -31,6 +32,7 @@ export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
     diagnosisUrl,
   } = props;
   const navigate = useNavigate();
+  const { showProfileBanner } = useUiStore();
 
   return (
     <WatermarkedModal
@@ -72,21 +74,32 @@ export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
           description={description}
         />
       )}
-      <Divider size={32} />
+      <Divider size={30} />
       {status === 'success' && (
-        <Button
-          id="widget-swap-details-modal-done-btn"
-          variant="contained"
-          type="primary"
-          size="large"
-          onClick={() => {
-            const home = '../../';
-            navigate(home);
-          }}>
-          <Typography variant="title" size="medium" color="neutral100">
+        <>
+          {showProfileBanner && (
+            <>
+              <img
+                src={
+                  'https://raw.githubusercontent.com/rango-exchange/assets/main/banners/widget/profile.png'
+                }
+                alt="Profile Banner"
+              />
+              <Divider size={30} />
+            </>
+          )}
+          <Button
+            id="widget-swap-details-modal-done-btn"
+            variant="contained"
+            type="primary"
+            size="large"
+            onClick={() => {
+              const home = '../../';
+              navigate(home);
+            }}>
             {i18n.t('Done')}
-          </Typography>
-        </Button>
+          </Button>
+        </>
       )}
       <Divider size={12} />
       {diagnosisUrl && (

--- a/widget/embedded/src/hooks/useFetchApiConfig.ts
+++ b/widget/embedded/src/hooks/useFetchApiConfig.ts
@@ -6,6 +6,9 @@ export type Watermark = 'NONE' | 'FULL';
 type ConfigResponse = {
   config: {
     watermark: Watermark;
+    banners: {
+      profile: boolean;
+    };
   };
 };
 
@@ -14,7 +17,7 @@ interface UseFetchApiConfig {
 }
 
 export function useFetchApiConfig(): UseFetchApiConfig {
-  const { setWatermark } = useUiStore();
+  const { setWatermark, setShowProfileBanner } = useUiStore();
 
   const fetchApiConfig: UseFetchApiConfig['fetchApiConfig'] = async () => {
     const response = await fetch(
@@ -28,6 +31,7 @@ export function useFetchApiConfig(): UseFetchApiConfig {
     const data: ConfigResponse = await response.json();
 
     setWatermark(data.config.watermark);
+    setShowProfileBanner(data.config.banners.profile);
   };
   return { fetchApiConfig };
 }

--- a/widget/embedded/src/store/ui.ts
+++ b/widget/embedded/src/store/ui.ts
@@ -12,12 +12,14 @@ interface UiState {
   tabManagerInitiated: boolean;
   showActivateTabModal: boolean;
   watermark: Watermark;
+  showProfileBanner: boolean;
   activateCurrentTab: (
     setCurrentTabAsActive: () => void,
     hasRunningSwaps: boolean
   ) => void;
   setShowActivateTabModal: (flag: boolean) => void;
   setWatermark: (watermark: Watermark) => void;
+  setShowProfileBanner: (showProfileBanner: boolean) => void;
 }
 
 export const useUiStore = createSelectors(
@@ -26,6 +28,7 @@ export const useUiStore = createSelectors(
     tabManagerInitiated: false,
     showActivateTabModal: false,
     watermark: 'NONE',
+    showProfileBanner: false,
     fetchingApiConfig: false,
     activateCurrentTab: (setCurrentTabAsActive, hasRunningSwaps) => {
       const { showActivateTabModal } = get();
@@ -41,6 +44,9 @@ export const useUiStore = createSelectors(
     },
     setWatermark: (watermark) => {
       set({ watermark });
+    },
+    setShowProfileBanner: (showProfileBanner) => {
+      set({ showProfileBanner });
     },
   }))
 );

--- a/widget/embedded/tsconfig.json
+++ b/widget/embedded/tsconfig.json
@@ -1,1 +1,4 @@
-{ "extends": "./tsconfig.build.json", "include": ["src", "tests"] }
+{
+  "extends": "./tsconfig.build.json",
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
# Summary

In the `config` API, we have an object named `banners` that has a boolean object named `profile`. If it is `true`, we need to display the profile banner in the widget success modal.

Fixes # (issue)

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
