### PR TITLE
chore: avoid throwing error in fetch balances

### DIFF
--- a/widget/embedded/src/store/slices/wallets.ts
+++ b/widget/embedded/src/store/slices/wallets.ts
@@ -641,7 +641,8 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
         response = await httpService().getWalletsDetails(addressesToFetch);
       } catch (e) {
         get().setConnectedWalletHasError(accounts);
-        throw new Error(`Request for fetching balances failed.`, { cause: e });
+        console.error(`Request for fetching balances failed. cause: ${e}`);
+        return;
       }
 
       const walletsDetails = response.wallets;
@@ -720,8 +721,8 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
         get().setConnectedWalletRetrievedData(accounts, walletsDetails);
       } else {
         get().setConnectedWalletHasError(accounts);
-        throw new Error(
-          `We couldn't fetch your account balances. Seem there is no information on blockchain for them yet.`
+        console.error(
+          "We couldn't fetch your account balances. Seem there is no information on blockchain for them yet."
         );
       }
     },


### PR DESCRIPTION
# Summary

Currently, there are two places in `fetchBalances` action in `wallets` slice in which we throw an error but we do not handle that error in places we initiate `fetchBalances`. Also there is another action named `fetchCustomTokensBalance` which has a similar functionality but it just log errors in console instead of throwing errors. 
To ensure consistency and reduce the need for error handling in multiple places, this PR replaces error throwing with `console.error in the `fetchBalances` action, aligning it with the `fetchCustomTokensBalance` behavior.


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
