### PR TITLE
feat: add base chain to phantom evm supported chains

### DIFF
--- a/wallets/core/src/legacy/types.ts
+++ b/wallets/core/src/legacy/types.ts
@@ -60,7 +60,7 @@ export enum Networks {
   UMEE = 'UMEE',
   STARKNET = 'STARKNET',
   TON = 'TON',
-
+  BASE = 'BASE',
   // Using instead of null
   Unknown = 'Unkown',
 }

--- a/wallets/provider-phantom/src/constants.ts
+++ b/wallets/provider-phantom/src/constants.ts
@@ -4,6 +4,7 @@ import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 export const EVM_SUPPORTED_CHAINS = [
   LegacyNetworks.ETHEREUM,
   LegacyNetworks.POLYGON,
+  LegacyNetworks.BASE,
 ];
 
 export const WALLET_ID = 'phantom';


### PR DESCRIPTION
# Summary

Phantom Wallet has added support for the Base chain, which means we can now include Base in the list of supported chains.
