### PR TITLE
fix: fix incorrect input amount on max button click

### DIFF
--- a/widget/embedded/src/containers/Inputs/Inputs.tsx
+++ b/widget/embedded/src/containers/Inputs/Inputs.tsx
@@ -117,7 +117,7 @@ export function Inputs(props: PropTypes) {
 
             // if a token hasn't any value, we will reset the input by setting an empty string.
             const nextInputAmount = !!fromTokenBalance?.amount
-              ? tokenBalanceReal
+              ? tokenBalanceReal.split(',').join('')
               : '';
 
             setInputAmount(nextInputAmount);


### PR DESCRIPTION
# Summary

There was an issue happening on clicking on max button with balance of more than 1000 units which was causing an empty input amount and Nan for value of input amount.
It is fixed the way it was working before [this](https://github.com/rango-exchange/rango-client/commit/a14bdf9619e448bc4568d6b758ca86d2359e1740#diff-9edb2091bb12bc14426dc63306f12e3356cef0b428425161bfc44f6a4f079275L110) commit change its behavior.


# How did you test this change?

You can test this change by clicking on max button with more that 1000 units balance for a token and observe that it sets the input amount properly.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
