### PR TITLE
chore: remove experimental wallets from widget config

### DIFF
--- a/wallets/react/src/hub/utils.ts
+++ b/wallets/react/src/hub/utils.ts
@@ -37,34 +37,25 @@ import { LastConnectedWalletsFromStorage } from './lastConnectedWallets.js';
 
 /* Gets a list of hub and legacy providers and returns a tuple which separates them. */
 export function separateLegacyAndHubProviders(
-  providers: VersionedProviders[],
-  options?: { isExperimentalEnabled?: boolean }
+  providers: VersionedProviders[]
 ): [LegacyProviderInterface[], Provider[]] {
   const LEGACY_VERSION = '0.0.0';
   const HUB_VERSION = '1.0.0';
-  const { isExperimentalEnabled = false } = options || {};
 
-  if (isExperimentalEnabled) {
-    const legacyProviders: LegacyProviderInterface[] = [];
-    const hubProviders: Provider[] = [];
+  const legacyProviders: LegacyProviderInterface[] = [];
+  const hubProviders: Provider[] = [];
 
-    providers.forEach((provider) => {
-      try {
-        const target = pickVersion(provider, HUB_VERSION);
-        hubProviders.push(target[1]);
-      } catch {
-        const target = pickVersion(provider, LEGACY_VERSION);
-        legacyProviders.push(target[1]);
-      }
-    });
+  providers.forEach((provider) => {
+    try {
+      const target = pickVersion(provider, HUB_VERSION);
+      hubProviders.push(target[1]);
+    } catch {
+      const target = pickVersion(provider, LEGACY_VERSION);
+      legacyProviders.push(target[1]);
+    }
+  });
 
-    return [legacyProviders, hubProviders];
-  }
-
-  const legacyProviders = providers.map(
-    (provider) => pickVersion(provider, LEGACY_VERSION)[1]
-  );
-  return [legacyProviders, []];
+  return [legacyProviders, hubProviders];
 }
 
 export function findProviderByType(

--- a/wallets/react/src/legacy/types.ts
+++ b/wallets/react/src/legacy/types.ts
@@ -56,7 +56,6 @@ export type ProviderProps = PropsWithChildren<{
   autoConnect?: boolean;
   providers: VersionedProviders[];
   configs?: {
-    isExperimentalEnabled?: boolean;
     wallets?: (WalletType | LegacyProviderInterface)[];
   };
 }>;

--- a/wallets/react/src/useProviders.ts
+++ b/wallets/react/src/useProviders.ts
@@ -22,12 +22,8 @@ import { useLegacyProviders } from './legacy/mod.js';
  */
 function useProviders(props: ProviderProps) {
   const { providers, ...restProps } = props;
-  const [legacyProviders, hubProviders] = separateLegacyAndHubProviders(
-    providers,
-    {
-      isExperimentalEnabled: restProps.configs?.isExperimentalEnabled,
-    }
-  );
+  const [legacyProviders, hubProviders] =
+    separateLegacyAndHubProviders(providers);
 
   const legacyApi = useLegacyProviders({
     ...restProps,

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -19,7 +19,6 @@ import React, { createContext, useEffect, useMemo, useRef } from 'react';
 import { useWalletProviders } from '../../hooks/useWalletProviders';
 import { AppStoreProvider, useAppStore } from '../../store/AppStore';
 import { useUiStore } from '../../store/ui';
-import { isFeatureEnabled } from '../../utils/settings';
 import {
   prepareAccountsForWalletStore,
   walletAndSupportedChainsNames,
@@ -54,7 +53,6 @@ function Main(props: PropsWithChildren<PropTypes>) {
     walletConnectListedDesktopWalletLink:
       props.config.__UNSTABLE_OR_INTERNAL__
         ?.walletConnectListedDesktopWalletLink,
-    experimentalWallet: props.config.features?.experimentalWallet,
   };
   const { providers } = useWalletProviders(config.wallets, walletOptions);
   const onConnectWalletHandler = useRef<OnWalletConnectionChange>();
@@ -209,10 +207,6 @@ function Main(props: PropsWithChildren<PropTypes>) {
         autoConnect={!!isActiveTab}
         configs={{
           wallets: config.wallets,
-          isExperimentalEnabled: isFeatureEnabled(
-            'experimentalWallet',
-            config.features
-          ),
         }}>
         {props.children}
       </Provider>

--- a/widget/embedded/src/hooks/useWalletList.ts
+++ b/widget/embedded/src/hooks/useWalletList.ts
@@ -40,21 +40,14 @@ interface API {
  */
 export function useWalletList(params?: Params): API {
   const { chain } = params || {};
-  const { config, connectedWallets, getAvailableProviders } = useAppStore();
+  const { connectedWallets, getAvailableProviders } = useAppStore();
   const { state, getWalletInfo } = useWallets();
   const blockchains = useAppStore().blockchains();
   const { handleDisconnect } = useStatefulConnect();
 
   /** It can be what has been set by widget config or as a fallback we use all the supported wallets by our library */
   const listAvailableWalletTypes = configWalletsToWalletName(
-    getAvailableProviders(),
-    {
-      trezorManifest: config?.trezorManifest,
-      walletConnectProjectId: config?.walletConnectProjectId,
-      walletConnectListedDesktopWalletLink:
-        config.__UNSTABLE_OR_INTERNAL__?.walletConnectListedDesktopWalletLink,
-      tonConnect: config.tonConnect,
-    }
+    getAvailableProviders()
   );
 
   let wallets = mapWalletTypesToWalletInfo(

--- a/widget/embedded/src/store/slices/config.ts
+++ b/widget/embedded/src/store/slices/config.ts
@@ -22,7 +22,6 @@ function makeProvidersOptionsFromConfig(
     tonConnect: config?.tonConnect,
     walletConnectListedDesktopWalletLink:
       config.__UNSTABLE_OR_INTERNAL__?.walletConnectListedDesktopWalletLink,
-    experimentalWallet: config.features?.experimentalWallet,
   };
 
   return options;
@@ -42,9 +41,6 @@ export const DEFAULT_CONFIG: WidgetConfig = {
   tonConnect: {
     manifestUrl:
       'https://raw.githubusercontent.com/rango-exchange/rango-types/main/assets/manifests/tonconnect-manifest.json',
-  },
-  features: {
-    experimentalWallet: 'enabled',
   },
 };
 

--- a/widget/embedded/src/store/slices/data.test.ts
+++ b/widget/embedded/src/store/slices/data.test.ts
@@ -34,9 +34,6 @@ const DEFAULT_CONFIG: WidgetConfig = {
     manifestUrl:
       'https://raw.githubusercontent.com/rango-exchange/rango-types/main/assets/manifests/tonconnect-manifest.json',
   },
-  features: {
-    experimentalWallet: 'enabled',
-  },
 };
 
 beforeEach(() => {

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -134,9 +134,6 @@ export type SignersConfig = {
  *
  * @property {'visible' | 'hidden'} [liquiditySource]
  * - The visibility state for the liquiditySource feature. Optional property.
- *
- * @property {'disabled' | 'enabled'} [experimentalWallet]
- * - Enable our experimental version of wallets. Default: disable on production, enabled on dev.
  */
 export type Features = Partial<
   Record<
@@ -148,8 +145,7 @@ export type Features = Partial<
     | 'customTokens',
     'visible' | 'hidden'
   >
-> &
-  Partial<Record<'experimentalWallet', 'disabled' | 'enabled'>>;
+>;
 
 /**
  * `Routing`

--- a/widget/embedded/src/utils/providers.ts
+++ b/widget/embedded/src/utils/providers.ts
@@ -15,7 +15,6 @@ export interface ProvidersOptions {
   >['walletConnectListedDesktopWalletLink'];
   trezorManifest: WidgetConfig['trezorManifest'];
   tonConnect: WidgetConfig['tonConnect'];
-  experimentalWallet?: 'enabled' | 'disabled';
 }
 
 /**
@@ -28,7 +27,6 @@ type BothProvidersInterface = LegacyProviderInterface | Provider;
 export function matchAndGenerateProviders({
   allProviders,
   configWallets,
-  options,
 }: {
   allProviders: VersionedProviders[];
   configWallets: WidgetConfig['wallets'];
@@ -56,10 +54,8 @@ export function matchAndGenerateProviders({
            * If the corresponding provider to a wallet was found in allProvider,
            * it will be add to selected providers.
            */
-          const versionedProvider = pickProviderVersionWithFallbackToLegacy(
-            provider,
-            options
-          );
+          const versionedProvider =
+            pickProviderVersionWithFallbackToLegacy(provider);
           if (versionedProvider instanceof Provider) {
             return versionedProvider.id === requestedWallet;
           }
@@ -100,14 +96,10 @@ export function matchAndGenerateProviders({
 }
 
 function pickProviderVersionWithFallbackToLegacy(
-  provider: VersionedProviders,
-  options?: ProvidersOptions
+  provider: VersionedProviders
 ): BothProvidersInterface {
-  const { experimentalWallet = 'enabled' } = options || {};
-  const version = experimentalWallet == 'disabled' ? '0.0.0' : '1.0.0';
-
   try {
-    return pickVersion(provider, version)[1];
+    return pickVersion(provider, '1.0.0')[1];
   } catch {
     // Fallback to legacy version, if target version doesn't exists.
     return pickVersion(provider, '0.0.0')[1];
@@ -115,13 +107,10 @@ function pickProviderVersionWithFallbackToLegacy(
 }
 
 export function configWalletsToWalletName(
-  providers: VersionedProviders[],
-  options?: ProvidersOptions
+  providers: VersionedProviders[]
 ): string[] {
   const names = providers
-    .map((provider) =>
-      pickProviderVersionWithFallbackToLegacy(provider, options)
-    )
+    .map((provider) => pickProviderVersionWithFallbackToLegacy(provider))
     .map((provider) => {
       if (provider instanceof Provider) {
         return provider.id;

--- a/widget/embedded/src/utils/settings.ts
+++ b/widget/embedded/src/utils/settings.ts
@@ -72,10 +72,6 @@ export function isFeatureHidden(feature: keyof Features, features?: Features) {
   return features?.[feature] === 'hidden';
 }
 
-export function isFeatureEnabled(feature: keyof Features, features?: Features) {
-  return features?.[feature] === 'enabled';
-}
-
 export function isRoutingEnabled(item: keyof Routing, routing?: Routing) {
   return routing?.[item] === 'enabled';
 }

--- a/widget/playground/src/App.tsx
+++ b/widget/playground/src/App.tsx
@@ -31,7 +31,6 @@ export function App() {
     apiKey: RANGO_PUBLIC_API_KEY,
     features: {
       theme: 'hidden',
-      experimentalWallet: 'enabled',
     },
     __UNSTABLE_OR_INTERNAL__: {
       autoUpdateSettings: true,

--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
@@ -51,9 +51,7 @@ export function WalletSection() {
     };
     const allProviders = getAllProviders(envs);
     const allBuiltProviders = allProviders.map((build) => build());
-    const [legacyProviders] = separateLegacyAndHubProviders(allBuiltProviders, {
-      isExperimentalEnabled: config.features?.experimentalWallet === 'enabled',
-    });
+    const [legacyProviders] = separateLegacyAndHubProviders(allBuiltProviders);
     const filteredProviders = legacyProviders.filter(
       (provider) =>
         !excludedWallets.includes(provider.config.type as WalletTypes)


### PR DESCRIPTION
# Summary

Removed `experimentalWallets` from widget config because it is no longer needed and we enabled that feature by default.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
