### PR TITLE
chore: refactor get legacy providers

### DIFF
--- a/wallets/react/src/hub/mod.ts
+++ b/wallets/react/src/hub/mod.ts
@@ -1,2 +1,6 @@
-export { separateLegacyAndHubProviders, findProviderByType } from './utils.js';
+export {
+  separateLegacyAndHubProviders,
+  getAllLegacyProviders,
+  findProviderByType,
+} from './utils.js';
 export { useHubAdapter } from './useHubAdapter.js';

--- a/wallets/react/src/hub/utils.ts
+++ b/wallets/react/src/hub/utils.ts
@@ -238,12 +238,29 @@ export function checkHubStateAndTriggerEvents(
   });
 }
 
+export function getAllLegacyProviders(
+  allProviders: VersionedProviders[]
+): LegacyProviderInterface[] {
+  const LEGACY_VERSION = '0.0.0';
+
+  const legacyProviders: LegacyProviderInterface[] = [];
+
+  allProviders.forEach((provider) => {
+    const target = pickVersion(provider, LEGACY_VERSION);
+    legacyProviders.push(target[1]);
+  });
+
+  return legacyProviders;
+}
+
 export function getLegacyProvider(
   allProviders: VersionedProviders[],
   type: string
 ): LegacyProviderInterface {
-  const [legacy] = separateLegacyAndHubProviders(allProviders);
-  const provider = legacy.find((legacyProvider) => {
+  const legacyProviders: LegacyProviderInterface[] =
+    getAllLegacyProviders(allProviders);
+
+  const provider = legacyProviders.find((legacyProvider) => {
     return legacyProvider.config.type === type;
   });
 

--- a/wallets/react/src/index.ts
+++ b/wallets/react/src/index.ts
@@ -2,4 +2,7 @@ export * from './legacy/helpers.js';
 export { default as Provider } from './provider.js';
 export { useWallets } from './legacy/hooks.js';
 export * from './legacy/types.js';
-export { separateLegacyAndHubProviders } from './hub/mod.js';
+export {
+  separateLegacyAndHubProviders,
+  getAllLegacyProviders,
+} from './hub/mod.js';

--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
@@ -9,7 +9,7 @@ import {
   Typography,
   WalletIcon,
 } from '@rango-dev/ui';
-import { separateLegacyAndHubProviders } from '@rango-dev/wallets-react';
+import { getAllLegacyProviders } from '@rango-dev/wallets-react';
 import { WalletTypes } from '@rango-dev/wallets-shared';
 import { useWallets } from '@rango-dev/widget-embedded';
 import React from 'react';
@@ -51,7 +51,7 @@ export function WalletSection() {
     };
     const allProviders = getAllProviders(envs);
     const allBuiltProviders = allProviders.map((build) => build());
-    const [legacyProviders] = separateLegacyAndHubProviders(allBuiltProviders);
+    const legacyProviders = getAllLegacyProviders(allBuiltProviders);
     const filteredProviders = legacyProviders.filter(
       (provider) =>
         !excludedWallets.includes(provider.config.type as WalletTypes)


### PR DESCRIPTION
# Summary

In some places we used `separateLegacyAndHubProviders` without any config to access only legacy providers which was unsafe and produced some issues after removing the `experimentalWallet` config. It is fixed by defining a seperate function for accessing legacy providers.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
