### PR TITLE
fix: fix incorrect default install link

### DIFF
--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -295,7 +295,7 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
       Object.keys(info.extensions).forEach((k) => {
         const key = k as ExtensionLink;
 
-        if (info.extensions[key] === 'homepage') {
+        if (key === 'homepage') {
           installLink.DEFAULT = info.extensions[key] || '';
         }
 


### PR DESCRIPTION
# Summary

Fixed incorrect default install link for wallets.

# How did you test this change?

It can be tested by checking install link for Phantom wallet in Firefox browser.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
