### PR TITLE
fix: adding balances to ConnectedWallet for WidgetInfo

### DIFF
--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
@@ -23,8 +23,8 @@ export function WidgetInfo(props: React.PropsWithChildren) {
   const retrySwap = useQuoteStore.use.retry();
   const {
     findToken,
-    connectedWallets,
     getBalances,
+    getConnectedWalletsDetails,
     fetchBalances: refetch,
   } = useAppStore();
 
@@ -49,7 +49,7 @@ export function WidgetInfo(props: React.PropsWithChildren) {
     history,
     wallets: {
       isLoading,
-      details: connectedWallets,
+      details: getConnectedWalletsDetails(),
       totalBalance,
       refetch: async (accounts) => refetch(accounts),
     },

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.types.ts
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.types.ts
@@ -1,6 +1,6 @@
 import type { WidgetHistory } from './WidgetInfo.helpers';
 import type { FetchStatus, FindToken } from '../../store/slices/data';
-import type { ConnectedWallet } from '../../store/slices/wallets';
+import type { DeprecatedWalletDetail } from '../../store/slices/wallets';
 import type { QuoteInputs, UpdateQuoteInputs, Wallet } from '../../types';
 import type { Notification } from '../../types/notification';
 import type { BlockchainMeta, SwapperMeta, Token } from 'rango-sdk';
@@ -10,7 +10,7 @@ export interface WidgetInfoContextInterface {
   setCurrentTabAsActive: () => void;
   history: WidgetHistory;
   wallets: {
-    details: ConnectedWallet[];
+    details: DeprecatedWalletDetail[];
     totalBalance: string;
     isLoading: boolean;
     refetch: (accounts: Wallet[]) => void;

--- a/widget/embedded/src/store/utils/wallets.ts
+++ b/widget/embedded/src/store/utils/wallets.ts
@@ -33,8 +33,11 @@ export function createBalanceKey(
 
 export function extractAssetFromBalanceKey(key: BalanceKey): Asset {
   const [assetChain, assetAddress, assetSymbol] = key.split('-');
+
+  // null will be serialized to 'null', we need to make it back to a null type
+  const address = assetAddress === 'null' ? null : assetAddress;
   return {
-    address: assetAddress,
+    address,
     blockchain: assetChain,
     symbol: assetSymbol,
   };


### PR DESCRIPTION
# Summary

Add `balances` to WidgetInfo's `wallets.details`.
 
In https://github.com/rango-exchange/rango-client/pull/852, we refactored the wallets store and a part of that was logic related to `ConnectedWallet`. After refactoring, we've removed a field from the object called `balances`. since this was exposed to outside world using `WalletInfo` we need to revert it back for backward compatibility. (used in our dApp as well.)


# How did you test this change?
 
Don't need to test, it will be tested in https://github.com/rango-exchange/app-v2/pull/145.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
