### PR TITLE
Fix/rf 2135 coinbase wallet different behaviour

### DIFF
--- a/wallets/shared/src/helpers.ts
+++ b/wallets/shared/src/helpers.ts
@@ -211,7 +211,8 @@ export function detectMobileScreens(): boolean {
  */
 
 export function splitWalletNetwork(input: string): string[] {
-  const removedAddressInput = input?.split(':')[0] || '';
+  const removedNullInput = input?.split('-null').join('');
+  const removedAddressInput = removedNullInput?.split(':')[0] || '';
   const splittedInput = removedAddressInput.split('-');
   const network = splittedInput[splittedInput.length - 1];
   const walletNetwork = splittedInput.slice(0, -1);


### PR DESCRIPTION
# Summary

This PR addresses an issue where a swap transaction could be incorrectly marked as expired due to the early initialization of hasAlreadyProceededToSign. Additionally, this PR includes updates to ESLint packages.

Fixes # (issue)

- Moved the initialization of hasAlreadyProceededToSign to the finally block of the signing call.
  - Previously, it was initialized before requesting the wallet provider to sign the transaction.
  - If an error occurred during signing, the swap would be incorrectly marked as expired.
  - Now, the variable is only set after the signing attempt, preventing premature expiration.

Other Changes
Updated ESLint packages, leading to some additional modifications.

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
