### PR TITLE
fix: make connect namespaces sequential

### DIFF
--- a/wallets/react/package.json
+++ b/wallets/react/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "@rango-dev/wallets-core": "^0.40.1-next.11",
     "@rango-dev/wallets-shared": "^0.41.1-next.4",
-    "rango-types": "^0.1.78"
+    "rango-types": "^0.1.78",
+    "ts-results": "^3.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19574,6 +19574,11 @@ ts-mixer@^6.0.3:
   resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.4.tgz#1da39ceabc09d947a82140d9f09db0f84919ca28"
   integrity sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==
 
+ts-results@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ts-results/-/ts-results-3.3.0.tgz#68623a6c18e65556287222dab76498a28154922f"
+  integrity sha512-FWqxGX2NHp5oCyaMd96o2y2uMQmSu8Dey6kvyuFdRJ2AzfmWo3kWa4UsPlCGlfQ/qu03m09ZZtppMoY8EMHuiA==
+
 tsconfig-paths@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"


### PR DESCRIPTION
# Summary

This pull request addresses an issue with connecting to namespaces on the Phantom wallet. That issue was happening in this scenario: Imagine you have two accounts on Phantom which one of them supports both evm and solana and the other one only supports solana address and widget does not have access to connect each of them. First, we try to connect to the account which only supports solana. After it gets connected successfully, we disconnect it and switch to the other account which supports both namespaces on Phantom. Now, if we try to connect to that account, it fails on connecting to solana namespace. After some investigation, it turned out that there is a problem on Phantom extension which fails to address two parallel requests in this scenario.

In this PR, connecting to namespaces has made sequential to address this issue. 


# How did you test this change?

1. Repeat the scenario described above with both accounts.
2. Verify that connections to both namespaces are established successfully after the changes implemented in this PR.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
