### PR TITLE
fix: batching state updates for fetchBalances

### DIFF
--- a/widget/embedded/src/store/middlewares/keepLastUpdated.ts
+++ b/widget/embedded/src/store/middlewares/keepLastUpdated.ts
@@ -7,13 +7,20 @@ export const keepLastUpdated: <Store, Slice extends { lastUpdatedAt: number }>(
   config: StateCreator<Store, [], [], Slice>
 ) => StateCreator<Store, [], [], Slice> = (slice) => (set, get, api) => {
   const modifedSet: typeof set = (...params) => {
+    const [partial, ...restParams] = params;
     set((state) => {
+      // @see https://github.com/pmndrs/zustand/blob/90f8d592d4cde9aa15f236e320f17ccbc86cf0fb/src/vanilla.ts#L69-L72
+      type State = ReturnType<typeof get>;
+      const nextState =
+        typeof partial === 'function'
+          ? (partial as (s: State) => State)(state)
+          : partial;
+
       return {
-        ...state,
+        ...nextState,
         lastUpdatedAt: +new Date(),
       };
-    });
-    set(...params);
+    }, ...restParams);
   };
   return slice(modifedSet, get, api);
 };


### PR DESCRIPTION
# Summary

Reduce state updates (calling `set`) by batching them into one update.

In `fetchBalances` we were updating `balances` and `aggregatedBalances` twice. each of them update the UI synchronously which means it was a render blocking operation. Also calling `fetchBalances` multiple times (during renders and connecting wallets) causes CPU be blocked for a noticeable time. 

In this PR, I made the remove operation into a util, then on fetching balances to batch the update, used that util.
Another change is in our middleware I changed it in someway to update the upcoming change and `lastUpdatedTime` in one update.

Fixes # (issue)


# How did you test this change?

The bug reported on Parcel, so you need to link this PR and then try to test. Please consider to test `fetchingBalances` scenarios which means on connecting/disconnecting/switching wallets.


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
