### PR TITLE
fix: update balance after transaction with max amount

### DIFF
--- a/widget/embedded/src/store/slices/wallets.ts
+++ b/widget/embedded/src/store/slices/wallets.ts
@@ -442,6 +442,11 @@ export const createWalletsSlice: StateCreator<
           return;
         }
 
+        // Remove old balances for current wallet and blockchain
+        get().removeBalancesForWallet(walletType, {
+          chains: [wallet.blockChain],
+        });
+
         const balancesForWallet = createBalanceStateForNewAccount(wallet, get);
 
         nextAggregatedBalances = updateAggregatedBalanceStateForNewAccount(


### PR DESCRIPTION
# Summary

After a transaction gets executed, balance for that wallet address will be fetched for source and destination wallet address and blockchain, then new balances will be set in store and already existing balances will be updated, but old balances are not getting removed. This results in that if a transaction get executed with max amount for an asset, there will be no balance related to that asset in the response of fetch balance so old balance for that asset will not get removed from store.

As a result of this change, the old balances will be removed initially, followed by the application of updates to address the described issue.

Fixes # 2231


# How did you test this change?

Create a transaction with max amount of source asset. After executing the transaction successfully, you should observe that balances get updated properly.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
