### PR TITLE
feat: add can eager connect to namespaces

### DIFF
--- a/wallets/core/src/hub/namespaces/types.ts
+++ b/wallets/core/src/hub/namespaces/types.ts
@@ -2,14 +2,22 @@ import type { AnyFunction, FunctionWithContext } from '../../types/actions.js';
 import type { NamespaceData } from '../store/mod.js';
 
 type ActionName<K> = K | Omit<K, string>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Args = any[];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ActionResult = any;
 
 export type Subscriber<C extends Actions<C>> = (
   context: Context<C>,
-  ...args: any[]
+  ...args: Args
 ) => void;
 export type SubscriberCleanUp<C extends Actions<C>> = (
   context: Context<C>,
-  ...args: any[]
+  ...args: Args
+) => void;
+export type CanEagerConnect<C extends Actions<C>> = (
+  context: Context<C>,
+  ...args: Args
 ) => void;
 export type State = NamespaceData;
 export type SetState = <K extends keyof State>(
@@ -38,7 +46,7 @@ export type HooksWithOptions<T> = Map<
 >;
 export type Context<T extends Actions<T> = object> = {
   state: () => [GetState, SetState];
-  action: (name: keyof T, ...args: any[]) => any;
+  action: (name: keyof T, ...args: Args) => ActionResult;
 };
 
 /**

--- a/wallets/core/src/namespaces/cosmos/types.ts
+++ b/wallets/core/src/namespaces/cosmos/types.ts
@@ -8,4 +8,5 @@ export interface CosmosActions
     CommonActions {
   // TODO
   connect: () => Promise<string>;
+  canEagerConnect: () => Promise<boolean>;
 }

--- a/wallets/core/src/namespaces/evm/actions.ts
+++ b/wallets/core/src/namespaces/evm/actions.ts
@@ -1,7 +1,10 @@
 import type { EIP1193EventMap } from './eip1193.js';
 import type { EvmActions, ProviderAPI } from './types.js';
 import type { Context, Subscriber } from '../../hub/namespaces/mod.js';
-import type { SubscriberCleanUp } from '../../hub/namespaces/types.js';
+import type {
+  CanEagerConnect,
+  SubscriberCleanUp,
+} from '../../hub/namespaces/types.js';
 import type { CaipAccount } from '../../types/accounts.js';
 import type { FunctionWithContext } from '../../types/actions.js';
 
@@ -145,4 +148,30 @@ export function changeChainSubscriber(
       }
     },
   ];
+}
+
+export function canEagerConnect(
+  instance: () => ProviderAPI | undefined
+): CanEagerConnect<EvmActions> {
+  return async () => {
+    const evmInstance = instance();
+
+    if (!evmInstance) {
+      throw new Error(
+        'Trying to eagerly connect to your EVM wallet, but seems its instance is not available.'
+      );
+    }
+
+    try {
+      const accounts: string[] = await evmInstance.request({
+        method: 'eth_accounts',
+      });
+      if (accounts.length) {
+        return true;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  };
 }

--- a/wallets/core/src/namespaces/evm/builders.ts
+++ b/wallets/core/src/namespaces/evm/builders.ts
@@ -12,3 +12,6 @@ export const connect = () =>
     .and(connectAndUpdateStateForMultiNetworks)
     .before(intoConnecting)
     .after(intoConnectionFinished);
+
+export const canEagerConnect = () =>
+  new ActionBuilder<EvmActions, 'canEagerConnect'>('canEagerConnect');

--- a/wallets/core/src/namespaces/evm/types.ts
+++ b/wallets/core/src/namespaces/evm/types.ts
@@ -9,6 +9,7 @@ export interface EvmActions
   extends AutoImplementedActionsByRecommended,
     CommonActions {
   connect: (chain?: Chain | ChainId) => Promise<AccountsWithActiveChain>;
+  canEagerConnect: () => Promise<boolean>;
 }
 
 export type { EIP1193Provider as ProviderAPI } from './eip1193.js';

--- a/wallets/core/src/namespaces/solana/types.ts
+++ b/wallets/core/src/namespaces/solana/types.ts
@@ -8,6 +8,7 @@ export interface SolanaActions
   extends AutoImplementedActionsByRecommended,
     CommonActions {
   connect: () => Promise<Accounts>;
+  canEagerConnect: () => Promise<boolean>;
 }
 
 /*
@@ -17,4 +18,5 @@ export interface SolanaActions
  * If Phantom's interface is what Solana wallets are supporting, another option would be define that type here.
  *
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ProviderAPI = Record<string, any>;

--- a/wallets/core/src/namespaces/sui/types.ts
+++ b/wallets/core/src/namespaces/sui/types.ts
@@ -8,6 +8,7 @@ export interface SuiActions
   extends AutoImplementedActionsByRecommended,
     CommonActions {
   connect: () => Promise<Accounts>;
+  canEagerConnect: () => Promise<boolean>;
 }
 
 // eslint-disable-next-line

--- a/wallets/core/src/namespaces/utxo/types.ts
+++ b/wallets/core/src/namespaces/utxo/types.ts
@@ -8,6 +8,7 @@ export interface UtxoActions
   extends AutoImplementedActionsByRecommended,
     CommonActions {
   connect: () => Promise<Accounts>;
+  canEagerConnect: () => Promise<boolean>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/wallets/provider-phantom/src/namespaces/evm.ts
+++ b/wallets/provider-phantom/src/namespaces/evm.ts
@@ -28,9 +28,15 @@ const disconnect = commonBuilders
   .after(changeAccountCleanup)
   .build();
 
+const canEagerConnect = builders
+  .canEagerConnect()
+  .action(actions.canEagerConnect(evmPhantom))
+  .build();
+
 const evm = new NamespaceBuilder<EvmActions>('EVM', WALLET_ID)
   .action(connect)
   .action(disconnect)
+  .action(canEagerConnect)
   .build();
 
 export { evm };

--- a/wallets/provider-phantom/src/namespaces/solana.ts
+++ b/wallets/provider-phantom/src/namespaces/solana.ts
@@ -1,7 +1,7 @@
 import type { CaipAccount } from '@rango-dev/wallets-core/namespaces/common';
 import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
+import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
 import { builders as commonBuilders } from '@rango-dev/wallets-core/namespaces/common';
 import {
   actions,
@@ -60,9 +60,33 @@ const disconnect = commonBuilders
   .after(changeAccountCleanup)
   .build();
 
+export const canEagerConnectAction = async () => {
+  const solanaInstance = solanaPhantom();
+
+  if (!solanaInstance) {
+    throw new Error(
+      'Trying to eagerly connect to your Solana wallet, but seems its instance is not available.'
+    );
+  }
+
+  try {
+    const result = await solanaInstance.connect({ onlyIfTrusted: true });
+    return !!result;
+  } catch {
+    return false;
+  }
+};
+
+const canEagerConnect = new ActionBuilder<SolanaActions, 'canEagerConnect'>(
+  'canEagerConnect'
+)
+  .action(canEagerConnectAction)
+  .build();
+
 const solana = new NamespaceBuilder<SolanaActions>('Solana', WALLET_ID)
   .action(connect)
   .action(disconnect)
+  .action(canEagerConnect)
   .build();
 
 export { solana };

--- a/wallets/provider-phantom/src/namespaces/utxo.ts
+++ b/wallets/provider-phantom/src/namespaces/utxo.ts
@@ -1,10 +1,12 @@
 import type { CaipAccount } from '@rango-dev/wallets-core/namespaces/common';
+import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
 import type {
   ProviderAPI,
   UtxoActions,
 } from '@rango-dev/wallets-core/namespaces/utxo';
 
 import {
+  ActionBuilder,
   NamespaceBuilder,
   type Subscriber,
   type SubscriberCleanUp,
@@ -23,6 +25,8 @@ import {
 
 import { WALLET_ID } from '../constants.js';
 import { bitcoinPhantom } from '../utils.js';
+
+import { canEagerConnectAction as solanaCanEagerConnectAction } from './solana.js';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyFunction = (...args: any[]) => any;
@@ -144,9 +148,21 @@ const disconnect = commonBuilders
   .after(changeAccountCleanup)
   .build();
 
+/*
+ * TODO: We are currently using `solanaCanEagerConnectAction` to establish an eager connection to the BTC instance.
+ * This is a temporary workaround due to Phantom's limitation in silently connecting to a BTC account.
+ * Once Phantom introduces support for silent BTC connections, this implementation should be updated accordingly.
+ */
+const canEagerConnect = new ActionBuilder<SolanaActions, 'canEagerConnect'>(
+  'canEagerConnect'
+)
+  .action(solanaCanEagerConnectAction)
+  .build();
+
 const utxo = new NamespaceBuilder<UtxoActions>('UTXO', WALLET_ID)
   .action(connect)
   .action(disconnect)
+  .action(canEagerConnect)
   .build();
 
 export { utxo };

--- a/wallets/react/src/hub/lastConnectedWallets.ts
+++ b/wallets/react/src/hub/lastConnectedWallets.ts
@@ -124,7 +124,9 @@ export class LastConnectedWalletsFromStorage {
     );
 
     this.#removeWalletsFromHub([providerId]);
-    this.#addWalletToHub(providerId, newProviderNamespaces);
+    if (newProviderNamespaces.length > 0) {
+      this.#addWalletToHub(providerId, newProviderNamespaces);
+    }
   }
   #removeWalletsFromLegacy(providerIds?: string[]): void {
     const persistor = new Persistor<LegacyLastConnectedWalletsStorage>();


### PR DESCRIPTION
# Summary

Added `canEagerConnect` action to namespaces so each namespace can be checked if is available for eager connect and also decouple `canEagerConnect` from `legacyProvider`. As a result, auto connect can now take place on a Phantom account which only supports evm addresses. 

# How did you test this change?

This change can be tested by connecting to a phantom account containing only EVM address, then refreshing the page and observing that auto connect working properly.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
