### PR TITLE
feat: introducing store events for hub and fix switching accounts issues

### DIFF
--- a/wallets/core/package.json
+++ b/wallets/core/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/utils/mod.d.ts",
       "default": "./dist/utils/mod.js"
     },
+    "./store": {
+      "types": "./dist/hub/store/mod.d.ts",
+      "default": "./dist/hub/store/mod.js"
+    },
     "./namespaces/common": {
       "types": "./dist/namespaces/common/mod.d.ts",
       "default": "./dist/namespaces/common/mod.js"
@@ -38,7 +42,7 @@
     "legacy"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/core --inputs src/mod.ts,src/utils/mod.ts,src/legacy/mod.ts,src/namespaces/evm/mod.ts,src/namespaces/solana/mod.ts,src/namespaces/common/mod.ts",
+    "build": "node ../../scripts/build/command.mjs --path wallets/core --inputs src/mod.ts,src/utils/mod.ts,src/legacy/mod.ts,src/hub/store/mod.ts,src/namespaces/evm/mod.ts,src/namespaces/solana/mod.ts,src/namespaces/common/mod.ts",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",

--- a/wallets/core/src/hub/store/events.ts
+++ b/wallets/core/src/hub/store/events.ts
@@ -1,0 +1,89 @@
+export type NamespaceDisconnectedEvent = {
+  type: 'namespace_disconnected';
+  provider: string;
+  namespace: string;
+};
+
+export type NamespaceConnectedEvent = {
+  type: 'namespace_connected';
+  provider: string;
+  namespace: string;
+  accounts: string[];
+};
+
+export type NamespaceSwitchedAccountEvent = {
+  type: 'namespace_account_switched';
+  provider: string;
+  namespace: string;
+  accounts: string[];
+  previousAccounts: string[];
+};
+
+export type NamespaceSwitchedNetworkEvent = {
+  type: 'namespace_network_switched';
+  provider: string;
+  namespace: string;
+  network: string;
+  previousNetwork: string | null;
+};
+
+export type ProviderDetectedEvent = {
+  type: 'provider_detected';
+  provider: string;
+};
+
+export type ProviderConnectingEvent = {
+  type: 'provider_connecting';
+  provider: string;
+  value: boolean;
+};
+
+export type ProviderConnectedEvent = {
+  type: 'provider_connected';
+  provider: string;
+};
+
+export type ProviderDisconnectedEvent = {
+  type: 'provider_disconnected';
+  provider: string;
+};
+
+export type Event =
+  | NamespaceDisconnectedEvent
+  | NamespaceConnectedEvent
+  | NamespaceSwitchedAccountEvent
+  | NamespaceSwitchedNetworkEvent
+  | ProviderDetectedEvent
+  | ProviderConnectingEvent
+  | ProviderConnectedEvent
+  | ProviderDisconnectedEvent;
+
+/**
+ *
+ * Keeping an array of Event and when iterates over its values, it will be removed (consume) from the array.
+ *
+ */
+export class ConsumableEvents {
+  #data: Event[] = [];
+
+  push(val: Event) {
+    this.#data.push(val);
+  }
+
+  [Symbol.iterator](): Iterator<Event> {
+    return {
+      next: (): IteratorResult<Event> => {
+        if (this.#data.length == 0) {
+          return { done: true, value: undefined };
+        }
+
+        // Typescript can not narrow the type, but we have a runtime check to ensure it will never be an empty list
+        const value = this.#data.shift()!;
+        return {
+          done: false,
+          value,
+        };
+      },
+    };
+  }
+}

--- a/wallets/core/src/hub/store/extend.ts
+++ b/wallets/core/src/hub/store/extend.ts
@@ -1,0 +1,125 @@
+import type {
+  Event,
+  ProviderConnectedEvent,
+  ProviderConnectingEvent,
+  ProviderDisconnectedEvent,
+} from './events.js';
+import type { RawStore, State } from './store.js';
+
+import { guessProviderStateSelector } from './selectors.js';
+
+export interface Store extends Omit<RawStore, 'subscribe'> {
+  subscribe(listener: (event: Event, state: State, prevState: State) => void): {
+    flushEvents(): void;
+  };
+}
+
+/**
+ * Zustand's store provides a set of built-in functionalities,
+ * but it may not meet all our requirements.
+ * This function modifies the interface and adds or updates the available methods.
+ */
+export function extend(store: RawStore): Store {
+  const extendedSubscribe: (store: RawStore) => Store['subscribe'] =
+    (store) => (listener) => {
+      const executeListener = (
+        events: Event[],
+        state: State,
+        prevState: State
+      ) => {
+        for (const ev of events) {
+          listener(ev, state, prevState);
+        }
+      };
+
+      /*
+       * only known changes will fire event for lib users
+       * so all the changes in store won't trigger a user-face event
+       */
+      store.subscribe((state, prevState) => {
+        const eventsLike = getEventsLike(state, prevState);
+        const events = tryConsumeEvents(state);
+        const allQueuedEvents = [...events, ...eventsLike];
+        executeListener(allQueuedEvents, state, prevState);
+      });
+
+      return {
+        /**
+         * Manually run pending events.
+         * This useful when use `subscribe` method after sometime and when store initialized.
+         *
+         * Note: Please consider both current and previous state will be same and we don't have access to previous state in a such scenario.
+         */
+        flushEvents: () => {
+          const state = store.getState();
+          const events = tryConsumeEvents(state);
+          executeListener(events, state, state);
+        },
+      };
+    };
+
+  return new Proxy(store, {
+    get: function (target, prop, receiver) {
+      if (prop === 'subscribe') {
+        return extendedSubscribe(target);
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  }) as unknown as Store;
+}
+
+/**
+ * Retrieves the ConsumableEvent from the store and returns its values.
+ * The values will be consumed by iterating over the field.
+ */
+function tryConsumeEvents(state: State): Event[] {
+  return [...state.providers.events, ...state.namespaces.events];
+}
+
+/**
+ * In certain cases, adding events to the store is not possible (e.g., namespace or provider layer).
+ * In these cases, we observe store changes and treat specific patterns as events when detected.
+ *
+ * Note: This approach should be avoided in most cases. It is used here to maintain backward compatibility
+ * with the provider's legacy interface.
+ */
+function getEventsLike(state: State, prevState: State): Event[] {
+  const events: Event[] = [];
+
+  for (const providerId of Object.keys(state.providers.list)) {
+    const currentProviderState = guessProviderStateSelector(state, providerId);
+    const previousProviderState = guessProviderStateSelector(
+      prevState,
+      providerId
+    );
+
+    if (previousProviderState.connecting !== currentProviderState.connecting) {
+      const ev: ProviderConnectingEvent = {
+        type: 'provider_connecting',
+        provider: providerId,
+        value: currentProviderState.connecting,
+      };
+      events.push(ev);
+    }
+
+    if (!previousProviderState.connected && currentProviderState.connected) {
+      const ev: ProviderConnectedEvent = {
+        type: 'provider_connected',
+        provider: providerId,
+      };
+
+      events.push(ev);
+    }
+
+    if (previousProviderState.connected && !currentProviderState.connected) {
+      const ev: ProviderDisconnectedEvent = {
+        type: 'provider_disconnected',
+        provider: providerId,
+      };
+
+      events.push(ev);
+    }
+  }
+
+  return events;
+}

--- a/wallets/core/src/hub/store/mod.ts
+++ b/wallets/core/src/hub/store/mod.ts
@@ -2,7 +2,20 @@ export {
   guessProviderStateSelector,
   namespaceStateSelector,
 } from './selectors.js';
-export type { Store, State } from './store.js';
+export type { Store } from './extend.js';
+export type { State } from './store.js';
+export type {
+  Event,
+  // Providers
+  ProviderDetectedEvent,
+  ProviderConnectingEvent,
+  ProviderConnectedEvent,
+  ProviderDisconnectedEvent,
+  // Namespaces
+  NamespaceDisconnectedEvent,
+  NamespaceConnectedEvent,
+  NamespaceSwitchedAccountEvent,
+} from './events.js';
 export type { ProviderInfo, ProviderConfig } from './providers.js';
 export type { NamespaceConfig, NamespaceData } from './namespaces.js';
 export { createStore } from './store.js';

--- a/wallets/core/src/hub/store/namespaces.ts
+++ b/wallets/core/src/hub/store/namespaces.ts
@@ -4,12 +4,17 @@ import type { StateCreator } from 'zustand';
 
 import { produce } from 'immer';
 
+import {
+  ConsumableEvents,
+  type NamespaceConnectedEvent,
+  type NamespaceDisconnectedEvent,
+  type NamespaceSwitchedAccountEvent,
+  type NamespaceSwitchedNetworkEvent,
+} from './events.js';
 import { namespaceStateSelector, type State } from './mod.js';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface NamespaceConfig {
-  // Currently, namespace doesn't has any config.
-}
+// Currently, namespace doesn't has any config.
+export type NamespaceConfig = object;
 
 export interface NamespaceData {
   accounts: null | string[];
@@ -23,20 +28,27 @@ interface NamespaceInfo {
   namespaceId: string;
 }
 
+interface NamespaceItem {
+  info: NamespaceInfo;
+  data: NamespaceData;
+  error: unknown;
+}
+
 type NamespaceState = {
-  list: Record<
-    string,
-    {
-      info: NamespaceInfo;
-      data: NamespaceData;
-      error: unknown;
-    }
-  >;
+  events: InstanceType<typeof ConsumableEvents>;
+  list: Record<string, NamespaceItem>;
 };
 
 interface NamespaceActions {
   addNamespace: (id: string, config: NamespaceInfo) => void;
   updateStatus: <K extends keyof NamespaceData>(
+    id: string,
+    key: K,
+    value: NamespaceData[K]
+  ) => void;
+
+  _produceEventsWhenUpdatingStatus: <K extends keyof NamespaceData>(
+    namespace: NamespaceItem,
     id: string,
     key: K,
     value: NamespaceData[K]
@@ -52,15 +64,19 @@ export type NamespaceStore = NamespaceState &
 type NamespaceStateCreator = StateCreator<State, [], [], NamespaceStore>;
 
 const namespacesStore: NamespaceStateCreator = (set, get) => ({
+  events: new ConsumableEvents(),
+
   list: {},
   addNamespace: (id, info) => {
+    const data: NamespaceData = {
+      accounts: null,
+      network: null,
+      connected: false,
+      connecting: false,
+    };
+
     const item = {
-      data: {
-        accounts: null,
-        network: null,
-        connected: false,
-        connecting: false,
-      },
+      data,
       error: '',
       info,
     };
@@ -72,10 +88,14 @@ const namespacesStore: NamespaceStateCreator = (set, get) => ({
     );
   },
   updateStatus: (id, key, value) => {
-    if (!get().namespaces.list[id]) {
+    const ns = get().namespaces.list[id];
+    if (!ns) {
       throw new Error(`No namespace with '${id}' found.`);
     }
 
+    get().namespaces._produceEventsWhenUpdatingStatus(ns, id, key, value);
+
+    // Updating state
     set(
       produce((state: State) => {
         state.namespaces.list[id].data[key] = value;
@@ -84,6 +104,69 @@ const namespacesStore: NamespaceStateCreator = (set, get) => ({
   },
   getNamespaceData(storeId) {
     return namespaceStateSelector(get(), storeId);
+  },
+
+  _produceEventsWhenUpdatingStatus: (namespace, id, key, value) => {
+    if (key === 'accounts') {
+      // check for both null and empty array
+      const isAccountsEmpty =
+        Object.is(value, null) || (Array.isArray(value) && value.length === 0);
+
+      if (isAccountsEmpty) {
+        const currentConnectedStatus = get().namespaces.list[id].data.connected;
+        if (currentConnectedStatus) {
+          const event: NamespaceDisconnectedEvent = {
+            type: 'namespace_disconnected',
+            provider: namespace.info.providerId,
+            namespace: namespace.info.namespaceId,
+          };
+
+          get().namespaces.events.push(event);
+        }
+        // Skip emitting disconnect event, if the `connected` is false
+      } else {
+        const currentAccounts = get().namespaces.list[id].data.accounts;
+
+        if (!currentAccounts) {
+          const event: NamespaceConnectedEvent = {
+            type: 'namespace_connected',
+            provider: namespace.info.providerId,
+            namespace: namespace.info.namespaceId,
+            accounts: value as string[],
+          };
+
+          get().namespaces.events.push(event);
+        } else {
+          const areSameAccounts =
+            currentAccounts.sort().toString() ===
+            (value as string[]).sort().toString();
+
+          if (!areSameAccounts) {
+            const event: NamespaceSwitchedAccountEvent = {
+              type: 'namespace_account_switched',
+              provider: namespace.info.providerId,
+              namespace: namespace.info.namespaceId,
+              previousAccounts: currentAccounts,
+              accounts: value as string[],
+            };
+
+            get().namespaces.events.push(event);
+          }
+        }
+      }
+    } else if (key === 'network') {
+      const currentNetwork = get().namespaces.list[id].data.network;
+
+      const event: NamespaceSwitchedNetworkEvent = {
+        type: 'namespace_network_switched',
+        provider: namespace.info.providerId,
+        namespace: namespace.info.namespaceId,
+        network: value as string,
+        previousNetwork: currentNetwork,
+      };
+
+      get().namespaces.events.push(event);
+    }
   },
 });
 

--- a/wallets/core/src/hub/store/providers.ts
+++ b/wallets/core/src/hub/store/providers.ts
@@ -4,6 +4,7 @@ import type { StateCreator } from 'zustand';
 
 import { produce } from 'immer';
 
+import { ConsumableEvents, type ProviderDetectedEvent } from './events.js';
 import { guessProviderStateSelector, type State } from './mod.js';
 
 type Browsers = 'firefox' | 'chrome' | 'edge' | 'brave' | 'homepage';
@@ -25,19 +26,26 @@ interface ProviderData {
   installed: boolean;
 }
 
+interface ProviderItem {
+  config: ProviderConfig;
+  data: ProviderData;
+  error: unknown;
+}
+
 type ProviderState = {
-  list: Record<
-    string,
-    {
-      config: ProviderConfig;
-      data: ProviderData;
-      error: unknown;
-    }
-  >;
+  events: ConsumableEvents;
+  list: Record<string, ProviderItem>;
 };
 interface ProviderActions {
   addProvider: (id: string, config: ProviderConfig) => void;
   updateStatus: <K extends keyof ProviderData>(
+    id: string,
+    key: K,
+    value: ProviderData[K]
+  ) => void;
+
+  _produceEventsWhenUpdatingStatus: <K extends keyof ProviderData>(
+    provider: ProviderItem,
     id: string,
     key: K,
     value: ProviderData[K]
@@ -56,6 +64,8 @@ export type ProviderStore = ProviderState & ProviderActions & ProviderSelectors;
 type ProvidersStateCreator = StateCreator<State, [], [], ProviderStore>;
 
 const providersStore: ProvidersStateCreator = (set, get) => ({
+  events: new ConsumableEvents(),
+
   list: {},
   addProvider: (id, config) => {
     const item = {
@@ -73,9 +83,12 @@ const providersStore: ProvidersStateCreator = (set, get) => ({
     );
   },
   updateStatus: (id, key, value) => {
-    if (!get().providers.list[id]) {
+    const provider = get().providers.list[id];
+    if (!provider) {
       throw new Error(`No namespace namespace with '${id}' found.`);
     }
+
+    get().providers._produceEventsWhenUpdatingStatus(provider, id, key, value);
 
     set(
       produce((state: State) => {
@@ -85,6 +98,17 @@ const providersStore: ProvidersStateCreator = (set, get) => ({
   },
   guessNamespacesState: (providerId: string): InternalProviderState => {
     return guessProviderStateSelector(get(), providerId);
+  },
+
+  _produceEventsWhenUpdatingStatus: (_provider, id, key, _value) => {
+    if (key === 'installed') {
+      const event: ProviderDetectedEvent = {
+        type: 'provider_detected',
+        provider: id,
+      };
+
+      get().providers.events.push(event);
+    }
   },
 });
 

--- a/wallets/core/src/hub/store/store.test.ts
+++ b/wallets/core/src/hub/store/store.test.ts
@@ -1,4 +1,4 @@
-import type { Store } from './store.js';
+import type { Store } from './mod.js';
 
 import { beforeEach, describe, expect, test } from 'vitest';
 

--- a/wallets/core/src/hub/store/store.ts
+++ b/wallets/core/src/hub/store/store.ts
@@ -2,6 +2,7 @@ import type { StoreApi } from 'zustand/vanilla';
 
 import { createStore as createZustandStore } from 'zustand/vanilla';
 
+import { extend, type Store } from './extend.js';
 import { hubStore, type HubStore } from './hub.js';
 import { namespacesStore, type NamespaceStore } from './namespaces.js';
 import { providersStore, type ProviderStore } from './providers.js';
@@ -14,13 +15,16 @@ export interface State {
   namespaces: NamespaceStore;
 }
 
-export type Store = StoreApi<State>;
+export type RawStore = StoreApi<State>;
+
 export const createStore = (): Store => {
-  return createZustandStore<State>((...api) => {
+  const store = createZustandStore<State>((...api) => {
     return {
       hub: hubStore(...api),
       providers: providersStore(...api),
       namespaces: namespacesStore(...api),
     };
   });
+
+  return extend(store);
 };

--- a/wallets/core/src/legacy/types.ts
+++ b/wallets/core/src/legacy/types.ts
@@ -65,6 +65,9 @@ export enum Networks {
   Unknown = 'Unkown',
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type InstanceType = any;
+
 export type NamespaceData = {
   namespace: Namespace;
   derivationPath?: string;
@@ -127,10 +130,10 @@ export type State = {
 export type ConnectResult = {
   accounts: string[] | null;
   network: Network | null;
-  provider: any;
+  provider: InstanceType;
 };
 
-export type Providers = { [type in WalletType]?: any };
+export type Providers = { [type in WalletType]?: InstanceType };
 
 export enum Events {
   CONNECTED = 'connected',
@@ -139,6 +142,8 @@ export enum Events {
   INSTALLED = 'installed',
   ACCOUNTS = 'accounts',
   NETWORK = 'network',
+  // Hub only events
+  NAMESPACE_DISCONNECTED = 'namespace_disconnected',
 }
 
 export type ProviderConnectResult = {
@@ -148,7 +153,7 @@ export type ProviderConnectResult = {
 
 export type GetInstanceOptions = {
   network?: Network;
-  currentProvider: any;
+  currentProvider: InstanceType;
   meta: BlockchainMeta[];
   getState: () => WalletState;
   /**
@@ -162,29 +167,31 @@ export type GetInstanceOptions = {
 };
 
 export type GetInstance =
-  | (() => any)
-  | ((options: GetInstanceOptions) => Promise<any>);
+  | (() => InstanceType)
+  | ((options: GetInstanceOptions) => Promise<InstanceType>);
 
 export type TryGetInstance =
-  | (() => any)
-  | ((options: Pick<GetInstanceOptions, 'force' | 'network'>) => Promise<any>);
+  | (() => InstanceType)
+  | ((
+      options: Pick<GetInstanceOptions, 'force' | 'network'>
+    ) => Promise<InstanceType>);
 
 export type Connect = (options: {
-  instance: any;
+  instance: InstanceType;
   network?: Network;
   meta: BlockchainMeta[];
   namespaces?: NamespaceData[];
 }) => Promise<ProviderConnectResult | ProviderConnectResult[]>;
 
 export type Disconnect = (options: {
-  instance: any;
+  instance: InstanceType;
   destroyInstance: () => void;
 }) => Promise<void>;
 
 type CleanupSubscribe = () => void;
 
 export type Subscribe = (options: {
-  instance: any;
+  instance: InstanceType;
   state: WalletState;
   meta: BlockchainMeta[];
   updateChainId: (chainId: string) => void;
@@ -194,7 +201,7 @@ export type Subscribe = (options: {
 }) => CleanupSubscribe | void;
 
 export type SwitchNetwork = (options: {
-  instance: any;
+  instance: InstanceType;
   network: Network;
   meta: BlockchainMeta[];
   newInstance?: TryGetInstance;
@@ -203,7 +210,7 @@ export type SwitchNetwork = (options: {
 }) => Promise<void>;
 
 export type Suggest = (options: {
-  instance: any;
+  instance: InstanceType;
   network: Network;
   meta: BlockchainMeta[];
 }) => Promise<void>;
@@ -211,11 +218,11 @@ export type Suggest = (options: {
 export type CanSwitchNetwork = (options: {
   network: Network;
   meta: BlockchainMeta[];
-  provider: any;
+  provider: InstanceType;
 }) => boolean;
 
 export type CanEagerConnect = (options: {
-  instance: any;
+  instance: InstanceType;
   meta: BlockchainMeta[];
 }) => Promise<boolean>;
 
@@ -227,7 +234,7 @@ export type EagerConnectResult<I = unknown> = {
 
 export interface WalletActions {
   connect: Connect;
-  getInstance: any;
+  getInstance: InstanceType;
   disconnect?: Disconnect;
   subscribe?: Subscribe;
   // unsubscribe, // coupled to subscribe.
@@ -235,7 +242,7 @@ export interface WalletActions {
   // Optional, but should be provided at the same time.
   suggest?: Suggest;
   switchNetwork?: SwitchNetwork;
-  getSigners: (provider: any) => Promise<SignerFactory>;
+  getSigners: (provider: InstanceType) => Promise<SignerFactory>;
   canSwitchNetworkTo?: CanSwitchNetwork;
   canEagerConnect?: CanEagerConnect;
   getWalletInfo(allBlockChains: BlockchainMeta[]): WalletInfo;

--- a/wallets/core/src/namespaces/evm/builders.ts
+++ b/wallets/core/src/namespaces/evm/builders.ts
@@ -1,10 +1,14 @@
 import type { EvmActions } from './types.js';
 
 import { ActionBuilder } from '../../mod.js';
-import { intoConnectionFinished } from '../common/after.js';
-import { connectAndUpdateStateForMultiNetworks } from '../common/and.js';
+import {
+  connectAndUpdateStateForMultiNetworks,
+  intoConnecting,
+  intoConnectionFinished,
+} from '../common/mod.js';
 
 export const connect = () =>
   new ActionBuilder<EvmActions, 'connect'>('connect')
     .and(connectAndUpdateStateForMultiNetworks)
+    .before(intoConnecting)
     .after(intoConnectionFinished);

--- a/wallets/core/src/namespaces/solana/builders.ts
+++ b/wallets/core/src/namespaces/solana/builders.ts
@@ -1,10 +1,14 @@
 import type { SolanaActions } from './types.js';
 
 import { ActionBuilder } from '../../mod.js';
-import { intoConnectionFinished } from '../common/after.js';
-import { connectAndUpdateStateForSingleNetwork } from '../common/and.js';
+import {
+  connectAndUpdateStateForSingleNetwork,
+  intoConnecting,
+  intoConnectionFinished,
+} from '../common/mod.js';
 
 export const connect = () =>
   new ActionBuilder<SolanaActions, 'connect'>('connect')
     .and(connectAndUpdateStateForSingleNetwork)
+    .before(intoConnecting)
     .after(intoConnectionFinished);

--- a/wallets/react/src/legacy/types.ts
+++ b/wallets/react/src/legacy/types.ts
@@ -11,6 +11,11 @@ import type {
 import type { BlockchainMeta, SignerFactory } from 'rango-types';
 import type { PropsWithChildren } from 'react';
 
+import { LegacyEvents as Events } from '@rango-dev/wallets-core/legacy';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type InstanceType = any;
+
 export type State = {
   [key: string]: WalletState | undefined;
 };
@@ -18,10 +23,10 @@ export type State = {
 export type ConnectResult = {
   accounts: string[] | null;
   network: Network | null;
-  provider: any;
+  provider: InstanceType;
 };
 
-export type Providers = { [type in WalletType]?: any };
+export type Providers = { [type in WalletType]?: InstanceType };
 
 export type ExtendedWalletInfo = WalletInfo & {
   properties?: ProviderInfo['properties'];
@@ -34,6 +39,7 @@ export type ProviderContext = {
     namespaces?: LegacyNamespaceInputForConnect[]
   ): Promise<ConnectResult[]>;
   disconnect(type: WalletType): Promise<void>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   disconnectAll(): Promise<PromiseSettledResult<any>[]>;
   state(type: WalletType): WalletState;
   canSwitchNetworkTo(type: WalletType, network: Network): boolean;
@@ -60,14 +66,7 @@ export type ProviderProps = PropsWithChildren<{
   };
 }>;
 
-export enum Events {
-  CONNECTED = 'connected',
-  CONNECTING = 'connecting',
-  REACHABLE = 'reachable',
-  INSTALLED = 'installed',
-  ACCOUNTS = 'accounts',
-  NETWORK = 'network',
-}
+export { Events };
 
 export type ProviderConnectResult = {
   accounts: string[];
@@ -76,7 +75,7 @@ export type ProviderConnectResult = {
 
 export type GetInstanceOptions = {
   network?: Network;
-  currentProvider: any;
+  currentProvider: InstanceType;
   meta: BlockchainMeta[];
   getState: () => WalletState;
   /**
@@ -90,26 +89,28 @@ export type GetInstanceOptions = {
 };
 
 export type GetInstance =
-  | (() => any)
-  | ((options: GetInstanceOptions) => Promise<any>);
+  | (() => InstanceType)
+  | ((options: GetInstanceOptions) => Promise<InstanceType>);
 export type TryGetInstance =
-  | (() => any)
-  | ((options: Pick<GetInstanceOptions, 'force' | 'network'>) => Promise<any>);
+  | (() => InstanceType)
+  | ((
+      options: Pick<GetInstanceOptions, 'force' | 'network'>
+    ) => Promise<InstanceType>);
 export type Connect = (options: {
-  instance: any;
+  instance: InstanceType;
   network?: Network;
   meta: BlockchainMeta[];
 }) => Promise<ProviderConnectResult | ProviderConnectResult[]>;
 
 export type Disconnect = (options: {
-  instance: any;
+  instance: InstanceType;
   destroyInstance: () => void;
 }) => Promise<void>;
 
 type CleanupSubscribe = () => void;
 
 export type Subscribe = (options: {
-  instance: any;
+  instance: InstanceType;
   state: WalletState;
   meta: BlockchainMeta[];
   updateChainId: (chainId: string) => void;
@@ -119,7 +120,7 @@ export type Subscribe = (options: {
 }) => CleanupSubscribe | void;
 
 export type SwitchNetwork = (options: {
-  instance: any;
+  instance: InstanceType;
   network: Network;
   meta: BlockchainMeta[];
   newInstance?: TryGetInstance;
@@ -128,7 +129,7 @@ export type SwitchNetwork = (options: {
 }) => Promise<void>;
 
 export type Suggest = (options: {
-  instance: any;
+  instance: InstanceType;
   network: Network;
   meta: BlockchainMeta[];
 }) => Promise<void>;
@@ -136,17 +137,17 @@ export type Suggest = (options: {
 export type CanSwitchNetwork = (options: {
   network: Network;
   meta: BlockchainMeta[];
-  provider: any;
+  provider: InstanceType;
 }) => boolean;
 
 export type CanEagerConnect = (options: {
-  instance: any;
+  instance: InstanceType;
   meta: BlockchainMeta[];
 }) => Promise<boolean>;
 
 export interface WalletActions {
   connect: Connect;
-  getInstance: any;
+  getInstance: InstanceType;
   disconnect?: Disconnect;
   subscribe?: Subscribe;
   // unsubscribe, // coupled to subscribe.
@@ -154,7 +155,7 @@ export interface WalletActions {
   // Optional, but should be provided at the same time.
   suggest?: Suggest;
   switchNetwork?: SwitchNetwork;
-  getSigners: (provider: any) => Promise<SignerFactory>;
+  getSigners: (provider: InstanceType) => Promise<SignerFactory>;
   canSwitchNetworkTo?: CanSwitchNetwork;
   canEagerConnect?: CanEagerConnect;
   getWalletInfo(allBlockChains: BlockchainMeta[]): WalletInfo;

--- a/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
@@ -63,7 +63,7 @@ export function WalletList(props: PropTypes) {
     try {
       await suggestAndConnect(wallet.walletType, wallet.chain);
       setAddingExperimentalChainStatus('completed');
-    } catch (e) {
+    } catch {
       setAddingExperimentalChainStatus('rejected');
     }
   };


### PR DESCRIPTION
# Summary

Introducing store events to fix switching accounts issues.

We've been used an observer on store in `wallets-react` to compare two states and firing legacy events. In this PR, I tried to add the event system to Hub's store. Besides the legacy events, we've have new ones which mapped or the proper logic added to the flow.




Fixes RF-2252


# How did you test this change?

Just run the widget then try to switch account on your Phantom wallet. You can check some legacy wallets as well.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
