### PR TITLE
feat: add sui namespace to wallets-core

### DIFF
--- a/wallets/core/namespaces/sui/package.json
+++ b/wallets/core/namespaces/sui/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rango-dev/wallets-core/namespaces/sui",
+  "type": "module",
+  "main": "../../dist/namespaces/sui/mod.js",
+  "module": "../../dist/namespaces/sui/mod.js",
+  "types": "../../dist/namespaces/sui/mod.d.ts",
+  "sideEffects": false
+}

--- a/wallets/core/package.json
+++ b/wallets/core/package.json
@@ -34,6 +34,10 @@
     "./namespaces/solana": {
       "types": "./dist/namespaces/solana/mod.d.ts",
       "default": "./dist/namespaces/solana/mod.js"
+    },
+    "./namespaces/sui": {
+      "types": "./dist/namespaces/sui/mod.d.ts",
+      "default": "./dist/namespaces/sui/mod.js"
     }
   },
   "files": [
@@ -42,7 +46,7 @@
     "legacy"
   ],
   "scripts": {
-    "build": "node ../../scripts/build/command.mjs --path wallets/core --inputs src/mod.ts,src/utils/mod.ts,src/legacy/mod.ts,src/hub/store/mod.ts,src/namespaces/evm/mod.ts,src/namespaces/solana/mod.ts,src/namespaces/common/mod.ts",
+    "build": "node ../../scripts/build/command.mjs --path wallets/core --inputs src/mod.ts,src/utils/mod.ts,src/legacy/mod.ts,src/hub/store/mod.ts,src/namespaces/evm/mod.ts,src/namespaces/solana/mod.ts,src/namespaces/sui/mod.ts,src/namespaces/common/mod.ts",
     "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
     "clean": "rimraf dist",
     "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",
@@ -51,6 +55,7 @@
     "coverage": "vitest run --coverage"
   },
   "peerDependencies": {
+    "@mysten/wallet-standard": "^0.13.26",
     "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0"

--- a/wallets/core/src/hub/provider/types.ts
+++ b/wallets/core/src/hub/provider/types.ts
@@ -4,6 +4,7 @@ import type { LegacyState } from '../../legacy/mod.js';
 import type { CosmosActions } from '../../namespaces/cosmos/mod.js';
 import type { EvmActions } from '../../namespaces/evm/mod.js';
 import type { SolanaActions } from '../../namespaces/solana/mod.js';
+import type { SuiActions } from '../../namespaces/sui/mod.js';
 import type { AnyFunction, FunctionWithContext } from '../../types/actions.js';
 import type { Prettify } from '../../types/utils.js';
 
@@ -25,6 +26,7 @@ export interface CommonNamespaces {
   evm: EvmActions;
   solana: SolanaActions;
   cosmos: CosmosActions;
+  sui: SuiActions;
 }
 
 export type CommonNamespaceKeys = Prettify<keyof CommonNamespaces>;

--- a/wallets/core/src/legacy/types.ts
+++ b/wallets/core/src/legacy/types.ts
@@ -61,6 +61,7 @@ export enum Networks {
   STARKNET = 'STARKNET',
   TON = 'TON',
   BASE = 'BASE',
+  SUI = 'SUI',
   // Using instead of null
   Unknown = 'Unkown',
 }

--- a/wallets/core/src/namespaces/common/types.ts
+++ b/wallets/core/src/namespaces/common/types.ts
@@ -9,9 +9,9 @@ type RangoNamespace =
   | 'UTXO'
   | 'Starknet'
   | 'Tron'
-  | 'Ton';
+  | 'Ton'
+  | 'Sui';
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 export type Namespace = RangoNamespace | (string & {});
 
 export interface CommonActions {

--- a/wallets/core/src/namespaces/sui/actions.ts
+++ b/wallets/core/src/namespaces/sui/actions.ts
@@ -1,0 +1,59 @@
+import type { SuiActions } from './types.js';
+import type { Subscriber } from '../../hub/namespaces/mod.js';
+import type { SubscriberCleanUp } from '../../hub/namespaces/types.js';
+import type { StandardEventsChangeProperties } from '@mysten/wallet-standard';
+
+import { AccountId } from 'caip';
+
+import { CAIP_NAMESPACE, CAIP_SUI_CHAIN_ID } from './constants.js';
+import { getInstanceOrThrow } from './mod.js';
+
+interface ChangeAccountSubscriberParams {
+  name: string;
+}
+
+export function changeAccountSubscriber(
+  params: ChangeAccountSubscriberParams
+): [Subscriber<SuiActions>, SubscriberCleanUp<SuiActions>] {
+  let eventCallback: (event: StandardEventsChangeProperties) => void;
+
+  // subscriber can be passed to `or`, it will get the error and should rethrow error to pass the error to next `or` or throw error.
+  return [
+    (context, err) => {
+      const wallet = getInstanceOrThrow(params.name);
+
+      const [, setState] = context.state();
+      eventCallback = (event) => {
+        if (event.accounts) {
+          if (event.accounts.length === 0) {
+            context.action('disconnect');
+          } else {
+            setState(
+              'accounts',
+              event.accounts.map((account) => {
+                return AccountId.format({
+                  address: account.address,
+                  chainId: {
+                    namespace: CAIP_NAMESPACE,
+                    reference: CAIP_SUI_CHAIN_ID,
+                  },
+                });
+              })
+            );
+          }
+        }
+      };
+      wallet.features['standard:events'].on('change', eventCallback);
+
+      if (err instanceof Error) {
+        throw err;
+      }
+    },
+    (_context, err) => {
+      // TODO: Wallet Standard doesn't have a off method
+      if (err instanceof Error) {
+        throw err;
+      }
+    },
+  ];
+}

--- a/wallets/core/src/namespaces/sui/builders.ts
+++ b/wallets/core/src/namespaces/sui/builders.ts
@@ -1,0 +1,41 @@
+import type { SuiActions } from './types.js';
+
+import { ActionBuilder } from '../../mod.js';
+import { CAIP } from '../../utils/mod.js';
+import {
+  type CaipAccount,
+  connectAndUpdateStateForSingleNetwork,
+  intoConnecting,
+  intoConnectionFinished,
+} from '../common/mod.js';
+
+import { CAIP_NAMESPACE, CAIP_SUI_CHAIN_ID } from './constants.js';
+import { getInstanceOrThrow } from './utils.js';
+
+interface ConnectParams {
+  name: string;
+}
+
+export const connect = (params: ConnectParams) =>
+  new ActionBuilder<SuiActions, 'connect'>('connect')
+    .action(async function () {
+      const wallet = getInstanceOrThrow(params.name);
+      const features = wallet.features;
+
+      const result = await features['standard:connect'].connect();
+
+      const accounts = result.accounts.map((account) => {
+        return CAIP.AccountId.format({
+          address: account.address,
+          chainId: {
+            namespace: CAIP_NAMESPACE,
+            reference: CAIP_SUI_CHAIN_ID,
+          },
+        }) as CaipAccount;
+      });
+
+      return accounts;
+    })
+    .and(connectAndUpdateStateForSingleNetwork)
+    .before(intoConnecting)
+    .after(intoConnectionFinished);

--- a/wallets/core/src/namespaces/sui/constants.ts
+++ b/wallets/core/src/namespaces/sui/constants.ts
@@ -1,0 +1,8 @@
+/*
+ * TODO: I couldn't found sui in caip
+ * @see https://namespaces.chainagnostic.org/
+ */
+
+// if the value neeeds to be change make sure you will update mapCaipNamespaceToLegacyNetworkName as well
+export const CAIP_NAMESPACE = 'move';
+export const CAIP_SUI_CHAIN_ID = 'sui';

--- a/wallets/core/src/namespaces/sui/mod.ts
+++ b/wallets/core/src/namespaces/sui/mod.ts
@@ -1,0 +1,7 @@
+export type { ProviderAPI, SuiActions } from './types.js';
+
+export * as actions from './actions.js';
+export * as builders from './builders.js';
+export { getInstanceOrThrow } from './utils.js';
+
+export { CAIP_NAMESPACE, CAIP_SUI_CHAIN_ID } from './constants.js';

--- a/wallets/core/src/namespaces/sui/types.ts
+++ b/wallets/core/src/namespaces/sui/types.ts
@@ -1,0 +1,14 @@
+import type { Accounts } from '../../types/accounts.js';
+import type {
+  AutoImplementedActionsByRecommended,
+  CommonActions,
+} from '../common/types.js';
+
+export interface SuiActions
+  extends AutoImplementedActionsByRecommended,
+    CommonActions {
+  connect: () => Promise<Accounts>;
+}
+
+// eslint-disable-next-line
+export type ProviderAPI = Record<string, any>;

--- a/wallets/core/src/namespaces/sui/utils.ts
+++ b/wallets/core/src/namespaces/sui/utils.ts
@@ -1,0 +1,33 @@
+import type {
+  StandardConnectFeature,
+  StandardEventsFeature,
+  SuiFeatures,
+  WalletWithFeatures,
+} from '@mysten/wallet-standard';
+
+import { getWallets, SUI_MAINNET_CHAIN } from '@mysten/wallet-standard';
+
+// TODO: StandardFetures doesn't work, so we should add each feature separately
+type SuiWalletStandard = WalletWithFeatures<
+  StandardConnectFeature & StandardEventsFeature & SuiFeatures
+>;
+
+/**
+ * @param name each wallet has a name in WalletStandard. you should pass that value
+ */
+export function getInstanceOrThrow(name: string): SuiWalletStandard {
+  const wallet = getWallets()
+    .get()
+    .find(
+      (wallet) =>
+        wallet.name === name && wallet.chains.includes(SUI_MAINNET_CHAIN)
+    );
+
+  if (!wallet) {
+    throw new Error(
+      "We couldn't find the Sui instance on your wallet. It may be fixed by refreshing the page."
+    );
+  }
+
+  return wallet as SuiWalletStandard;
+}


### PR DESCRIPTION
# Summary

Adding standard methods to hub for sui.

`connect`, change account subscriber and get instance has been implemented by wallet-standard spec. which means all Sui wallet can use these (including Phantom)


# How did you test this change?
You can test on the [Phantom's PR](https://github.com/rango-exchange/rango-client/pull/1015). To be able to build, you need to link this [PR as well](https://github.com/rango-exchange/rango-types/pull/44).


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
