### PR TITLE
feat: implement search functionality for custom tokens

### DIFF
--- a/widget/embedded/src/components/AppRoutes.tsx
+++ b/widget/embedded/src/components/AppRoutes.tsx
@@ -13,7 +13,7 @@ import { LanguagePage } from '../pages/LanguagePage';
 import { LiquiditySourcePage } from '../pages/LiquiditySourcePage';
 import { RoutesPage } from '../pages/Routes';
 import { SelectBlockchainPage } from '../pages/SelectBlockchainPage';
-import { SelectSwapItemsPage } from '../pages/SelectSwapItemsPage';
+import { SelectSwapItemsPage } from '../pages/SelectSwapItemPage/index';
 import { SettingsPage } from '../pages/SettingsPage';
 import { SwapDetailsPage } from '../pages/SwapDetailsPage';
 import { WalletsPage } from '../pages/WalletsPage';

--- a/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.constants.ts
+++ b/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.constants.ts
@@ -1,0 +1,2 @@
+export const CUSTOM_TOKEN_LEARN_MORE_LINK =
+  'https://blog.rango.exchange/understanding-the-risks-of-using-custom-token-contract-addresses-96022308eca4';

--- a/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.tsx
+++ b/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.tsx
@@ -10,27 +10,38 @@ import {
 } from '@rango-dev/ui';
 import React from 'react';
 
+import { DEFAULT_TOKEN_IMAGE_SRC } from '../../constants/customTokens';
 import { getContainer } from '../../utils/common';
 import { WatermarkedModal } from '../common/WatermarkedModal';
 
+import { CUSTOM_TOKEN_LEARN_MORE_LINK } from './CustomTokenModal.constants';
 import { generateExplorerLink } from './CustomTokenModal.helpers';
 import { Container, StyledLink } from './CustomTokenModal.styles';
 
 export function CustomTokenModal(props: PropTypes) {
-  const { open, onClose, token, onSubmitClick, blockchain } = props;
+  const { open, onClose, token, onExit, onSubmitClick, blockchain } = props;
 
   const explorerLink = generateExplorerLink(token.address, blockchain);
+
+  const onClickLearnMore = () =>
+    window.open(CUSTOM_TOKEN_LEARN_MORE_LINK, '_blank');
 
   return (
     <WatermarkedModal
       open={open}
       dismissible
       onClose={onClose}
+      onExit={onExit}
       container={getContainer()}>
       <Container>
-        <Image src={token.image} size={45} type="circular" />
+        <Image
+          src={token.image === '' ? DEFAULT_TOKEN_IMAGE_SRC : token.image}
+          size={45}
+          type="circular"
+        />
+        <Divider size={4} />
         <Typography variant="title" size="medium">
-          {token.name}
+          {token.symbol}
         </Typography>
         <Typography variant="body" size="small" className="_blockchain-name">
           {blockchain.displayName}
@@ -72,7 +83,7 @@ export function CustomTokenModal(props: PropTypes) {
           variant="body"
           className="_custom-token-description">
           {i18n.t(
-            `This token doesn't appear on the active token list(s). Make sure this is the token that you want to trade.`
+            `This token is not part of our verified token list. please verify its source and make sure to understand all associated risks before proceeding.`
           )}
         </Typography>
       </Container>
@@ -86,7 +97,17 @@ export function CustomTokenModal(props: PropTypes) {
         type="primary"
         fullWidth
         onClick={onSubmitClick}>
-        {i18n.t('Import')}
+        {i18n.t('Import Anyway')}
+      </Button>
+      <Divider size={10} />
+      <Button
+        id="widget-custom-token-modal-learn-more-btn"
+        variant="outlined"
+        size="large"
+        type="primary"
+        fullWidth
+        onClick={onClickLearnMore}>
+        {i18n.t('Learn More')}
       </Button>
     </WatermarkedModal>
   );

--- a/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.types.ts
+++ b/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.types.ts
@@ -3,6 +3,7 @@ import type { BlockchainMeta, Token } from 'rango-sdk';
 export type PropTypes = {
   open: boolean;
   onClose: () => void;
+  onExit: () => void;
   onSubmitClick: () => void;
   token: Token;
   blockchain: BlockchainMeta;

--- a/widget/embedded/src/components/ImportCustomToken/ImportCustomToken.tsx
+++ b/widget/embedded/src/components/ImportCustomToken/ImportCustomToken.tsx
@@ -1,0 +1,121 @@
+import type { PropTypes } from './ImportCustomToken.types';
+
+import { i18n } from '@lingui/core';
+import { Button, Divider, MessageBox } from '@rango-dev/ui';
+import React, { useEffect, useState } from 'react';
+
+import { useAppStore } from '../../store/AppStore';
+import { getContainer } from '../../utils/common';
+import { WatermarkedModal } from '../common/WatermarkedModal';
+import { CustomTokenModal } from '../CustomTokenModal';
+
+export function ImportCustomToken(props: PropTypes) {
+  const {
+    token,
+    blockchain,
+    error,
+    address,
+    fetchCustomToken,
+    onCloseErrorModal,
+    onImport,
+    onExitErrorModal,
+    onExitImportModal,
+  } = props;
+  const { setCustomToken } = useAppStore();
+  const [showErrorModal, setShowErrorModal] = useState<boolean>(false);
+  const [showImportModal, setShowImportModal] = useState<boolean>(false);
+  const [retryClicked, setRetryClicked] = useState(false);
+
+  const getCustomToken = () => {
+    if (blockchain) {
+      void fetchCustomToken?.({
+        blockchain: blockchain.name,
+        tokenAddress: address,
+      });
+    }
+  };
+
+  const closeErrorModal = () => {
+    if (error?.type !== 'network-error') {
+      onCloseErrorModal?.();
+    }
+    setShowErrorModal(false);
+  };
+
+  const handleErrorModalButtonClick = () => {
+    setRetryClicked(true);
+    closeErrorModal();
+  };
+
+  const handleExit = () => {
+    if (retryClicked && error?.type === 'network-error') {
+      setRetryClicked(false);
+      void getCustomToken();
+    }
+    onExitErrorModal();
+  };
+
+  const handleSubmit = () => {
+    if (token) {
+      setCustomToken(token);
+      onImport();
+    }
+  };
+
+  useEffect(() => {
+    if (!!error) {
+      setShowErrorModal(true);
+    }
+  }, [error]);
+
+  useEffect(() => {
+    if (blockchain && token) {
+      setShowImportModal(true);
+    }
+  }, [blockchain, token]);
+
+  return (
+    <>
+      <WatermarkedModal
+        open={showErrorModal}
+        dismissible
+        onClose={closeErrorModal}
+        onExit={handleExit}
+        container={getContainer()}>
+        <MessageBox
+          title={error?.title ?? ''}
+          type="error"
+          description={
+            error?.message || i18n.t('Failed Network, Please retry.')
+          }>
+          <Divider size={40} />
+          <Divider size={10} />
+          {/* eslint-disable-next-line jsx-id-attribute-enforcement/missing-ids */}
+          <Button
+            id={`widget-add-custom-token-${
+              error?.type === 'network-error' ? 'retry' : 'add-another'
+            }-btn`}
+            variant="contained"
+            size="large"
+            type="primary"
+            fullWidth
+            onClick={handleErrorModalButtonClick}>
+            {error?.type === 'network-error'
+              ? i18n.t('Retry')
+              : i18n.t('Add another custom token')}
+          </Button>
+        </MessageBox>
+      </WatermarkedModal>
+      {blockchain && token && (
+        <CustomTokenModal
+          blockchain={blockchain}
+          token={token}
+          onSubmitClick={handleSubmit}
+          onClose={() => setShowImportModal(false)}
+          open={showImportModal}
+          onExit={onExitImportModal}
+        />
+      )}
+    </>
+  );
+}

--- a/widget/embedded/src/components/ImportCustomToken/ImportCustomToken.types.ts
+++ b/widget/embedded/src/components/ImportCustomToken/ImportCustomToken.types.ts
@@ -1,0 +1,18 @@
+import type {
+  CustomTokenError,
+  UseFetchCustomToken,
+} from '../../hooks/useFetchCustomToken';
+import type { TokenData } from '../TokenList/TokenList.types';
+import type { BlockchainMeta } from 'rango-sdk';
+
+export type PropTypes = {
+  token: TokenData | null;
+  error?: CustomTokenError;
+  blockchain?: BlockchainMeta;
+  address: string;
+  fetchCustomToken?: UseFetchCustomToken['fetchCustomToken'];
+  onCloseErrorModal?: () => void;
+  onImport: () => void;
+  onExitErrorModal: () => void;
+  onExitImportModal: () => void;
+};

--- a/widget/embedded/src/components/ImportCustomToken/index.ts
+++ b/widget/embedded/src/components/ImportCustomToken/index.ts
@@ -1,0 +1,1 @@
+export { ImportCustomToken } from './ImportCustomToken';

--- a/widget/embedded/src/components/NotificationContent/NotificationContent.tsx
+++ b/widget/embedded/src/components/NotificationContent/NotificationContent.tsx
@@ -26,9 +26,9 @@ export function NotificationContent() {
     <Notifications
       list={notifications}
       getBlockchainImage={(blockchain) =>
-        getBlockchainImage(blockchain, blockchains) ?? ''
+        getBlockchainImage(blockchain, blockchains)
       }
-      getTokenImage={(token) => findToken(token)?.image ?? ''}
+      getTokenImage={(token) => findToken(token)?.image}
       onClickItem={onClickItem}
       onClearAll={clearNotifications}
     />

--- a/widget/embedded/src/components/Quote/QuoteTrigger.tsx
+++ b/widget/embedded/src/components/Quote/QuoteTrigger.tsx
@@ -77,7 +77,7 @@ export function QuoteTrigger(props: QuoteTriggerProps) {
             <React.Fragment key={key}>
               <ImageComponent
                 content={step.swapper.displayName}
-                src={step.swapper.image}
+                src={step.swapper.image ?? ''}
                 state={step.state}
                 container={container}
               />
@@ -90,7 +90,7 @@ export function QuoteTrigger(props: QuoteTriggerProps) {
                 <>
                   <ImageComponent
                     content={step.swapper.displayName}
-                    src={step.swapper.image}
+                    src={step.swapper.image ?? ''}
                     state={step.state}
                     container={container}
                   />
@@ -113,7 +113,7 @@ export function QuoteTrigger(props: QuoteTriggerProps) {
                               <React.Fragment key={key}>
                                 <ImageComponent
                                   content={step.swapper.displayName}
-                                  src={step.swapper.image}
+                                  src={step.swapper.image ?? ''}
                                   state={step.state}
                                   open={false}
                                 />
@@ -162,7 +162,7 @@ export function QuoteTrigger(props: QuoteTriggerProps) {
                     sideOffset={4}>
                     <ImageComponent
                       content={''}
-                      src={blockchain.image}
+                      src={blockchain.image ?? ''}
                       open={false}
                       className={index !== 0 ? 'blockchainImage' : ''}
                     />
@@ -182,7 +182,7 @@ export function QuoteTrigger(props: QuoteTriggerProps) {
                                 <ImageComponent
                                   key={chain.displayName}
                                   content={''}
-                                  src={chain.image}
+                                  src={chain.image ?? ''}
                                   open={false}
                                   className={i > index ? 'blockchainImage' : ''}
                                   container={container}

--- a/widget/embedded/src/components/QuoteSkeleton/QuoteSummarySkeleton.tsx
+++ b/widget/embedded/src/components/QuoteSkeleton/QuoteSummarySkeleton.tsx
@@ -23,7 +23,7 @@ export function QuoteSummarySkeleton(props: PropTypes) {
   const quotePreview = (
     <QuoteSummary>
       <TokenAmount>
-        <ChainToken loading size="medium" chainImage="" tokenImage="" />
+        <ChainToken loading size="medium" />
         <Divider size={8} direction="horizontal" />
         <TokenAmountLabel>
           <Skeleton height={10} width={60} variant="rounded" />
@@ -72,7 +72,7 @@ export function QuoteSummarySkeleton(props: PropTypes) {
       {type === 'list-item' && (
         <Output>
           <OutputTokenInfo>
-            <ChainToken loading size="medium" chainImage="" tokenImage="" />
+            <ChainToken loading size="medium" />
             <Divider direction="horizontal" size={4} />
             <Skeleton height={15} width={150} variant="rounded" />
           </OutputTokenInfo>

--- a/widget/embedded/src/components/QuoteSkeleton/StepSkeleton.tsx
+++ b/widget/embedded/src/components/QuoteSkeleton/StepSkeleton.tsx
@@ -25,7 +25,7 @@ export function StepSkeleton(props: PropTypes) {
         <StepSeparator hideSeparator={!separator} />
         <StepTokens extraSpace={separator}>
           <StepTokenInfo>
-            <ChainToken size="small" loading chainImage="" tokenImage="" />
+            <ChainToken size="small" loading />
             <Divider direction="horizontal" size={8} />
             <Skeleton height={12} variant="rounded" />
           </StepTokenInfo>
@@ -33,7 +33,7 @@ export function StepSkeleton(props: PropTypes) {
             <NextIcon color="gray" size={16} />
           </StepIconContainer>
           <StepTokenInfo>
-            <ChainToken size="small" loading chainImage="" tokenImage="" />
+            <ChainToken size="small" loading />
             <Divider direction="horizontal" size={8} />
             <Skeleton height={12} variant="rounded" />
           </StepTokenInfo>

--- a/widget/embedded/src/components/SearchInput/SearchInput.tsx
+++ b/widget/embedded/src/components/SearchInput/SearchInput.tsx
@@ -15,8 +15,20 @@ export function SearchInput(props: PropTypes) {
     value,
     style,
     setValue,
+    suffix,
     ...inputAttributes
   } = props;
+
+  let inputSuffix = !!value.length ? (
+    // eslint-disable-next-line jsx-id-attribute-enforcement/missing-ids
+    <IconButton variant="ghost" onClick={() => setValue?.('')} size="small">
+      <CloseIcon color="gray" size={10} />
+    </IconButton>
+  ) : null;
+
+  if (suffix) {
+    inputSuffix = suffix;
+  }
 
   return (
     <TextField
@@ -25,16 +37,7 @@ export function SearchInput(props: PropTypes) {
           <SearchIcon color="black" />
         </IconWrapper>
       }
-      suffix={
-        !!value.length && (
-          <IconButton
-            variant="ghost"
-            onClick={() => setValue?.('')}
-            size="small">
-            <CloseIcon color="gray" size={10} />
-          </IconButton>
-        )
-      }
+      suffix={inputSuffix}
       fullWidth={fullWidth}
       color={color}
       variant={variant}

--- a/widget/embedded/src/components/SearchInput/SearchInput.types.ts
+++ b/widget/embedded/src/components/SearchInput/SearchInput.types.ts
@@ -1,5 +1,6 @@
+import type { TextField } from '@rango-dev/ui';
 import type * as Stitches from '@stitches/react';
-import type React from 'react';
+import type { ComponentProps, ReactElement } from 'react';
 
 export type PropTypes = {
   variant?: 'contained' | 'outlined' | 'ghost';
@@ -9,4 +10,5 @@ export type PropTypes = {
   value: string;
   setValue?: (value: string) => void;
   style?: Stitches.CSS;
-} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'value'>;
+  suffix?: ReactElement;
+} & ComponentProps<typeof TextField>;

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.types.ts
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.types.ts
@@ -31,11 +31,11 @@ export interface CompleteModalPropTypes {
   percentageChange: string;
   chain: {
     displayName?: string;
-    image: string;
+    image?: string;
   };
   token: {
     displayName: string;
-    image: string;
+    image?: string;
   };
   description?: React.ReactNode;
   diagnosisUrl?: string | null;

--- a/widget/embedded/src/components/TokenList/TokenList.styles.ts
+++ b/widget/embedded/src/components/TokenList/TokenList.styles.ts
@@ -2,6 +2,7 @@ import {
   css,
   darkTheme,
   ImageContainer,
+  ListItemButton,
   styled,
   Typography,
 } from '@rango-dev/ui';
@@ -102,6 +103,18 @@ export const List = styled('ul', {
   },
 });
 
+export const StyledListItemButton = styled(ListItemButton, {
+  variants: {
+    customToken: {
+      true: {
+        '&:hover': {
+          cursor: 'unset',
+        },
+      },
+    },
+  },
+});
+
 export const Tag = styled('div', {
   paddingLeft: '$5',
   paddingRight: '$5',
@@ -163,5 +176,32 @@ export const TokenBalance = styled(Typography, {
 export const StyledLink = styled('a', {
   '& svg:hover': {
     color: '$colors$info',
+  },
+});
+
+export const ListItemContainer = styled('div', {
+  paddingRight: '$5',
+
+  '& .widget-token-list-item-btn': {
+    width: '100%',
+    overflow: 'hidden',
+    height: '60px',
+  },
+
+  '& .widget-token-list-item-import-btn': {
+    height: '$20',
+    padding: '0 $10',
+
+    '& ._text': {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+
+    '& ._typography': {
+      [`.${darkTheme} &`]: {
+        color: '$foreground',
+      },
+    },
   },
 });

--- a/widget/embedded/src/components/TokenList/TokenList.types.ts
+++ b/widget/embedded/src/components/TokenList/TokenList.types.ts
@@ -1,14 +1,18 @@
 import type { Token } from 'rango-sdk';
 import type { ReactElement } from 'react';
 
+export type TokenData = Token &
+  (Token & { customToken?: boolean; warning?: boolean });
+
 export interface PropTypes {
-  list: Token[];
+  list: (TokenData | 'skeleton')[];
   searchedFor?: string;
   onChange?: (token: Token) => void;
   selectedBlockchain?: string;
   type: 'source' | 'destination' | 'custom-token';
   action?: (token: Token) => ReactElement;
   showTitle?: boolean;
+  showWarning?: boolean;
 }
 
 export interface LoadingTokenListProps {

--- a/widget/embedded/src/constants/customTokens.ts
+++ b/widget/embedded/src/constants/customTokens.ts
@@ -4,3 +4,6 @@ export const ACTIVE_BLOCKCHAINS_FOR_CUSTOM_TOKENS: string[] = [
   TransactionType.EVM,
   TransactionType.SOLANA,
 ];
+
+export const DEFAULT_TOKEN_IMAGE_SRC =
+  'https://raw.githubusercontent.com/rango-exchange/assets/refs/heads/main/common/unknown-image.png';

--- a/widget/embedded/src/containers/Inputs/Inputs.tsx
+++ b/widget/embedded/src/containers/Inputs/Inputs.tsx
@@ -82,11 +82,12 @@ export function Inputs(props: PropTypes) {
           balance={fromTokenFormattedBalance}
           chain={{
             displayName: fromBlockchain?.displayName || '',
-            image: fromBlockchain?.logo || '',
+            image: fromBlockchain?.logo,
           }}
           token={{
             displayName: fromToken?.symbol || '',
-            image: fromToken?.image || '',
+            image: fromToken?.image,
+            securityWarning: !!fromToken?.warning,
           }}
           onClickToken={() => onClickToken('from')}
           price={{
@@ -133,11 +134,12 @@ export function Inputs(props: PropTypes) {
         fetchingQuote={fetchingQuote}
         chain={{
           displayName: toBlockchain?.displayName || '',
-          image: toBlockchain?.logo || '',
+          image: toBlockchain?.logo,
         }}
         token={{
           displayName: toToken?.symbol || '',
-          image: toToken?.image || '',
+          image: toToken?.image,
+          securityWarning: !!toToken?.warning,
         }}
         percentageChange={numberToString(
           getPriceImpact(inputUsdValue, outputUsdValue),

--- a/widget/embedded/src/hooks/useSearchCustomTokens/index.ts
+++ b/widget/embedded/src/hooks/useSearchCustomTokens/index.ts
@@ -1,0 +1,1 @@
+export { useSearchCustomTokens } from './useSearchCustomTokens';

--- a/widget/embedded/src/hooks/useSearchCustomTokens/types.ts
+++ b/widget/embedded/src/hooks/useSearchCustomTokens/types.ts
@@ -1,0 +1,9 @@
+import type { Token } from 'rango-sdk';
+
+export type UseSearchCustomTokens = {
+  fetch: (query: string, blockchain?: string) => void;
+  cancel: () => void;
+  loading: boolean;
+  tokens: Token[];
+  error: string | null;
+};

--- a/widget/embedded/src/hooks/useSearchCustomTokens/useSearchCustomTokens.constants.ts
+++ b/widget/embedded/src/hooks/useSearchCustomTokens/useSearchCustomTokens.constants.ts
@@ -1,0 +1,1 @@
+export const DEBOUNCE_DELAY = 600;

--- a/widget/embedded/src/hooks/useSearchCustomTokens/useSearchCustomTokens.ts
+++ b/widget/embedded/src/hooks/useSearchCustomTokens/useSearchCustomTokens.ts
@@ -1,0 +1,81 @@
+import type { UseSearchCustomTokens } from './types';
+import type { Token } from 'rango-sdk';
+
+import { useCallback, useRef, useState } from 'react';
+
+import { httpService } from '../../services/httpService';
+import { useAppStore } from '../../store/AppStore';
+import { createAssetKey } from '../../store/utils/wallets';
+import { debounce } from '../../utils/common';
+
+import { DEBOUNCE_DELAY } from './useSearchCustomTokens.constants';
+
+export function useSearchCustomTokens(): UseSearchCustomTokens {
+  const blockchains = useAppStore().blockchains();
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const { customTokens } = useAppStore();
+  const [loading, setLoading] = useState(false);
+  const [tokens, setTokens] = useState<Token[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = async (query: string, blockchain?: string) => {
+    setError(null);
+    setLoading(true);
+    setTokens([]);
+
+    try {
+      const response = await httpService().searchCustomTokens(
+        { query, blockchain },
+        { signal: abortControllerRef.current?.signal }
+      );
+
+      const customTokensSet = new Set(
+        customTokens().map((token) => createAssetKey(token))
+      );
+      const blockchainsSet = new Set(
+        blockchains.map((blockchain) => blockchain.name)
+      );
+      const filteredTokens = response.tokens.filter(
+        (token) =>
+          blockchainsSet.has(token.blockchain) &&
+          !customTokensSet.has(createAssetKey(token))
+      );
+
+      setTokens(filteredTokens);
+      setLoading(false);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      setError(error instanceof Error ? error.message : 'something went wrong');
+      setTokens([]);
+      if (error?.name !== 'CanceledError') {
+        setLoading(false);
+      }
+    }
+  };
+
+  const debouncedFetch = useCallback(
+    debounce((query: string, blockchain?: string) => {
+      if (abortControllerRef.current?.signal.aborted) {
+        return;
+      }
+      void fetch(query, blockchain);
+    }, DEBOUNCE_DELAY),
+    [blockchains.length]
+  );
+
+  const cancel = () => {
+    abortControllerRef.current?.abort();
+  };
+  return {
+    fetch: (query: string, blockchain?: string) => {
+      abortControllerRef.current = new AbortController();
+      setTokens([]);
+      setLoading(true);
+      debouncedFetch(query, blockchain);
+    },
+    cancel,
+    loading,
+    tokens,
+    error,
+  };
+}

--- a/widget/embedded/src/hooks/useSyncStoresWithConfig.ts
+++ b/widget/embedded/src/hooks/useSyncStoresWithConfig.ts
@@ -26,7 +26,6 @@ export function useSyncStoresWithConfig() {
   const config = useAppStore().config;
   const fetchMetaStatus = useAppStore().fetchStatus;
   const blockchains = useAppStore().blockchains();
-  const tokens = useAppStore().tokens();
   const { findToken } = useAppStore();
 
   const { setAffiliateRef, setAffiliatePercent, setAffiliateWallets } =
@@ -61,7 +60,7 @@ export function useSyncStoresWithConfig() {
       }
 
       if (token) {
-        setFromToken({ token, meta: { blockchains, tokens } });
+        setFromToken({ token, meta: { blockchains } });
       } else if (!token && prevConfigFromToken.current) {
         setFromToken({ token: null });
       }
@@ -111,7 +110,7 @@ export function useSyncStoresWithConfig() {
       }
 
       if (token) {
-        setToToken({ token, meta: { blockchains, tokens } });
+        setToToken({ token, meta: { blockchains } });
       } else if (!token && prevConfigToToken.current) {
         setToToken({ token: null });
       }

--- a/widget/embedded/src/hooks/useSyncUrlAndStore/useSyncUrlAndStore.ts
+++ b/widget/embedded/src/hooks/useSyncUrlAndStore/useSyncUrlAndStore.ts
@@ -31,7 +31,6 @@ export function useSyncUrlAndStore() {
   } = useQuoteStore();
   const fetchMetaStatus = useAppStore().fetchStatus;
   const blockchains = useAppStore().blockchains();
-  const tokens = useAppStore().tokens();
   const isInRouterContext = useInRouterContext();
   const { updateIframe, updateCampaignMode } = useAppStore();
   const campaignMode = useAppStore().isInCampaignMode();
@@ -157,7 +156,6 @@ export function useSyncUrlAndStore() {
             token: fromToken,
             meta: {
               blockchains: blockchains,
-              tokens: tokens,
             },
           });
         }
@@ -168,7 +166,7 @@ export function useSyncUrlAndStore() {
         if (!!toToken) {
           setToToken({
             token: toToken,
-            meta: { blockchains: blockchains, tokens: tokens },
+            meta: { blockchains: blockchains },
           });
         }
       }

--- a/widget/embedded/src/pages/AddCustomTokenPage.tsx
+++ b/widget/embedded/src/pages/AddCustomTokenPage.tsx
@@ -5,25 +5,21 @@ import {
   darkTheme,
   Divider,
   DoneIcon,
-  MessageBox,
   styled,
   TextField,
   Typography,
 } from '@rango-dev/ui';
-import { type Token } from 'rango-sdk';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { BlockchainSelectorButton } from '../components/BlockchainSelectorButton';
-import { WatermarkedModal } from '../components/common/WatermarkedModal';
-import { CustomTokenModal } from '../components/CustomTokenModal';
+import { ImportCustomToken } from '../components/ImportCustomToken';
 import { Layout, PageContainer } from '../components/Layout';
 import { navigationRoutes } from '../constants/navigationRoutes';
 import { SearchParams } from '../constants/searchParams';
 import { useFetchCustomToken } from '../hooks/useFetchCustomToken';
 import { useNavigateBack } from '../hooks/useNavigateBack';
 import { useAppStore } from '../store/AppStore';
-import { getContainer } from '../utils/common';
 import { findBlockchain, isValidTokenAddress } from '../utils/meta';
 
 const Content = styled('div', {
@@ -41,68 +37,31 @@ const Content = styled('div', {
     height: '$40',
   },
 });
-const CUSTOM_TOKEN_REFRESH_DELAY = 1000;
 
 export function AddCustomTokenPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const navigateBack = useNavigateBack();
-  const { setCustomToken } = useAppStore();
   const blockchains = useAppStore().blockchains();
 
   const blockchainName = searchParams.get(SearchParams.BLOCKCHAIN) || '';
   const blockchain = findBlockchain(blockchainName, blockchains);
   const [address, setAddress] = useState('');
-  const [isOpenErrorModal, setIsOpenErrorModal] = useState<boolean>(false);
-  const [token, setToken] = useState<Token>();
-  const { fetchCustomToken, loading, error } = useFetchCustomToken();
-  const [networkError, setNetworkError] = useState('');
+  const { fetchCustomToken, token, loading, error, resetState } =
+    useFetchCustomToken();
   const isValidAddress =
     !!blockchain && isValidTokenAddress(blockchain, address);
   const isImportDisabled = !blockchain || !address || !isValidAddress;
 
-  const getCustomToken = async () => {
+  const getCustomToken = () => {
     if (blockchain) {
-      try {
-        const res = await fetchCustomToken({
-          blockchain: blockchainName,
-          tokenAddress: address,
-        });
-        setNetworkError('');
-        if (!!res) {
-          setToken(res);
-        }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
-        if (error.message === 'Failed to fetch') {
-          setNetworkError(i18n.t('Network Error'));
-          setIsOpenErrorModal(true);
-        }
-      }
+      void fetchCustomToken({
+        blockchain: blockchainName,
+        tokenAddress: address,
+      });
     }
   };
 
-  const closeErrorModal = () => {
-    if (!!error) {
-      setAddress('');
-    }
-    setIsOpenErrorModal(false);
-  };
-
-  const handleErrorModalButtonClick = async () => {
-    if (!!networkError) {
-      setTimeout(async () => {
-        await getCustomToken();
-      }, CUSTOM_TOKEN_REFRESH_DELAY);
-    }
-    closeErrorModal();
-  };
-
-  useEffect(() => {
-    if (!!error) {
-      setIsOpenErrorModal(true);
-    }
-  }, [error]);
   return (
     <Layout
       header={{
@@ -164,50 +123,21 @@ export function AddCustomTokenPage() {
             {i18n.t('Import')}
           </Button>
         </Content>
-        <WatermarkedModal
-          open={isOpenErrorModal}
-          dismissible
-          onClose={closeErrorModal}
-          container={getContainer()}>
-          <MessageBox
-            title={error?.title || networkError}
-            type="error"
-            description={
-              error?.message || i18n.t('Failed Network, Please retry.')
-            }>
-            <Divider size={40} />
-            <Divider size={10} />
-            {/* eslint-disable-next-line jsx-id-attribute-enforcement/missing-ids */}
-            <Button
-              id={`widget-add-custom-token-${
-                networkError ? 'retry' : 'add-another'
-              }-btn`}
-              variant="contained"
-              size="large"
-              type="primary"
-              fullWidth
-              onClick={handleErrorModalButtonClick}>
-              {networkError
-                ? i18n.t('Retry')
-                : i18n.t('Add another custom token')}
-            </Button>
-          </MessageBox>
-        </WatermarkedModal>
-        {blockchain && token && (
-          <CustomTokenModal
-            blockchain={blockchain}
-            token={token}
-            onSubmitClick={() => {
-              if (token) {
-                setCustomToken(token);
-                setToken(undefined);
-                navigateBack();
-              }
-            }}
-            onClose={() => setToken(undefined)}
-            open={!!blockchain && !!token}
-          />
-        )}
+        <ImportCustomToken
+          token={token}
+          blockchain={blockchain ?? undefined}
+          address={address}
+          error={error ?? undefined}
+          fetchCustomToken={fetchCustomToken}
+          onCloseErrorModal={() => {
+            if (error?.type !== 'network-error') {
+              setAddress('');
+            }
+          }}
+          onImport={navigateBack}
+          onExitErrorModal={resetState}
+          onExitImportModal={resetState}
+        />
       </PageContainer>
     </Layout>
   );

--- a/widget/embedded/src/pages/CustomTokensPage.tsx
+++ b/widget/embedded/src/pages/CustomTokensPage.tsx
@@ -108,6 +108,7 @@ export function CustomTokensPage() {
                 type="custom-token"
                 searchedFor={searchedFor}
                 showTitle={false}
+                showWarning={false}
                 action={(token) => (
                   <DeleteIconButton
                     id="widget-custom-token-delete-icon-btn"

--- a/widget/embedded/src/pages/SelectSwapItemPage/SelectSwapItemPage.constants.ts
+++ b/widget/embedded/src/pages/SelectSwapItemPage/SelectSwapItemPage.constants.ts
@@ -1,0 +1,2 @@
+export const MAX_TOKENS_BEFORE_FETCH = 20;
+export const MIN_SEARCH_LENGTH = 3;

--- a/widget/embedded/src/pages/SelectSwapItemPage/SelectSwapItemPage.helpers.ts
+++ b/widget/embedded/src/pages/SelectSwapItemPage/SelectSwapItemPage.helpers.ts
@@ -1,0 +1,51 @@
+import type { TokenList } from '../../components/TokenList';
+import type { Token } from 'rango-sdk';
+import type { ComponentProps } from 'react';
+
+import {
+  MAX_TOKENS_BEFORE_FETCH,
+  MIN_SEARCH_LENGTH,
+} from './SelectSwapItemPage.constants';
+
+export function shouldSearchForCustomTokens(
+  metaSearchResultTokens: Token[],
+  query: string,
+  blockchain?: string
+) {
+  if (
+    blockchain &&
+    metaSearchResultTokens.length === 1 &&
+    metaSearchResultTokens[0].address === query
+  ) {
+    return false;
+  }
+  return (
+    metaSearchResultTokens.length < MAX_TOKENS_BEFORE_FETCH &&
+    query.trim().length >= MIN_SEARCH_LENGTH
+  );
+}
+
+export function prepareTokensList(
+  tokens: Token[],
+  customTokens: Token[],
+  query: string,
+  loading: boolean,
+  blockchain?: string
+) {
+  let modifiedList: ComponentProps<typeof TokenList>['list'] = [...tokens];
+
+  if (shouldSearchForCustomTokens(tokens, query, blockchain)) {
+    modifiedList = loading
+      ? [...modifiedList, 'skeleton', 'skeleton', 'skeleton']
+      : [
+          ...modifiedList,
+          ...customTokens.map((customToken) => ({
+            ...customToken,
+            customToken: true,
+            warning: true,
+          })),
+        ];
+  }
+
+  return modifiedList;
+}

--- a/widget/embedded/src/pages/SelectSwapItemPage/index.ts
+++ b/widget/embedded/src/pages/SelectSwapItemPage/index.ts
@@ -1,0 +1,1 @@
+export { SelectSwapItemsPage } from './SelectSwapItemsPage';

--- a/widget/embedded/src/store/app.ts
+++ b/widget/embedded/src/store/app.ts
@@ -1,5 +1,5 @@
-import type { AppStoreState } from './slices/types';
 import type { WidgetConfig } from '../types';
+import type { AppStoreState } from './slices/types';
 import type { StateCreator } from 'zustand';
 
 import { create } from 'zustand';
@@ -47,6 +47,17 @@ export function createAppStore(initialData?: WidgetConfig) {
             preferredBlockchains: state.preferredBlockchains,
             disabledLiquiditySources: state.disabledLiquiditySources,
           };
+        },
+        version: 1,
+        migrate: (persistedState, version) => {
+          const state = persistedState as AppStoreState;
+          if (version === 0) {
+            state._customTokens = state._customTokens.map((token) => ({
+              ...token,
+              warning: true,
+            }));
+          }
+          return state;
         },
       }
     )

--- a/widget/embedded/src/store/quote.ts
+++ b/widget/embedded/src/store/quote.ts
@@ -1,3 +1,4 @@
+import type { TokenData } from '../components/TokenList/TokenList.types';
 import type {
   BlockchainMeta,
   MetaResponse,
@@ -35,7 +36,9 @@ export const getUsdValue = (
 
 export type Meta = Pick<MetaResponse, 'blockchains' | 'tokens'>;
 
-export type SetTokenParams = { token: Token; meta: Meta } | { token: null };
+export type SetTokenParams =
+  | { token: TokenData; meta: { blockchains: BlockchainMeta[] } }
+  | { token: null };
 
 type SomeQuoteState = {
   quotes: MultiRouteResponse | null;
@@ -58,9 +61,9 @@ export interface QuoteState {
   inputUsdValue: BigNumber | null;
   outputAmount: BigNumber | null;
   outputUsdValue: BigNumber | null;
-  fromToken: Token | null;
+  fromToken: TokenData | null;
   sortStrategy: PreferenceType;
-  toToken: Token | null;
+  toToken: TokenData | null;
   quoteWalletsConfirmed: boolean;
   selectedWallets: Wallet[];
   quoteWarningsConfirmed: boolean;

--- a/widget/embedded/src/store/slices/settings.ts
+++ b/widget/embedded/src/store/slices/settings.ts
@@ -1,5 +1,6 @@
 import type { ConfigSlice } from './config';
 import type { DataSlice } from './data';
+import type { TokenData } from '../../components/TokenList/TokenList.types';
 import type { WidgetConfig } from '../../types';
 import type { SwapperMeta, Token } from 'rango-sdk';
 import type { StateCreator } from 'zustand';
@@ -46,7 +47,7 @@ export interface SettingsSlice {
   ) => void;
   addPreferredBlockchain: (blockchain: string) => void;
   updateSettings: (config: WidgetConfig) => void;
-  setCustomToken: (token: Token) => void;
+  setCustomToken: (token: TokenData) => void;
   deleteCustomToken: (token: Token) => void;
   customTokens: () => Token[];
 }

--- a/widget/embedded/src/utils/quote.ts
+++ b/widget/embedded/src/utils/quote.ts
@@ -293,7 +293,7 @@ export function getPriceImpact(
 
 export const getUniqueBlockchains = (steps: Step[]) => {
   const set = new Set();
-  const result: { displayName: string; image: string }[] = [];
+  const result: { displayName: string; image?: string }[] = [];
   steps.forEach((step) => {
     if (!set.has(step.from.chain.displayName)) {
       set.add(step.from.chain.displayName);

--- a/widget/ui/src/components/ChainToken/ChainToken.constants.ts
+++ b/widget/ui/src/components/ChainToken/ChainToken.constants.ts
@@ -8,3 +8,6 @@ export const tokenChainSizeMap: {
   medium: { token: 27, chain: 10 },
   large: { token: 30, chain: 15 },
 };
+
+export const DEFAULT_TOKEN_IMAGE_SRC =
+  'https://raw.githubusercontent.com/rango-exchange/assets/refs/heads/main/common/unknown-image.png';

--- a/widget/ui/src/components/ChainToken/ChainToken.tsx
+++ b/widget/ui/src/components/ChainToken/ChainToken.tsx
@@ -5,7 +5,10 @@ import React from 'react';
 import { Image } from '../common/index.js';
 import { Skeleton } from '../Skeleton/index.js';
 
-import { tokenChainSizeMap } from './ChainToken.constants.js';
+import {
+  DEFAULT_TOKEN_IMAGE_SRC,
+  tokenChainSizeMap,
+} from './ChainToken.constants.js';
 import {
   ChainImageContainer,
   Container,
@@ -21,6 +24,11 @@ export const ChainToken: React.FC<ChainTokenPropTypes> = (props) => {
     useAsPlaceholder,
     loading,
   } = props;
+
+  const tokenImageSrc =
+    tokenImage === '' ? DEFAULT_TOKEN_IMAGE_SRC : tokenImage;
+  const chainImageSrc =
+    chainImage === '' ? DEFAULT_TOKEN_IMAGE_SRC : chainImage;
 
   return (
     <Container
@@ -39,19 +47,19 @@ export const ChainToken: React.FC<ChainTokenPropTypes> = (props) => {
           width={tokenChainSizeMap[size].token}
         />
       ) : (
-        <TokenImageContainer hasBorder={!tokenImage}>
+        <TokenImageContainer hasBorder={!tokenImageSrc}>
           <Image
             size={tokenChainSizeMap[size].token}
-            src={tokenImage}
+            src={tokenImageSrc}
             type="circular"
-            {...((useAsPlaceholder || !tokenImage) && {
+            {...((useAsPlaceholder || !tokenImageSrc) && {
               useAsPlaceholder: true,
               backgroundColor: 'transparent',
             })}
           />
         </TokenImageContainer>
       )}
-      <ChainImageContainer size={size} hasBorder={!chainImage}>
+      <ChainImageContainer size={size} hasBorder={!chainImageSrc}>
         {loading ? (
           <Skeleton
             variant="circular"
@@ -62,9 +70,9 @@ export const ChainToken: React.FC<ChainTokenPropTypes> = (props) => {
           <Image
             id={chianImageId}
             size={tokenChainSizeMap[size].chain}
-            src={chainImage}
+            src={chainImageSrc}
             type="circular"
-            {...((useAsPlaceholder || !chainImage) && {
+            {...((useAsPlaceholder || !chainImageSrc) && {
               useAsPlaceholder: true,
               backgroundColor: 'transparent',
             })}

--- a/widget/ui/src/components/ChainToken/ChainToken.types.ts
+++ b/widget/ui/src/components/ChainToken/ChainToken.types.ts
@@ -5,8 +5,8 @@ type BaseProps = Stitches.VariantProps<typeof ChainImageContainer>;
 type BaseSizes = Exclude<BaseProps['size'], object>;
 
 export type ChainTokenPropTypes = {
-  tokenImage: string;
-  chainImage: string;
+  tokenImage?: string;
+  chainImage?: string;
   chianImageId?: string;
   size: NonNullable<BaseSizes>;
   useAsPlaceholder?: boolean;

--- a/widget/ui/src/components/CustomTokenWarning/CustomTokenWarning.styles.ts
+++ b/widget/ui/src/components/CustomTokenWarning/CustomTokenWarning.styles.ts
@@ -1,0 +1,30 @@
+import type { Tooltip } from '../Tooltip';
+import type { ComponentProps } from 'react';
+
+import { styled } from '../../theme';
+import { IconHighlight } from '../Alert/Alert.styles';
+
+export const tooltipStyles: ComponentProps<typeof Tooltip>['styles'] = {
+  root: {
+    zIndex: 10,
+  },
+};
+
+export const TooltipContent = styled('div', {
+  width: '217px',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+
+  '& .warning-icon-container': {
+    width: '$20',
+    height: '$20',
+    alignSelf: 'unset',
+  },
+});
+
+export const StyledIconHighlight = styled(IconHighlight, {
+  width: '14px',
+  height: '14px',
+  alignSelf: 'unset',
+});

--- a/widget/ui/src/components/CustomTokenWarning/CustomTokenWarning.tsx
+++ b/widget/ui/src/components/CustomTokenWarning/CustomTokenWarning.tsx
@@ -1,0 +1,44 @@
+import type { PropTypes } from './CustomTokenWarning.types';
+
+import { i18n } from '@lingui/core';
+import React from 'react';
+
+import { WarningIcon } from '../../icons';
+import { IconHighlight } from '../Alert/Alert.styles';
+import { Divider } from '../Divider';
+import { Tooltip } from '../Tooltip';
+import { Typography } from '../Typography';
+
+import {
+  StyledIconHighlight,
+  TooltipContent,
+  tooltipStyles,
+} from './CustomTokenWarning.styles';
+
+export function CustomTokenWarning(props: PropTypes) {
+  return (
+    <Tooltip
+      styles={tooltipStyles}
+      side="bottom"
+      align="center"
+      sideOffset={20}
+      container={props.container}
+      content={
+        <TooltipContent>
+          <IconHighlight type="warning" className="warning-icon-container">
+            <WarningIcon color="warning" size={13} />
+          </IconHighlight>
+          <Divider size={4} direction="horizontal" />
+          <Typography variant="body" size="xsmall">
+            {i18n.t(
+              'This token may involve potential security risks; proceed with caution.'
+            )}
+          </Typography>
+        </TooltipContent>
+      }>
+      <StyledIconHighlight type="warning">
+        <WarningIcon color="warning" size={9} />
+      </StyledIconHighlight>
+    </Tooltip>
+  );
+}

--- a/widget/ui/src/components/CustomTokenWarning/CustomTokenWarning.types.ts
+++ b/widget/ui/src/components/CustomTokenWarning/CustomTokenWarning.types.ts
@@ -1,0 +1,3 @@
+export type PropTypes = {
+  container?: HTMLElement;
+};

--- a/widget/ui/src/components/CustomTokenWarning/index.ts
+++ b/widget/ui/src/components/CustomTokenWarning/index.ts
@@ -1,0 +1,1 @@
+export { CustomTokenWarning } from './CustomTokenWarning';

--- a/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.Skeletons.tsx
+++ b/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.Skeletons.tsx
@@ -34,13 +34,7 @@ export function SkeletonHeader() {
 export function SkeletonOutput() {
   return (
     <OutputLoading>
-      <ChainToken
-        useAsPlaceholder={true}
-        size="large"
-        chainImage=""
-        tokenImage=""
-        loading={true}
-      />
+      <ChainToken useAsPlaceholder={true} size="large" loading={true} />
       <Skeleton variant="rounded" width={122} height={29} />
     </OutputLoading>
   );

--- a/widget/ui/src/components/SwapListItem/SwapListItem.types.ts
+++ b/widget/ui/src/components/SwapListItem/SwapListItem.types.ts
@@ -25,11 +25,11 @@ export const StatusColors = {
 export interface SwapTokenData {
   from: {
     token: {
-      image: string;
+      image?: string;
       displayName: string;
     };
     blockchain: {
-      image: string;
+      image?: string;
     };
     amount: string;
     realAmount: string;
@@ -37,11 +37,11 @@ export interface SwapTokenData {
 
   to: {
     token: {
-      image: string;
+      image?: string;
       displayName: string;
     };
     blockchain: {
-      image: string;
+      image?: string;
     };
     amount: string;
     realAmount: string;

--- a/widget/ui/src/components/SwapListItem/SwapToken.tsx
+++ b/widget/ui/src/components/SwapListItem/SwapToken.tsx
@@ -27,23 +27,13 @@ export function SwapToken(props: PropTypes) {
       <TokenContainer>
         <Images>
           <div>
-            <ChainToken
-              tokenImage=""
-              chainImage=""
-              size="medium"
-              loading={true}
-            />
+            <ChainToken size="medium" loading={true} />
           </div>
           <div
             style={{
               transform: 'translateX(-5px)',
             }}>
-            <ChainToken
-              tokenImage=""
-              chainImage=""
-              size="medium"
-              loading={true}
-            />
+            <ChainToken size="medium" loading={true} />
           </div>
         </Images>
         <LayoutLoading>

--- a/widget/ui/src/components/index.ts
+++ b/widget/ui/src/components/index.ts
@@ -43,6 +43,7 @@ export * from './Flags/index.js';
 export * from './Select/index.js';
 export * from './QuoteTag/index.js';
 export * from './Tabs/index.js';
+export * from './CustomTokenWarning/index.js';
 export type {
   SvgIconProps,
   SvgIconPropsWithChildren,

--- a/widget/ui/src/containers/Notifications/Notifications.types.ts
+++ b/widget/ui/src/containers/Notifications/Notifications.types.ts
@@ -9,8 +9,8 @@ type Notification = {
 
 export type PropTypes = {
   list: Notification[];
-  getBlockchainImage: (blockchain: string) => string;
-  getTokenImage: (token: Asset) => string;
+  getBlockchainImage: (blockchain: string) => string | undefined;
+  getTokenImage: (token: Asset) => string | undefined;
   onClickItem: (requestId: string) => void;
   onClearAll: () => void;
   containerStyles?: CSS;

--- a/widget/ui/src/containers/SwapInput/SwapInput.tsx
+++ b/widget/ui/src/containers/SwapInput/SwapInput.tsx
@@ -96,6 +96,8 @@ export function SwapInput(props: SwapInputPropTypes) {
           tokenImage={props.token.image}
           onClick={props.onClickToken}
           loading={props.loading}
+          warning={props.token.securityWarning}
+          tooltipContainer={props.tooltipContainer}
         />
         <div className={amountStyles()}>
           {props.loading || (props.mode === 'To' && props.fetchingQuote) ? (

--- a/widget/ui/src/containers/SwapInput/SwapInput.types.ts
+++ b/widget/ui/src/containers/SwapInput/SwapInput.types.ts
@@ -3,11 +3,12 @@ import type { PriceImpactWarningLevel } from '../../components/PriceImpact/Price
 export type BaseProps = {
   chain: {
     displayName: string;
-    image: string;
+    image?: string;
   };
   token: {
     displayName: string;
-    image: string;
+    image?: string;
+    securityWarning?: boolean;
   };
   price: {
     value: string;
@@ -41,4 +42,5 @@ type ToProps = {
   warningLevel: PriceImpactWarningLevel;
 };
 
-export type SwapInputPropTypes = BaseProps & (FromProps | ToProps);
+export type SwapInputPropTypes = BaseProps &
+  (FromProps | ToProps) & { tooltipContainer?: HTMLElement };

--- a/widget/ui/src/containers/SwapInput/TokenSection.styles.ts
+++ b/widget/ui/src/containers/SwapInput/TokenSection.styles.ts
@@ -74,3 +74,10 @@ export const skeletonStyles = css({
   width: '100%',
   padding: '$5 $0',
 });
+
+export const TitleContainer = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  flexWrap: 'wrap',
+});

--- a/widget/ui/src/containers/SwapInput/TokenSection.tsx
+++ b/widget/ui/src/containers/SwapInput/TokenSection.tsx
@@ -2,6 +2,7 @@ import type { TokenSectionProps } from './TokenSection.types.js';
 
 import { i18n } from '@lingui/core';
 import React from 'react';
+import { CustomTokenWarning } from 'src/components/CustomTokenWarning/CustomTokenWarning.js';
 
 import {
   ChainToken,
@@ -14,6 +15,7 @@ import {
   chainNameStyles,
   Container,
   skeletonStyles,
+  TitleContainer,
   tokenChainStyles,
   TokenSectionContainer,
 } from './TokenSection.styles.js';
@@ -28,6 +30,8 @@ export function TokenSection(props: TokenSectionProps) {
     chianImageId,
     onClick,
     loading,
+    warning,
+    tooltipContainer,
   } = props;
   return (
     <Container variant="default" disabled={error || loading} onClick={onClick}>
@@ -49,11 +53,19 @@ export function TokenSection(props: TokenSectionProps) {
             </div>
           ) : (
             <>
-              <Typography variant="title" size="medium">
-                {error || (!loading && !tokenSymbol)
-                  ? i18n.t('Select Token')
-                  : tokenSymbol}
-              </Typography>
+              <TitleContainer>
+                <Typography variant="title" size="medium">
+                  {error || (!loading && !tokenSymbol)
+                    ? i18n.t('Select Token')
+                    : tokenSymbol}
+                </Typography>
+                {warning && (
+                  <>
+                    <Divider size={4} direction="horizontal" />
+                    <CustomTokenWarning container={tooltipContainer} />
+                  </>
+                )}
+              </TitleContainer>
               <Typography
                 variant="body"
                 size="medium"

--- a/widget/ui/src/containers/SwapInput/TokenSection.types.ts
+++ b/widget/ui/src/containers/SwapInput/TokenSection.types.ts
@@ -1,10 +1,12 @@
 export type TokenSectionProps = {
-  chainImage: string;
-  tokenImage: string;
+  chainImage?: string;
+  tokenImage?: string;
   tokenSymbol: string;
   chain: string;
   chianImageId?: string;
   error?: boolean;
   onClick: () => void;
   loading?: boolean;
+  warning?: boolean;
+  tooltipContainer?: HTMLElement;
 };


### PR DESCRIPTION
# Summary

implement search functionality for custom tokens

If the user enters a query in the search input of the token list and the following criteria are met, we should call the search endpoint to find custom tokens:  

- The total number of tokens in the list is below 20.  
- The search query has at least 3 characters.  

To prevent unnecessary API calls, we can implement a debounce mechanism.  

Additional features:  
- Display a warning badge in the token selector and on the home page when a custom token is selected.  
- Implement an import function similar to the custom token feature in settings.  
- If a custom token is imported while on the token selector page, it should be automatically selected, and the user should be redirected back to the home page.

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
