### PR TITLE
fix: remove namespace from storage on auto connect failure

### DIFF
--- a/wallets/react/src/hub/helpers.ts
+++ b/wallets/react/src/hub/helpers.ts
@@ -42,14 +42,20 @@ export function fromAccountIdToLegacyAddressFormat(account: string): string {
 /**
  * Getting a list of (lazy) promises and run them one after another.
  */
-export async function sequentiallyRun<T extends () => Promise<unknown>>(
+export async function runSequentiallyWithoutFailure<
+  T extends () => Promise<unknown>
+>(
   promises: Array<T>
 ): Promise<Array<T extends () => Promise<infer R> ? R : never>> {
   const result = await promises.reduce(async (prev, task) => {
     const previousResults = await prev;
-    const taskResult = await task();
+    try {
+      const taskResult = await task();
 
-    return [...previousResults, taskResult];
+      return [...previousResults, taskResult];
+    } catch (error) {
+      return [...previousResults, error];
+    }
   }, Promise.resolve([]) as Promise<any>);
   return result;
 }

--- a/wallets/react/src/legacy/autoConnect.ts
+++ b/wallets/react/src/legacy/autoConnect.ts
@@ -46,33 +46,21 @@ export async function autoConnect(
       eagerConnectQueue.map(async ({ eagerConnect }) => eagerConnect())
     );
 
-    const canRestoreAnyConnection = !!result.find(
-      ({ status }) => status === 'fulfilled'
-    );
+    const walletsToRemoveFromPersistance: WalletType[] = [];
+    result.forEach((settleResult, index) => {
+      const { status } = settleResult;
 
-    /*
-     *After successfully connecting to at least one wallet,
-     *we will removing the other wallets from persistence.
-     *If we are unable to connect to any wallet,
-     *the persistence will not be removed and the eager connection will be retried with another page load.
-     */
-    if (canRestoreAnyConnection) {
-      const walletsToRemoveFromPersistance: WalletType[] = [];
-      result.forEach((settleResult, index) => {
-        const { status } = settleResult;
-
-        if (status === 'rejected') {
-          walletsToRemoveFromPersistance.push(
-            eagerConnectQueue[index].walletType
-          );
-        }
-      });
-
-      if (walletsToRemoveFromPersistance.length) {
-        lastConnectedWalletsFromStorage.removeWallets(
-          walletsToRemoveFromPersistance
+      if (status === 'rejected') {
+        walletsToRemoveFromPersistance.push(
+          eagerConnectQueue[index].walletType
         );
       }
+    });
+
+    if (walletsToRemoveFromPersistance.length) {
+      lastConnectedWalletsFromStorage.removeWallets(
+        walletsToRemoveFromPersistance
+      );
     }
   }
 }


### PR DESCRIPTION
# Summary

Remove namespace from storage on auto connect failure. 

Fixes # (RF-2118)


# How did you test this change?

Tested this change by changin phantom account to an account containg only Solana address and setting `{"phantom":[{"namespace":"Solana"},{"namespace":"EVM"}]}` value for `hub-v1-last-connected-wallets` in localStorage and refreshing the app. Observed that Solana namespace connected successfully and also EVM namespace removed from localstorage.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
