### PR TITLE
fix: close wallet connection modal after connect with namespace

### DIFF
--- a/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
@@ -14,10 +14,7 @@ import React, { useEffect, useState } from 'react';
 
 import { useWallets } from '../..';
 import { WIDGET_UI_ID } from '../../constants';
-import {
-  ResultStatus,
-  useStatefulConnect,
-} from '../../hooks/useStatefulConnect';
+import { useStatefulConnect } from '../../hooks/useStatefulConnect';
 import { useWalletList } from '../../hooks/useWalletList';
 import { useAppStore } from '../../store/AppStore';
 import { useUiStore } from '../../store/ui';
@@ -227,8 +224,8 @@ export function WalletList(props: PropTypes) {
         onClose={() => {
           setSelectedWalletToConnect(undefined);
         }}
-        onConnect={(result) => {
-          if (props.onConnect && result.status === ResultStatus.Connected) {
+        onConnect={() => {
+          if (props.onConnect) {
             if (selectedWalletToConnect?.type) {
               props.onConnect(selectedWalletToConnect.type);
             } else {


### PR DESCRIPTION
# Summary

Wallet connection modal was not closing automatically after connecting a wallet which needs namespace selection or derivation path entering. It is fixed by calling `afterConnect` method after connecting wallet with namespace or derivation path.

Fixes # 2147


# How did you test this change?

Tested by connecting a wallet which needs namespace or derivation path (such as phantom and ledger) and observing that wallet connection modal closes automatically after successful connect.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
