### PR TITLE
fix: avoid problematic routes for contract wallets

### DIFF
--- a/widget/embedded/src/hooks/useSwapInput.ts
+++ b/widget/embedded/src/hooks/useSwapInput.ts
@@ -23,10 +23,9 @@ import {
 import { useFetchAllQuotes } from './useFetchAllQuotes';
 
 const DEBOUNCE_DELAY = 600;
-const FIRST_INDEX = 0;
 
 type FetchQuoteParams = Omit<
-  Parameters<typeof createQuoteRequestBody>[typeof FIRST_INDEX],
+  Parameters<typeof createQuoteRequestBody>[0],
   'fromToken' | 'toToken'
 > & { fromToken: Token | null; toToken: Token | null };
 
@@ -48,6 +47,10 @@ export function useSwapInput({
   const { excludeLiquiditySources: configExcludeLiquiditySources, routing } =
     useAppStore().config;
   const { connectedWallets } = useAppStore();
+  const anyContractWalletConnected = connectedWallets.some(
+    (wallet) => wallet.isContractWallet
+  );
+  const contractCall = anyContractWalletConnected;
 
   const {
     fromToken,
@@ -119,6 +122,7 @@ export function useSwapInput({
         affiliateRef,
         affiliatePercent,
         affiliateWallets,
+        contractCall,
       });
       if (isRoutingEnabled('experimental', routing)) {
         requestBody.experimental = true;
@@ -227,6 +231,7 @@ export function useSwapInput({
       affiliateRef,
       affiliatePercent,
       affiliateWallets,
+      contractCall,
     });
     return cancelFetch;
   }, [
@@ -245,6 +250,7 @@ export function useSwapInput({
     userSlippage,
     affiliateRef,
     affiliatePercent,
+    contractCall,
     JSON.stringify(affiliateWallets),
   ]);
 
@@ -261,6 +267,7 @@ export function useSwapInput({
         affiliateRef,
         affiliatePercent,
         affiliateWallets,
+        contractCall,
       }),
     loading,
   };

--- a/widget/embedded/src/store/slices/wallets.ts
+++ b/widget/embedded/src/store/slices/wallets.ts
@@ -259,6 +259,7 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
             return {
               address: account.address,
               chain: account.chain,
+              isContractWallet: account.isContractWallet,
               explorerUrl: null,
               walletType: account.walletType,
               selected: shouldMarkWalletAsSelected,

--- a/widget/embedded/src/types/wallets.ts
+++ b/widget/embedded/src/types/wallets.ts
@@ -5,6 +5,7 @@ export interface Wallet {
   chain: string;
   address: string;
   walletType: WalletType;
+  isContractWallet?: boolean;
 }
 
 export type Balance = {

--- a/widget/embedded/src/utils/swap.ts
+++ b/widget/embedded/src/utils/swap.ts
@@ -455,6 +455,7 @@ export function createQuoteRequestBody(params: {
   affiliatePercent: number | null;
   affiliateWallets: { [key: string]: string } | null;
   destination?: string;
+  contractCall: boolean;
 }): BestRouteRequest {
   const {
     fromToken,
@@ -470,6 +471,7 @@ export function createQuoteRequestBody(params: {
     affiliatePercent,
     affiliateWallets,
     destination,
+    contractCall,
   } = params;
   const selectedWalletsMap = selectedWallets?.reduce(
     (
@@ -509,6 +511,7 @@ export function createQuoteRequestBody(params: {
     connectedWallets,
     selectedWallets: selectedWalletsMap ?? {},
     slippage: slippage.toString(),
+    contractCall,
     ...(destination && { destination: destination }),
     ...(excludeLiquiditySources && {
       swapperGroups: disabledLiquiditySources.concat(liquiditySources ?? []),

--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -45,6 +45,8 @@ export type ExtendedModalWalletInfo = WalletInfoWithExtra &
   Pick<ExtendedWalletInfo, 'properties' | 'isHub'>;
 
 export function mapStatusToWalletState(state: WalletState): WalletStatus {
+  // TODO: refactor
+  // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
   switch (true) {
     case state.connected:
       return WalletStatus.CONNECTED;
@@ -137,7 +139,11 @@ export function prepareAccountsForWalletStore(
 ): Wallet[] {
   const result: Wallet[] = [];
 
-  function addAccount(network: Network, address: string) {
+  function addAccount(
+    network: Network,
+    address: string,
+    isContractWallet?: boolean
+  ) {
     const accountForChainAlreadyExists = !!result.find(
       (account) => account.chain === network
     );
@@ -146,6 +152,7 @@ export function prepareAccountsForWalletStore(
         address,
         chain: network,
         walletType: wallet,
+        isContractWallet: isContractWallet ?? false,
       };
 
       result.push(newAccount);
@@ -192,7 +199,7 @@ export function prepareAccountsForWalletStore(
          * for contract wallets like Safe wallet, we should add only account for the
          * current connected blockchain not all of the supported blockchains
          */
-        addAccount(network, address.toLowerCase());
+        addAccount(network, address.toLowerCase(), isContractWallet);
       } else {
         /*
          * all evm chains are not supported in wallets, so we are adding


### PR DESCRIPTION
# Summary

If certain routes involve smart wallets, user funds could become trapped in the underlying bridge.  

To prevent this, we can add a `contractCall` parameter to the routing request, informing the API and ensuring that routes for these problematic wallets are not generated.

# How did you test this change?

You can create an account in the Safe Wallet app, build the widget, and copy the `manifest.json` file into the `dist` folder of the widget app package. Then, serve it using the command `serve -C` and test this pull request's functionality by adding the widget app as a Safe custom app.

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
