### PR TITLE
fix: fix balance not updating properly after transaction

### DIFF
--- a/widget/embedded/src/hooks/useSubscribeToWidgetEvents/useSubscribeToWidgetEvents.ts
+++ b/widget/embedded/src/hooks/useSubscribeToWidgetEvents/useSubscribeToWidgetEvents.ts
@@ -27,20 +27,30 @@ export function useSubscribeToWidgetEvents() {
         event.type === StepEventType.SUCCEEDED;
 
       if (shouldRefetchBalance) {
+        const fromWallet = route.wallets[step?.fromBlockchain];
         const fromAccount = connectedWallets.find(
-          (account) => account.chain === step?.fromBlockchain
+          (connectedWallet) =>
+            connectedWallet.address?.toLocaleLowerCase() ===
+              fromWallet.address?.toLocaleLowerCase() &&
+            connectedWallet.walletType === fromWallet.walletType &&
+            connectedWallet.chain === step?.fromBlockchain
         );
-        const toAccount =
-          step?.fromBlockchain !== step?.toBlockchain &&
-          connectedWallets.find(
-            (wallet) => wallet.chain === step?.toBlockchain
-          );
-
         if (fromAccount) {
           void fetchBalances([fromAccount]);
         }
-        if (toAccount) {
-          void fetchBalances([toAccount]);
+
+        if (step?.fromBlockchain !== step?.toBlockchain) {
+          const toWallet = route.wallets[step?.toBlockchain];
+          const toAccount = connectedWallets.find(
+            (connectedWallet) =>
+              connectedWallet.address?.toLocaleLowerCase() ===
+                toWallet.address?.toLocaleLowerCase() &&
+              connectedWallet.walletType === toWallet.walletType &&
+              connectedWallet.chain === step?.toBlockchain
+          );
+          if (toAccount) {
+            void fetchBalances([toAccount]);
+          }
         }
       }
 


### PR DESCRIPTION
# Summary

The issue with balance updates not functioning correctly was due to a scenario where two wallets sharing the same blockchain were connected as either the 'from' or 'to' account in a transaction. This problem has been resolved by implementing a solution that involves identifying the correct wallet for updating the balance. This is achieved by not only considering the blockchain of the account but also evaluating the address and type of wallet associated with the account.

Fixes # 2291


# How did you test this change?

It can be tested by connecting Metamask and Phantom on EVM and executing transaction with Phantom and observing that balances get updated properly.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
