### PR TITLE
fix: swap subtitle for history page

### DIFF
--- a/widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx
+++ b/widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx
@@ -1,6 +1,7 @@
 import type { PropTypes } from './HistoryGroupedList.types';
 
 import { i18n } from '@lingui/core';
+import { getCurrentStep } from '@rango-dev/queue-manager-rango-preset';
 import {
   Divider,
   GroupedVirtualizedList,
@@ -102,6 +103,7 @@ export function HistoryGroupedList(props: PropTypes) {
       }}
       itemContent={(index, groupIndex) => {
         const swap = swaps[index];
+        const currentStep = getCurrentStep(swap);
         if (!swap) {
           return null;
         }
@@ -114,6 +116,7 @@ export function HistoryGroupedList(props: PropTypes) {
               creationTime={swap.creationTime}
               status={swap.status}
               onClick={onSwapClick}
+              currentStep={currentStep}
               tooltipContainer={getContainer()}
               onlyShowTime={groups[groupIndex] === i18n.t('Today')}
               swapTokenData={{

--- a/widget/ui/src/components/SwapListItem/SwapListItem.tsx
+++ b/widget/ui/src/components/SwapListItem/SwapListItem.tsx
@@ -41,6 +41,7 @@ export function SwapListItem(props: PropsWithChildren<SwapListItemPropTypes>) {
     status,
     swapTokenData,
     tooltipContainer,
+    currentStep,
   } = props;
   return (
     <Main onClick={onClick.bind(null, requestId)}>
@@ -62,6 +63,7 @@ export function SwapListItem(props: PropsWithChildren<SwapListItemPropTypes>) {
           data={swapTokenData}
           status={status}
           tooltipContainer={tooltipContainer}
+          currentStep={currentStep}
         />
       </Container>
     </Main>

--- a/widget/ui/src/components/SwapListItem/SwapListItem.types.ts
+++ b/widget/ui/src/components/SwapListItem/SwapListItem.types.ts
@@ -1,3 +1,5 @@
+import type { PendingSwapStep } from 'rango-types';
+
 export type Status = 'running' | 'failed' | 'success';
 
 export interface SwapListItemProps {
@@ -8,6 +10,7 @@ export interface SwapListItemProps {
   swapTokenData: SwapTokenData;
   onlyShowTime?: boolean;
   tooltipContainer?: HTMLElement;
+  currentStep: PendingSwapStep | null;
 }
 
 export interface LoadingProps {

--- a/widget/ui/src/components/SwapListItem/SwapToken.tsx
+++ b/widget/ui/src/components/SwapListItem/SwapToken.tsx
@@ -82,6 +82,7 @@ export function SwapToken(props: PropTypes) {
     },
     status,
     tooltipContainer,
+    currentStep,
   } = props;
 
   return (
@@ -119,7 +120,9 @@ export function SwapToken(props: PropTypes) {
             </Typography>
           </TopSection>
           <Typography size="small" variant="body" color="neutral700">
-            {i18n.t('Waiting for bridge transaction')}
+            {currentStep?.fromBlockchain === currentStep?.toBlockchain
+              ? i18n.t('Waiting for the swap transaction')
+              : i18n.t('Waiting for the bridge transaction')}
           </Typography>
         </Layout>
       ) : (

--- a/widget/ui/src/components/SwapListItem/SwapToken.types.ts
+++ b/widget/ui/src/components/SwapListItem/SwapToken.types.ts
@@ -3,11 +3,13 @@ import type {
   Status,
   SwapTokenData,
 } from './SwapListItem.types.js';
+import type { PendingSwapStep } from 'rango-types';
 
 export interface SwapTokenProps {
   data: SwapTokenData;
   status: Status;
   tooltipContainer?: HTMLElement;
+  currentStep: PendingSwapStep | null;
 }
 
 export type PropTypes = SwapTokenProps | LoadingProps;


### PR DESCRIPTION
# Summary

If the source and destination blockchains in the current step are the same, the message "Waiting for swap transaction" will be displayed; otherwise, the message "Waiting for bridge transaction" will be shown.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
