### PR TITLE
chore: update balance key separator

### DIFF
--- a/widget/embedded/src/constants/wallets.ts
+++ b/widget/embedded/src/constants/wallets.ts
@@ -1,5 +1,5 @@
 import { WalletTypes } from '@rango-dev/wallets-shared';
 
-export const BALANCE_SEPARATOR = '$$';
+export const BALANCE_SEPARATOR = '~';
 
 export const EXCLUDED_WALLETS = [WalletTypes.LEAP];


### PR DESCRIPTION
# Summary

Currently, balance key separator is equal to `$$`. It has conflict with some tokens like `GEO$`. 
In this PR it is changed to `~` considering that there is no token in meta containing this character.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
