### PR TITLE
fix: throw error on connect only if all namespaces failed

### DIFF
--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -236,11 +236,16 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
       );
 
       const allResult = Result.all(...connectResults);
-      if (allResult.err) {
+      if (
+        Result.all(...connectResults).err &&
+        !successfullyConnectedNamespaces.length
+      ) {
         throw allResult.val;
       }
 
-      return allResult.unwrap();
+      return Result.all(
+        ...connectResults.filter((result) => !result.err)
+      ).unwrap();
     },
     async disconnect(type) {
       const wallet = getHub().get(type);


### PR DESCRIPTION
# Summary

Attempting to connect two namespaces which one of them is not available in Phantom account results in a success status but the success status modal will not close automatically because an error is thrown when any namespace fails to connect.
In this change, an error will be thrown only if all the namespaces fail to connect.

Fixes # 2242


# How did you test this change?

This change can be tested by selecting an account containing only one of the supported namespaces and try to connect to both of them and observing that success modal will close automatically.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
