### PR TITLE
fix: resolve issue with connecting to solana namespace

### DIFF
--- a/wallets/shared/src/helpers.ts
+++ b/wallets/shared/src/helpers.ts
@@ -146,10 +146,15 @@ export const evmChainsToRpcMap = (
 };
 
 export const getSolanaAccounts: Connect = async ({ instance }) => {
-  // Asking for account from wallet.
-  const solanaResponse = await instance.connect();
+  let account = '';
+  if (instance.isConnected && instance.publicKey) {
+    account = instance.publicKey.toString();
+  } else {
+    // Asking for account from wallet if not connected or no public key available.
+    const solanaResponse = await instance.connect();
+    account = solanaResponse.publicKey.toString();
+  }
 
-  const account = solanaResponse.publicKey.toString();
   return {
     accounts: [account],
     chainId: Networks.SOLANA,


### PR DESCRIPTION
# Summary

Resolved an issue in the Phantom wallet related to connecting to the Solana namespace. Previously, after disconnecting the wallet and attempting to reconnect to both Solana and EVM namespaces, errors occurred with the Solana instance. This problem was fixed by modifying the connection process to the Solana namespace, ensuring that account requests are not sent if the public key is already available.


# How did you test this change?

Connected to Solana namespace, then disconnected and then connected to both namespaces. Observed that both namespaces get connected without any error.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
