### PR TITLE
fix: ctrl wallet is changing 'keplr' named function to undefined

### DIFF
--- a/wallets/core/src/legacy/wallet.ts
+++ b/wallets/core/src/legacy/wallet.ts
@@ -318,6 +318,13 @@ class Wallet<InstanceType = any> {
   }
 
   onInit() {
+    // some times functions can be overridden by wallets. see rf-2119
+    if (!this.actions.getInstance) {
+      throw new Error(
+        `Provider hasn't defined how to get wallet's instance. provider: ${this.options.config.type} on: onInit`
+      );
+    }
+
     if (!this.options.config.isAsyncInstance) {
       const instance = this.actions.getInstance();
       if (!!instance && !this.state.installed) {

--- a/wallets/provider-keplr/src/helpers.ts
+++ b/wallets/provider-keplr/src/helpers.ts
@@ -1,6 +1,4 @@
-
-export function keplr() {
+// Note: for unknown reason CTRL wallet extension is overiding any function named `keplr`. so make sure you will not use this name for any function!
+export function getKeplrInstance() {
   return window.keplr || null;
 }
-
-

--- a/wallets/provider-keplr/src/index.ts
+++ b/wallets/provider-keplr/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from '@rango-dev/wallets-shared';
 import { cosmosBlockchains } from 'rango-types';
 
-import { keplr as keplrInstance } from './helpers.js';
+import { getKeplrInstance } from './helpers.js';
 import signer from './signer.js';
 
 const WALLET = WalletTypes.KEPLR;
@@ -24,7 +24,7 @@ export const config = {
   defaultNetwork: Networks.COSMOS,
 };
 
-export const getInstance = keplrInstance;
+export const getInstance = getKeplrInstance;
 
 export const connect: Connect = async ({ instance, network, meta }) => {
   return await getCosmosAccounts({


### PR DESCRIPTION
# Summary

Avoid CTRL to override the function named `keplr`.

We've faced with a weird bug where Having CTRL and Keplr at the same time causing an app crash. The first investigation was changing the getInstance from function declaration to arrow function in keplr provider will fix the issue. After more investigation I tried to see the difference between these two function declaring to find the root cause.

here is the transpiled verson for function declariont (simplified):

```js
var c = Object.defineProperty;
var r = (e, o) => c(e, "name", {
    value: o,
    configurable: !0
});

function s() {
    return window.keplr || null
}
r(s, "keplr");

// then export s as getInstance
```

and arrow function:
```js
r(() => window.keplr || null, "getInstance")

// then export.
```

the only difference is in the first one, the function will keep it's original name `keplr` but in the second one it will be named as `getInstance` (transpilers do this for better debugging).

I changed the name of function and issue has been solved! CTRL extension is changing `keplr` function to `undefined` somehow!


Fixes RF-2119


# How did you test this change?

Try to active both CTRL and Keplr wallets. app shouldn't crash.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
