### PR TITLE
fix: handle namespace before action failure

### DIFF
--- a/wallets/core/src/hub/namespaces/errors.ts
+++ b/wallets/core/src/hub/namespaces/errors.ts
@@ -4,5 +4,8 @@ export const ACTION_NOT_FOUND_ERROR = (name: string) =>
 export const OR_ELSE_ACTION_FAILED_ERROR = (name: string) =>
   `An error occurred during running ${name}`;
 
+export const BEFORE_ACTION_FAILED_ERROR = (name: string) =>
+  `An error occurred during running before for "${name}" action`;
+
 export const NO_STORE_FOUND_ERROR =
   'For setup store, you should set `store` first.';


### PR DESCRIPTION
# Summary

Previously, failures in "before" action hooks were not handled properly, preventing "or" action hooks from executing. This caused the UTXO namespace to get stuck in a "connecting" state when connecting Phantom, especially if BTC was turned off in Phantom.

The issue stemmed from changeAccountSubscriber, a "before" hook for the "connect" action, which checked for instance. If the check failed, it threw an error, blocking the execution of "or" and "after" hooks.

This PR introduces the following fixes:

Wraps "before" hooks in a try/catch to ensure errors don't prevent "or" hooks from running.
Adds intoConnectionFinished to the "or" hooks for the "connect" action.
These changes ensure that the connection process proceeds correctly, even if a "before" hook encounters an error.


# How did you test this change?

This change can be tested by turning "BTC" off in Phantom and trying to connect to "UTXO" namespace.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
