### PR TITLE
fix: update balance only if account is still connected

### DIFF
--- a/widget/embedded/src/store/slices/wallets.ts
+++ b/widget/embedded/src/store/slices/wallets.ts
@@ -485,6 +485,21 @@ export const createWalletsSlice: StateCreator<
           chains: [wallet.blockChain],
         });
 
+        /*
+         * Check if after fetching balance for an account, the account still exists.
+         * (It might get disconnected while fetching balances is pending)
+         */
+        if (
+          !get().connectedWallets.find(
+            (connectedWallet) =>
+              connectedWallet.walletType === walletType &&
+              connectedWallet.address === wallet.address &&
+              connectedWallet.chain === wallet.blockChain
+          )
+        ) {
+          return;
+        }
+
         const balancesForWallet = createBalanceStateForNewAccount(wallet, get);
 
         nextAggregatedBalances = updateAggregatedBalanceStateForNewAccount(


### PR DESCRIPTION
# Summary

Currently, if we connect a wallet, balances for the addresses related to the wallet will be fetched and after being resolved, balances in store will get updated. The problem is that if we disconnect the wallet while the request for fetching balances is in pending state, balances will get updated after request being resolved anyway.
In this PR, we are making sure  


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
