### PR TITLE
fix: fix total balance calculation for WidgetInfo

### DIFF
--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -280,7 +280,10 @@ export function resetConnectedWalletState(
 
 export const calculateWalletUsdValue = (balances: BalanceState) => {
   const total = Object.values(balances).reduce((prev, balance) => {
-    return balance.usdValue ? prev.plus(balance.usdValue) : prev;
+    const formattedBalance = formatBalance(balance);
+    return formattedBalance?.usdValue
+      ? prev.plus(formattedBalance.usdValue)
+      : prev;
   }, new BigNumber(ZERO));
 
   return numberWithThousandSeparator(total.toString());


### PR DESCRIPTION
# Summary

Fix total balance amount.

It should consider decimals first, then calculate the total balance.


# How did you test this change?

No need to test. will be tested on dApp.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
