### PR TITLE
fix: update connected namespaces in storage on switch account

### DIFF
--- a/wallets/react/src/hub/autoConnect.ts
+++ b/wallets/react/src/hub/autoConnect.ts
@@ -131,7 +131,7 @@ export async function autoConnect(deps: {
       const namespaces: LegacyNamespaceInputForConnect[] = lastConnectedWallets[
         providerName
       ].map((namespace) => ({
-        namespace: namespace.namsepace,
+        namespace: namespace.namespace,
         network: namespace.network,
       }));
 

--- a/wallets/react/src/hub/lastConnectedWallets.ts
+++ b/wallets/react/src/hub/lastConnectedWallets.ts
@@ -8,7 +8,7 @@ import {
 } from './constants.js';
 
 export interface NamespaceInput {
-  namsepace: Namespace;
+  namespace: Namespace;
   network: string | undefined;
 }
 
@@ -50,6 +50,12 @@ export class LastConnectedWalletsFromStorage {
       return this.#listFromHub();
     } else if (this.#storageKey === LEGACY_LAST_CONNECTED_WALLETS) {
       return this.#listFromLegacy();
+    }
+    throw new Error('Not implemented');
+  }
+  removeNamespacesFromWallet(providerId: string, namespaceIds: string[]) {
+    if (this.#storageKey === HUB_LAST_CONNECTED_WALLETS) {
+      return this.#removeNamespaceFromWalletHub(providerId, namespaceIds);
     }
     throw new Error('Not implemented');
   }
@@ -104,6 +110,21 @@ export class LastConnectedWalletsFromStorage {
     });
 
     persistor.setItem(this.#storageKey, storageState);
+  }
+  #removeNamespaceFromWalletHub(
+    providerId: string,
+    namespaceIds: string[]
+  ): void {
+    const persistor = new Persistor<LastConnectedWalletsStorage>();
+    const storageState = persistor.getItem(this.#storageKey) || {};
+
+    const currentProviderNamespaces = storageState[providerId];
+    const newProviderNamespaces = currentProviderNamespaces.filter(
+      (namespace) => !namespaceIds.includes(namespace.namespace)
+    );
+
+    this.#removeWalletsFromHub([providerId]);
+    this.#addWalletToHub(providerId, newProviderNamespaces);
   }
   #removeWalletsFromLegacy(providerIds?: string[]): void {
     const persistor = new Persistor<LegacyLastConnectedWalletsStorage>();

--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -187,7 +187,7 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
             .then<ConnectResult>(transformHubResultToLegacyResult)
             .then((res) => {
               successfulyConnectedNamespaces.push({
-                namsepace: namespaceInput.namespace,
+                namespace: namespaceInput.namespace,
                 network: namespaceInput.network,
               });
               return res;


### PR DESCRIPTION
# Summary

Fixed two bugs:

Update connected namespaces for wallets in storage on switch account

Fixes # (RF-2098)

# How did you test this change?

Tested this change by connecting phantom wallet on solana namespace. Observed that solana namespace is set in local storage in `hub-v1-last-connected-wallets` for phantom wallet. After that I switch to an account which only contains ethereum address and observed that local storage updated as result of disconnecting wallet.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
