### PR TITLE
fix: usdValue shouldn't be formatted to calculate the total value

### DIFF
--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -280,10 +280,10 @@ export function resetConnectedWalletState(
 
 export const calculateWalletUsdValue = (balances: BalanceState) => {
   const total = Object.values(balances).reduce((prev, balance) => {
-    const formattedBalance = formatBalance(balance);
-    return formattedBalance?.usdValue
-      ? prev.plus(formattedBalance.usdValue)
-      : prev;
+    const usdBalance = balance.usdValue
+      ? representAmountInNumber(balance.usdValue, balance.decimals)
+      : ZERO.toFixed();
+    return prev.plus(usdBalance);
   }, new BigNumber(ZERO));
 
   return numberWithThousandSeparator(total.toString());
@@ -324,16 +324,18 @@ export const getKeplrCompatibleConnectedWallets = (
   );
 };
 
+function representAmountInNumber(amount: string, decimals: number): string {
+  return new BigNumber(amount).shiftedBy(-decimals).toFixed();
+}
+
 export function formatBalance(balance: Balance | null): Balance | null {
   if (!balance) {
     return null;
   }
 
-  const amount = new BigNumber(balance.amount)
-    .shiftedBy(-balance.decimals)
-    .toFixed();
+  const amount = representAmountInNumber(balance.amount, balance.decimals);
   const usdValue = balance.usdValue
-    ? new BigNumber(balance.usdValue).shiftedBy(-balance.decimals).toFixed()
+    ? representAmountInNumber(balance.usdValue, balance.decimals)
     : null;
   const formattedAmount = numberToString(
     amount,


### PR DESCRIPTION
# Summary

In [another PR](https://github.com/rango-exchange/rango-client/pull/993) I tried to fix total balance for our dApp integration. I used `formatBalance` to convert amount (pair of amount and decimals) to be represented in decimal format. That function do this but also will format the output to separate numbers by comma (`1,350`). For the calculation I only need the represented value. 


# How did you test this change?

Will be tested in https://github.com/rango-exchange/app-v2/pull/145

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
