### PR TITLE
feat: adjust the number of blockchains in the token selector based on widget height changes

### DIFF
--- a/widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx
+++ b/widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers */
 import type { PropTypes } from './BlockchainsSection.types';
 
 import { i18n } from '@lingui/core';
@@ -12,20 +11,28 @@ import {
 } from '@rango-dev/ui';
 import React from 'react';
 
-import { BLOCKCHAIN_LIST_SIZE } from '../../constants/configs';
+import {
+  BLOCKCHAIN_LIST_SIZE,
+  BLOCKCHAIN_LIST_SIZE_COMPACT_MODE,
+} from '../../constants/configs';
 import { usePrepareBlockchainList } from '../../hooks/usePrepareBlockchainList';
 import { useAppStore } from '../../store/AppStore';
 import { useQuoteStore } from '../../store/quote';
+import { useUiStore } from '../../store/ui';
 import { getContainer } from '../../utils/common';
 
 import { Blockchains } from './BlockchainsSection.styles';
 
+const NUMBER_OF_LOADING_COMPACT_MODE = 6;
 const NUMBER_OF_LOADING = 12;
 
 export function BlockchainsSection(props: PropTypes) {
   const { blockchains, type, blockchain, onChange, onMoreClick } = props;
+  const { showCompactTokenSelector } = useUiStore();
   const blockchainsList = usePrepareBlockchainList(blockchains, {
-    limit: BLOCKCHAIN_LIST_SIZE,
+    limit: showCompactTokenSelector
+      ? BLOCKCHAIN_LIST_SIZE_COMPACT_MODE
+      : BLOCKCHAIN_LIST_SIZE,
     selected: blockchain?.name,
   });
 
@@ -41,16 +48,25 @@ export function BlockchainsSection(props: PropTypes) {
 
   return (
     <>
-      <Divider size={12} />
-      <Typography variant="label" size="large">
-        {i18n.t('Select Chain')}
-      </Typography>
+      {!showCompactTokenSelector && (
+        <>
+          <Divider size={12} />
+          <Typography variant="label" size="large">
+            {i18n.t('Select Chain')}
+          </Typography>
+        </>
+      )}
       <Divider size={12} />
       <Blockchains>
         {fetchStatus === 'loading' &&
-          Array.from(Array(NUMBER_OF_LOADING), (e) => (
-            <Skeleton key={e} variant="rounded" height={50} />
-          ))}
+          Array.from(
+            Array(
+              showCompactTokenSelector
+                ? NUMBER_OF_LOADING_COMPACT_MODE
+                : NUMBER_OF_LOADING
+            ),
+            (_, index) => <Skeleton key={index} variant="rounded" height={50} />
+          )}
         {fetchStatus === 'success' && (
           <>
             <BlockchainsChip

--- a/widget/embedded/src/components/Layout/Layout.constants.ts
+++ b/widget/embedded/src/components/Layout/Layout.constants.ts
@@ -1,3 +1,3 @@
 export const WIDGET_MAX_HEIGHT = 700;
 export const WIDGET_MIN_HEIGHT = 425;
-export const MAX_MOBILE_DEVICE_WIDTH = 640;
+export const COMPACT_TOKEN_SELECTOR_THRESHOLD = 640;

--- a/widget/embedded/src/components/Layout/Layout.tsx
+++ b/widget/embedded/src/components/Layout/Layout.tsx
@@ -22,7 +22,10 @@ import { ActivateTabModal } from '../common/ActivateTabModal';
 import { BackButton, CancelButton, WalletButton } from '../HeaderButtons';
 import { RefreshModal } from '../RefreshModal';
 
-import { WIDGET_MAX_HEIGHT } from './Layout.constants';
+import {
+  COMPACT_TOKEN_SELECTOR_THRESHOLD,
+  WIDGET_MAX_HEIGHT,
+} from './Layout.constants';
 import { onScrollContentAttachStatusToContainer } from './Layout.helpers';
 import { Container, Content, Footer, LayoutContainer } from './Layout.styles';
 
@@ -34,7 +37,7 @@ function Layout(props: PropsWithChildren<PropTypes>) {
   const {
     config: { features, theme },
   } = useAppStore();
-  const { watermark } = useUiStore();
+  const { watermark, setShowCompactTokenSelector } = useUiStore();
 
   const hasWatermark = watermark === 'FULL';
   const { activeTheme } = useTheme(theme || {});
@@ -116,10 +119,14 @@ function Layout(props: PropsWithChildren<PropTypes>) {
         containerRef.current.style.height = `${
           window.innerHeight - containerRef.current.offsetTop
         }px`;
-        return;
+      } else {
+        containerRef.current.style.height = `${WIDGET_MAX_HEIGHT}px`;
       }
 
-      containerRef.current.style.height = `${WIDGET_MAX_HEIGHT}px`;
+      setShowCompactTokenSelector(
+        parseFloat(containerRef.current.style.height) <
+          COMPACT_TOKEN_SELECTOR_THRESHOLD
+      );
     };
 
     handler();

--- a/widget/embedded/src/constants/configs.ts
+++ b/widget/embedded/src/constants/configs.ts
@@ -1,1 +1,2 @@
+export const BLOCKCHAIN_LIST_SIZE_COMPACT_MODE = 4;
 export const BLOCKCHAIN_LIST_SIZE = 10;

--- a/widget/embedded/src/store/ui.ts
+++ b/widget/embedded/src/store/ui.ts
@@ -13,6 +13,7 @@ interface UiState {
   showActivateTabModal: boolean;
   watermark: Watermark;
   showProfileBanner: boolean;
+  showCompactTokenSelector: boolean;
   activateCurrentTab: (
     setCurrentTabAsActive: () => void,
     hasRunningSwaps: boolean
@@ -20,6 +21,7 @@ interface UiState {
   setShowActivateTabModal: (flag: boolean) => void;
   setWatermark: (watermark: Watermark) => void;
   setShowProfileBanner: (showProfileBanner: boolean) => void;
+  setShowCompactTokenSelector: (showCompactTokenSelector: boolean) => void;
 }
 
 export const useUiStore = createSelectors(
@@ -30,6 +32,7 @@ export const useUiStore = createSelectors(
     watermark: 'NONE',
     showProfileBanner: false,
     fetchingApiConfig: false,
+    showCompactTokenSelector: false,
     activateCurrentTab: (setCurrentTabAsActive, hasRunningSwaps) => {
       const { showActivateTabModal } = get();
 
@@ -47,6 +50,9 @@ export const useUiStore = createSelectors(
     },
     setShowProfileBanner: (showProfileBanner) => {
       set({ showProfileBanner });
+    },
+    setShowCompactTokenSelector: (showCompactTokenSelector) => {
+      set({ showCompactTokenSelector });
     },
   }))
 );


### PR DESCRIPTION
# Summary

After deciding to make the widget height dynamic for mobile users based on their device viewport, we encountered an issue on the token selector page where the token list might appear too small, affecting the UX. To resolve this, I adjusted the number of blockchains in the blockchain section according to the page height changes.

# How did you test this change?

Decrease your browser width below 640px, go to the token selector page, and adjust the browser height.

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
