### PR TITLE
fix: fix retry swap on connect wallet

### DIFF
--- a/queue-manager/rango-preset/src/index.ts
+++ b/queue-manager/rango-preset/src/index.ts
@@ -26,6 +26,7 @@ export type {
   StepCheckStatusEvent,
   StepApprovalTxSucceededEvent,
   StepOutputRevealedEvent,
+  LastConnectedWallet,
 } from './types';
 export {
   WidgetEvents,

--- a/queue-manager/rango-preset/src/types.ts
+++ b/queue-manager/rango-preset/src/types.ts
@@ -81,8 +81,14 @@ export interface SwapQueueContext extends QueueContext {
   resetClaimedBy?: () => void;
 }
 
+export type LastConnectedWallet = {
+  walletType: string;
+  network?: string;
+  accounts?: string[];
+};
+
 export interface UseQueueManagerParams {
-  lastConnectedWallet: string;
+  lastConnectedWallet: LastConnectedWallet | null;
   disconnectedWallet: WalletType | undefined;
   clearDisconnectedWallet: () => void;
   evmChains: EvmBlockchainMeta[];

--- a/wallets/shared/src/helpers.ts
+++ b/wallets/shared/src/helpers.ts
@@ -39,6 +39,7 @@ export function deepCopy(obj: any): any {
 
   // Handle Object
   if (obj instanceof Object) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     copy = {} as any;
     for (const attr in obj) {
       if (Object.prototype.hasOwnProperty.call(obj, attr)) {
@@ -52,6 +53,7 @@ export function deepCopy(obj: any): any {
 }
 
 export async function switchOrAddNetworkForMetamaskCompatibleWallets(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   instance: any,
   network: Network,
   evmNetworksChainInfo: EvmNetworksChainInfo
@@ -64,7 +66,6 @@ export async function switchOrAddNetworkForMetamaskCompatibleWallets(
       params: [{ chainId: targetChain?.chainId }],
     });
   } catch (switchError) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     /*
      * @ts-ignore
      * To resolve this error: Catch clause variable type annotation must be any or unknown if specified
@@ -90,7 +91,9 @@ export async function switchOrAddNetworkForMetamaskCompatibleWallets(
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function timeout<T = any>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   forPromise: Promise<any>,
   time: number
 ): Promise<T> {
@@ -171,6 +174,7 @@ export function sortWalletsBasedOnState(wallets: Wallet[]): Wallet[] {
 
 function isBrave() {
   let isBrave = false;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const nav: any = navigator;
   if (nav.brave && nav.brave.isBrave) {
     nav.brave.isBrave().then((res: boolean) => {
@@ -204,27 +208,4 @@ export function detectMobileScreens(): boolean {
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
     navigator.userAgent
   );
-}
-
-/**
- * Sample inputs are:
- *  - "metamask-ETH"
- *  - "metamask-BSC-BSC:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
- *  - "token-pocket-BSC-BSC:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
- * Returns "wallet and network" separately, even if the wallet is dashed inside.
- *
- */
-
-export function splitWalletNetwork(input: string): string[] {
-  const removedAddressInput = input?.split(':')[0] || '';
-  const splittedInput = removedAddressInput.split('-');
-  const network = splittedInput[splittedInput.length - 1];
-  const walletNetwork = splittedInput.slice(0, -1);
-
-  if (walletNetwork[walletNetwork.length - 1] === network) {
-    walletNetwork.pop();
-  }
-  const wallet = walletNetwork.join('-');
-
-  return [wallet, network];
 }

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -1,5 +1,6 @@
 import type {
-  OnWalletConnectionChange,
+  OnWalletConnectHandler,
+  OnWalletDisconnectHandler,
   PropTypes,
   WidgetContextInterface,
 } from './Wallets.types';
@@ -45,8 +46,8 @@ function Main(props: PropsWithChildren<PropTypes>) {
         ?.walletConnectListedDesktopWalletLink,
   };
   const { providers } = useWalletProviders(config.wallets, walletOptions);
-  const onConnectWalletHandler = useRef<OnWalletConnectionChange>();
-  const onDisconnectWalletHandler = useRef<OnWalletConnectionChange>();
+  const onConnectWalletHandler = useRef<OnWalletConnectHandler>();
+  const onDisconnectWalletHandler = useRef<OnWalletDisconnectHandler>();
   const { handler: handleEvent } = useUpdates({
     onConnectWalletHandler,
     onDisconnectWalletHandler,
@@ -71,10 +72,10 @@ function Main(props: PropsWithChildren<PropTypes>) {
 
   const handlers = useMemo(
     () => ({
-      onConnectWallet: (handler: OnWalletConnectionChange) => {
+      onConnectWallet: (handler: OnWalletConnectHandler) => {
         onConnectWalletHandler.current = handler;
       },
-      onDisconnectWallet: (handler: OnWalletConnectionChange) => {
+      onDisconnectWallet: (handler: OnWalletDisconnectHandler) => {
         onDisconnectWalletHandler.current = handler;
       },
     }),

--- a/widget/embedded/src/containers/Wallets/Wallets.types.ts
+++ b/widget/embedded/src/containers/Wallets/Wallets.types.ts
@@ -1,23 +1,25 @@
 import type { WidgetConfig } from '../../types';
+import type { LastConnectedWallet } from '@rango-dev/queue-manager-rango-preset';
 import type {
   LegacyEventHandler as EventHandler,
   LegacyEvents,
 } from '@rango-dev/wallets-core/legacy';
 
-export type OnWalletConnectionChange = (key: string) => void;
+export type OnWalletConnectHandler = (wallet: LastConnectedWallet) => void;
+export type OnWalletDisconnectHandler = (walletType: string) => void;
 export interface WidgetContextInterface {
   /**
    * A wallet connection handler, utilized within the wallet provider,
    * is linked to the useBootstrap hook for synchronizing the state of the last connected wallet.
    * It's important not to override this handler in other locations.
    */
-  onConnectWallet(handler: OnWalletConnectionChange): void;
+  onConnectWallet(handler: OnWalletConnectHandler): void;
   /**
    * A wallet disconnection handler, utilized within the wallet provider,
    * is linked to the useBootstrap hook for synchronizing the state of the last disconnected wallet.
    * It's important not to override this handler in other locations.
    */
-  onDisconnectWallet(handler: OnWalletConnectionChange): void;
+  onDisconnectWallet(handler: OnWalletDisconnectHandler): void;
 }
 
 type EventHandlerParams = Parameters<EventHandler>;


### PR DESCRIPTION
# Summary

There was a problem in retrying on swaps when a wallet related to a swap gets connected. The problem mostly was happening on Solana transactions. 
In this PR, tried to improve the model for storing lastConnectedWallet and also changed the `retryOn` function to execute even if `network` of `lastConnectedWallet` is `null` (happens on Solana wallets).
Also, I've added a "disconnectAll" button in "ConfirmSwapPage" in the second commit to help testing the retry functionality. This change should be reverted.

Fixes # 2134


# How did you test this change?

Tested by disconnecting wallet before confirming the transaction and observing 


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
