### PR TITLE
Chore/upgrade provider station manually

### DIFF
--- a/wallets/provider-station/package.json
+++ b/wallets/provider-station/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rango-dev/provider-station",
-  "version": "0.39.1-next.13",
+  "version": "0.40.1-next.1",
   "license": "MIT",
   "type": "module",
   "source": "./src/index.ts",


### PR DESCRIPTION
# Summary

Upgraded version of `@rango-dev/provider-station` manually because it does not exist in `provider-all` dependencies.



# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
