### PR TITLE
fix: fix incorrect wallet state after switch account

### DIFF
--- a/wallets/react/src/hub/utils.ts
+++ b/wallets/react/src/hub/utils.ts
@@ -110,6 +110,7 @@ export function checkHubStateAndTriggerEvents(
     let hasAccountChanged = false;
     let hasNetworkChanged = false;
     let hasProviderDisconnected = false;
+    let anyNamespaceIsConnected = false;
     // It will pick the last network from namespaces.
     let maybeNetwork = null;
     const disconnectedNamespacesIds: string[] = [];
@@ -137,28 +138,30 @@ export function checkHubStateAndTriggerEvents(
       // TODO: `accounts` has been frozen, we should check and find where object.freeze() is calling.
 
       // Check for accounts
-      if (
-        previousNamespaceState.accounts?.slice().sort().toString() !==
-        currentNamespaceState.accounts?.slice().sort().toString()
-      ) {
-        if (currentNamespaceState.accounts) {
-          const formattedAddresses = currentNamespaceState.accounts.map(
-            fromAccountIdToLegacyAddressFormat
-          );
-
-          if (accounts) {
-            accounts = [...accounts, ...formattedAddresses];
-          } else {
-            accounts = [...formattedAddresses];
-          }
-
+      if (currentNamespaceState.accounts) {
+        anyNamespaceIsConnected = true;
+        if (
+          previousNamespaceState.accounts?.slice().sort().toString() !==
+          currentNamespaceState.accounts?.slice().sort().toString()
+        ) {
           hasAccountChanged = true;
-        } else {
-          // Namespace has been disconnected
-          disconnectedNamespacesIds.push(namespace.namespaceId);
-          accounts = null;
-          hasProviderDisconnected = true;
         }
+        const formattedAddresses = currentNamespaceState.accounts.map(
+          fromAccountIdToLegacyAddressFormat
+        );
+
+        if (accounts) {
+          accounts = [...accounts, ...formattedAddresses];
+        } else {
+          accounts = [...formattedAddresses];
+        }
+      } else if (!!previousNamespaceState.accounts) {
+        /*
+         * If previously namespace was connected and now we can not get any accounts from the namespace, the namespace should be considered as disconnected.
+         * For example switching to an account which did not permitted to connect yet or maybe the account does not support the requested namespace.
+         */
+        disconnectedNamespacesIds.push(namespace.namespaceId);
+        hasAccountChanged = true;
       }
     });
 
@@ -167,6 +170,11 @@ export function checkHubStateAndTriggerEvents(
         providerId,
         disconnectedNamespacesIds
       );
+    }
+
+    if (disconnectedNamespacesIds.length > 0 && !anyNamespaceIsConnected) {
+      accounts = null;
+      hasProviderDisconnected = true;
     }
 
     let legacyProvider;
@@ -224,6 +232,8 @@ export function checkHubStateAndTriggerEvents(
       );
     }
     if (hasAccountChanged) {
+      // This event is triggered to clear wallet state and after that set new accounts for wallet
+      onUpdateState(providerId, Events.ACCOUNTS, null, coreState, eventInfo);
       onUpdateState(
         providerId,
         Events.ACCOUNTS,


### PR DESCRIPTION
# Summary

This pull request addresses an inconsistency related to disconnecting Phantom wallets after switching to an account that does not contain both Solana and EVM addresses. Previously, when transitioning from an account with both addresses to one containing only the EVM address, only the Solana account would disconnect. Conversely, moving from an account with both addresses to one with only the Solana address resulted in both Solana and EVM accounts disconnecting.

This PR resolves the issue by ensuring that when switching from an account containing both addresses to one with only either the EVM or Solana address, only the connection to the unavailable address is disconnected. This enhancement provides a more coherent and expected behavior during account transitions.

Fixes # 2141


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
