### PR TITLE
fix: add unsupported tokens to wallets details

### DIFF
--- a/widget/embedded/src/store/slices/wallets.ts
+++ b/widget/embedded/src/store/slices/wallets.ts
@@ -545,28 +545,21 @@ export const createWalletsSlice: StateCreator<
           if (asset.blockchain === wallet.chain) {
             const token = get().findToken(asset);
 
-            if (!!token) {
-              const amount = balance.amount
-                ? new BigNumber(balance.amount).shiftedBy(-balance.decimals)
-                : ZERO;
+            const amount = balance.amount
+              ? new BigNumber(balance.amount).shiftedBy(-balance.decimals)
+              : ZERO;
 
-              output.push({
-                chain: wallet.chain,
-                symbol: token.symbol,
-                ticker: token.symbol,
-                address: token.address,
-                rawAmount: balance.amount,
-                decimal: balance.decimals,
-                amount: amount.toString(),
-                logo: token.image,
-                usdPrice: token.usdPrice,
-              });
-            } else {
-              console.debug(
-                "Looking for asset but it couldn't be found in tokens store. May not be provided in meta.'",
-                asset
-              );
-            }
+            output.push({
+              chain: wallet.chain,
+              symbol: asset.symbol,
+              ticker: asset.symbol,
+              address: asset.address,
+              rawAmount: balance.amount,
+              decimal: balance.decimals,
+              amount: amount.toString(),
+              logo: token?.image || null,
+              usdPrice: token?.usdPrice || null,
+            });
           }
 
           return output;


### PR DESCRIPTION
# Summary

Details related to unsupported tokens was missed in return value of `getConnectedWalletsDetails` leading to not appearing those tokens and balances in wallets details sidebar in app. In result of this change, it is fixed and unsupported tokens can be found in wallet details sidebar.


# How did you test this change?

This can be tested on app (after linking this changes to "upgrade to hub" PR on APP) by checking for unsupported tokens in wallets details sidebar.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
