### PR TITLE
fix: fix balances not updating properly after switch account

### DIFF
--- a/wallets/react/src/hub/utils.ts
+++ b/wallets/react/src/hub/utils.ts
@@ -223,8 +223,6 @@ export function checkHubStateAndTriggerEvents(
       );
     }
     if (hasAccountChanged) {
-      // This event is triggered to clear wallet state and after that set new accounts for wallet
-      onUpdateState(providerId, Events.ACCOUNTS, null, coreState, eventInfo);
       onUpdateState(
         providerId,
         Events.ACCOUNTS,

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -7,10 +7,6 @@ import type { ProvidersOptions } from '../../utils/providers';
 import type { LegacyEventHandler as EventHandler } from '@rango-dev/wallets-core/legacy';
 import type { PropsWithChildren } from 'react';
 
-import {
-  legacyFormatAddressWithNetwork as formatAddressWithNetwork,
-  legacyReadAccountAddress as readAccountAddress,
-} from '@rango-dev/wallets-core/legacy';
 import { Events, Provider } from '@rango-dev/wallets-react';
 import { type Network } from '@rango-dev/wallets-shared';
 import { isEvmBlockchain } from 'rango-sdk';
@@ -39,11 +35,9 @@ function Main(props: PropsWithChildren<PropTypes>) {
     updateSettings,
     fetch: fetchMeta,
     fetchStatus,
-    removeBalancesForWallet,
   } = useAppStore();
   const blockchains = useAppStore().blockchains();
-  const { newWalletConnected, disconnectWallet, connectedWallets } =
-    useAppStore();
+  const { updateWalletAccounts, disconnectWallet } = useAppStore();
   const config = useAppStore().config;
 
   const walletOptions: ProvidersOptions = {
@@ -82,58 +76,6 @@ function Main(props: PropsWithChildren<PropTypes>) {
       const supportedChainNames: Network[] | null =
         walletAndSupportedChainsNames(meta.supportedBlockchains);
 
-      /*
-       * When a wallet is connecting to an evm account, we will consider it as the account exists on other evm-compatible blockchains
-       * To get their balances.
-       *
-       * The logic here is for handling switching account functionality in wallets. when a wallet is switching to another account
-       * we need to clean the balances for old accounts.
-       */
-      const evmAccounts: string[] = [];
-      const nonEvmAccounts: string[] = [];
-
-      value?.forEach((account: string) => {
-        const { network } = readAccountAddress(account);
-        if (evmBasedChainNames.includes(network)) {
-          evmAccounts.push(account);
-        } else {
-          nonEvmAccounts.push(account);
-        }
-      });
-
-      const previousAccounts = connectedWallets
-        .filter((wallet) => wallet.walletType === type)
-        .map((wallet) =>
-          formatAddressWithNetwork(wallet.address, wallet.chain)
-        );
-
-      if (previousAccounts.length > 0) {
-        if (evmAccounts.length > 0) {
-          // We use same logic for removing as we use for adding.
-          const data = prepareAccountsForWalletStore(
-            type,
-            evmAccounts,
-            evmBasedChainNames,
-            supportedChainNames,
-            meta.isContractWallet
-          );
-
-          removeBalancesForWallet(type, {
-            chains: data.map((account) => account.chain),
-          });
-        }
-
-        if (nonEvmAccounts.length > 0) {
-          removeBalancesForWallet(type, {
-            chains: nonEvmAccounts.map((account) => {
-              const { network } = readAccountAddress(account);
-              return network;
-            }),
-          });
-        }
-      }
-
-      // After cleaning up balances, it's time to add new accounts.
       if (value) {
         const data = prepareAccountsForWalletStore(
           type,
@@ -143,10 +85,10 @@ function Main(props: PropsWithChildren<PropTypes>) {
           meta.isContractWallet
         );
         if (data.length) {
-          void newWalletConnected(data);
+          void updateWalletAccounts(type, data);
         }
       } else {
-        disconnectWallet(type);
+        void disconnectWallet(type);
         if (!!onDisconnectWalletHandler.current) {
           onDisconnectWalletHandler.current(type);
         } else {

--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -1,4 +1,8 @@
-import type { BalanceState, ConnectedWallet } from '../store/slices/wallets';
+import type {
+  BalanceKey,
+  BalanceState,
+  ConnectedWallet,
+} from '../store/slices/wallets';
 import type {
   Balance,
   SelectedQuote,
@@ -45,6 +49,7 @@ export type ExtendedModalWalletInfo = WalletInfoWithExtra &
   Pick<ExtendedWalletInfo, 'properties' | 'isHub'>;
 
 export function mapStatusToWalletState(state: WalletState): WalletStatus {
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
   switch (true) {
     case state.connected:
       return WalletStatus.CONNECTED;
@@ -261,15 +266,13 @@ export function getQuoteWallets(params: {
   return Array.from(wallets);
 }
 
-export function isAccountAndWalletMatched(
-  account: Wallet,
-  connectedWallet: ConnectedWallet
+export function isBalanceKeyAndWalletMatched(
+  balanceKey: BalanceKey,
+  wallet: ConnectedWallet
 ) {
-  return (
-    account.address === connectedWallet.address &&
-    account.chain === connectedWallet.chain &&
-    account.walletType === connectedWallet.walletType
-  );
+  const [keyChain, , , keyWalletAddress] = balanceKey.split('-');
+
+  return wallet.address === keyWalletAddress && wallet.chain === keyChain;
 }
 
 export function resetConnectedWalletState(


### PR DESCRIPTION
# Summary

This pull request addresses an issue with updating balances after switching accounts on the Phantom wallet. That issue was happening in this scenario:  Imagine you have two accounts on Phantom which one of them supports both evm and solana and the other one only supports solana address. First, we connect on Phantom to the wallet containing both solana abd evm addresses. In result of this, balances for evm and solana accounts get fetched and updated. Now if we switch to the account containing only Solana address. At first Solana address gets updated and in result of that balances related to old Solana address get removed and fetch balance API gets called for new Solana address and old Evm addresses. Then, old evm addresses get removed and in result of that balances related to old Evm addresses get removed and fetch balance API gets called for new Solana address. In this time the first api call gets settled and updates the balances with values related to new Solana address and old Evm addresses. At this state, balances for old Evm addresses should not be included in widget store because Phantom is not connected to those addresses anymore.
This issue was resolved by refactoring wallet slice such that  fetch balance API call not getting called for balances which are available in store anymore. This makes the first fetch balance API get called only for new Solana address and resolves the issue.

# How did you test this change?

1. Repeat the scenario described above with both accounts.
2. Verify that balances get updated properly.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
