### PR TITLE
feat: fetch balance for custom tokens

### DIFF
--- a/widget/embedded/src/store/slices/settings.ts
+++ b/widget/embedded/src/store/slices/settings.ts
@@ -1,5 +1,6 @@
 import type { ConfigSlice } from './config';
 import type { DataSlice } from './data';
+import type { WalletsSlice } from './wallets';
 import type { TokenData } from '../../components/TokenList/TokenList.types';
 import type { WidgetConfig } from '../../types';
 import type { SwapperMeta, Token } from 'rango-sdk';
@@ -53,7 +54,7 @@ export interface SettingsSlice {
 }
 
 export const createSettingsSlice: StateCreator<
-  SettingsSlice & DataSlice & ConfigSlice,
+  SettingsSlice & DataSlice & ConfigSlice & WalletsSlice,
   [],
   [],
   SettingsSlice
@@ -187,10 +188,15 @@ export const createSettingsSlice: StateCreator<
       }),
     });
   },
-  setCustomToken: (token) =>
+  setCustomToken: (token) => {
+    void get().fetchCustomTokensBalance({
+      tokens: [token],
+      connectedWallets: get().connectedWallets,
+    });
     set((state) => ({
       _customTokens: [token, ...state._customTokens],
-    })),
+    }));
+  },
   deleteCustomToken: (token) =>
     set((state) => ({
       _customTokens: state._customTokens.filter(

--- a/widget/embedded/src/store/slices/wallets.ts
+++ b/widget/embedded/src/store/slices/wallets.ts
@@ -1,6 +1,6 @@
 import type { AppStoreState } from './types';
 import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
-import type { Token, WalletDetail } from 'rango-sdk';
+import type { Asset, Token, WalletDetail } from 'rango-sdk';
 
 import BigNumber from 'bignumber.js';
 
@@ -24,6 +24,7 @@ import {
   extractAssetFromBalanceKey,
   removeBalanceFromAggregatedBalance,
   updateAggregatedBalanceStateForNewAccount,
+  updateBalancesWithNewPrices,
 } from '../utils/wallets';
 
 type WalletAddress = string;
@@ -124,6 +125,10 @@ export interface WalletsSlice {
     accounts: Wallet[],
     options?: { retryOnFailedBalances?: boolean }
   ) => Promise<void>;
+  fetchCustomTokensBalance: (params: {
+    tokens: Asset[];
+    connectedWallets: Wallet[];
+  }) => Promise<void>;
   getBalanceFor: (token: Token) => Balance | null;
   getBalances: () => BalanceState;
   getBalancesForWalletAddress: (address: string) => BalanceState;
@@ -295,6 +300,98 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
         });
       }
     },
+    fetchCustomTokensBalance: async (params) => {
+      const { tokens, connectedWallets } = params;
+
+      const tokensByBlockchain = tokens.reduce<{ [key: string]: Asset[] }>(
+        (acc, asset) => {
+          (acc[asset.blockchain] ||= []).push(asset);
+          return acc;
+        },
+        {}
+      );
+
+      const addedWallets = new Set<string>();
+
+      const tokensByWalletAddress = connectedWallets.reduce<{
+        [key: string]: Asset[];
+      }>((acc, wallet) => {
+        const key = `${wallet.address}-${wallet.chain}`;
+        if (addedWallets.has(key)) {
+          return acc;
+        }
+
+        addedWallets.add(key);
+        if (tokensByBlockchain[wallet.chain]) {
+          if (!acc[wallet.address]) {
+            acc[wallet.address] = [];
+          }
+          acc[wallet.address].push(...tokensByBlockchain[wallet.chain]);
+        }
+        return acc;
+      }, {});
+
+      Object.entries(tokensByWalletAddress).forEach(
+        async ([walletAddress, tokens]) => {
+          try {
+            const { balances } = await httpService().getMultipleTokenBalance({
+              assets: tokens.map(({ symbol, address, blockchain }) => ({
+                symbol,
+                address,
+                blockchain,
+              })),
+              walletAddress,
+            });
+
+            if (balances) {
+              let nextBalances: BalanceState = get()._balances;
+              let nextAggregatedBalances: AggregatedBalanceState =
+                get()._aggregatedBalances;
+
+              balances.forEach((balance) => {
+                if (parseFloat(balance.amount.amount) === 0) {
+                  return;
+                }
+
+                const WalletDetail = {
+                  blockChain: balance.asset.blockchain,
+                  balances: [balance],
+                  address: walletAddress,
+                };
+
+                updateBalancesWithNewPrices(WalletDetail, nextBalances, get);
+
+                const balancesForWallet = createBalanceStateForNewAccount(
+                  WalletDetail,
+                  get
+                );
+
+                nextAggregatedBalances =
+                  updateAggregatedBalanceStateForNewAccount(
+                    nextAggregatedBalances,
+                    balancesForWallet
+                  );
+
+                nextBalances = {
+                  ...nextBalances,
+                  ...balancesForWallet,
+                };
+              });
+
+              set((state) => ({
+                _balances: {
+                  ...state._balances,
+                  ...nextBalances,
+                },
+                _aggregatedBalances: nextAggregatedBalances,
+              }));
+            }
+          } catch (error) {
+            console.error(error);
+          }
+        }
+      );
+    },
     setWalletsAsSelected: (wallets) => {
       const nextConnectedWalletsWithUpdatedSelectedStatus =
         get().connectedWallets.map((connectedWallet) => {
@@ -332,6 +429,10 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
       get().addConnectedWallet(accounts, namespace);
 
       void get().fetchBalances(accounts);
+      void get().fetchCustomTokensBalance({
+        tokens: get().customTokens(),
+        connectedWallets: accounts,
+      });
     },
     removeBalancesForWallet: (walletType, options) => {
       let walletsNeedsToBeRemoved = get().connectedWallets.filter(
@@ -562,13 +663,15 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
           }
         }
 
-        let nextBalances: BalanceState = {};
+        let nextBalances: BalanceState = get()._balances;
         let nextAggregatedBalances: AggregatedBalanceState =
           get()._aggregatedBalances;
         walletsDetails.forEach((wallet) => {
           if (wallet.failed) {
             return;
           }
+
+          updateBalancesWithNewPrices(wallet, nextBalances, get);
 
           // Remove old balances for current wallet and blockchain
           get().removeBalancesForWallet(walletType, {


### PR DESCRIPTION
# Summary

We want to fetch the balances of custom tokens for wallets that support the corresponding blockchains whenever new custom tokens are added or a new wallet is connected.
Also implementing the retrieval of the token price from the balances response and updating the `usdValue` in the balance cache.

Fixes # (issue)


# How did you test this change?

You can add a custom token or connect a wallet that supports the blockchain of the custom tokens. A request will be sent to the server to fetch the balances of those tokens.

Sample test case:
3yoMkf3X6bDxjks6YaWwNk4SAbuaysLg1a4BjQKToQAA

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
