### PR TITLE
fix: remove null from wallet name

### DIFF
--- a/wallets/shared/src/helpers.ts
+++ b/wallets/shared/src/helpers.ts
@@ -216,7 +216,8 @@ export function detectMobileScreens(): boolean {
  */
 
 export function splitWalletNetwork(input: string): string[] {
-  const removedAddressInput = input?.split(':')[0] || '';
+  const removedNullInput = input?.split('-null').join('');
+  const removedAddressInput = removedNullInput?.split(':')[0] || '';
   const splittedInput = removedAddressInput.split('-');
   const network = splittedInput[splittedInput.length - 1];
   const walletNetwork = splittedInput.slice(0, -1);

--- a/wallets/shared/src/helpers.ts
+++ b/wallets/shared/src/helpers.ts
@@ -216,13 +216,15 @@ export function detectMobileScreens(): boolean {
  */
 
 export function splitWalletNetwork(input: string): string[] {
-  const removedNullInput = input?.split('-null').join('');
-  const removedAddressInput = removedNullInput?.split(':')[0] || '';
+  const removedAddressInput = input?.split(':')[0] || '';
   const splittedInput = removedAddressInput.split('-');
   const network = splittedInput[splittedInput.length - 1];
   const walletNetwork = splittedInput.slice(0, -1);
 
-  if (walletNetwork[walletNetwork.length - 1] === network) {
+  if (
+    walletNetwork[walletNetwork.length - 1] === network ||
+    walletNetwork[walletNetwork.length - 1] === 'null'
+  ) {
     walletNetwork.pop();
   }
   const wallet = walletNetwork.join('-');


### PR DESCRIPTION
# Summary

If the transaction gets blocked after it has started, it can't be resumed, and the user can't do anything more on Solana wallets.

Fixes # (issue)
I've removed null from the wallet name so the queue manager can resume its job. However, the transaction would be expired. 

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
