### PR TITLE
fix: fetch custom tokens balances after wallets balances

### DIFF
--- a/widget/embedded/src/hooks/useSubscribeToWidgetEvents/useSubscribeToWidgetEvents.ts
+++ b/widget/embedded/src/hooks/useSubscribeToWidgetEvents/useSubscribeToWidgetEvents.ts
@@ -1,4 +1,5 @@
-import type { RouteEventData, StepEventData } from '../..';
+import type { ConnectedWallet, RouteEventData, StepEventData } from '../..';
+import type { Asset } from 'rango-types';
 
 import {
   isApprovalTX,
@@ -15,11 +16,21 @@ import { useNotificationStore } from '../../store/notification';
 
 export function useSubscribeToWidgetEvents() {
   const setNotification = useNotificationStore.use.setNotification();
-  const { connectedWallets, fetchBalances } = useAppStore();
+  const {
+    connectedWallets,
+    fetchBalances,
+    customTokens: getCustomTokens,
+  } = useAppStore();
 
   useEffect(() => {
     const handleStepEvent = (widgetEvent: StepEventData) => {
       const { event, step, route } = widgetEvent;
+
+      /**
+       * Determine if we should refetch balances:
+       * - When a transaction is sent (TX_SENT) and it's not an approval transaction.
+       * - When a step succeeds.
+       */
       const shouldRefetchBalance =
         (event.type === StepEventType.TX_EXECUTION &&
           event.status === StepExecutionEventStatus.TX_SENT &&
@@ -27,6 +38,12 @@ export function useSubscribeToWidgetEvents() {
         event.type === StepEventType.SUCCEEDED;
 
       if (shouldRefetchBalance) {
+        const fetchBalanceAccounts: ConnectedWallet[] = [];
+
+        /**
+         * Identify the wallet corresponding to the `from` blockchain and match it with a connected wallet.
+         * If found, add it to the balance fetch list.
+         */
         const fromWallet = route.wallets[step?.fromBlockchain];
         if (fromWallet) {
           const fromAccount = connectedWallets.find(
@@ -37,10 +54,14 @@ export function useSubscribeToWidgetEvents() {
               connectedWallet.chain === step?.fromBlockchain
           );
           if (fromAccount) {
-            void fetchBalances([fromAccount]);
+            fetchBalanceAccounts.push(fromAccount);
           }
         }
 
+        /**
+         * If the transaction is cross-chain (`fromBlockchain !== toBlockchain`),
+         * find and add the `to` blockchain wallet to the balance fetch list.
+         */
         if (step?.fromBlockchain !== step?.toBlockchain) {
           const toWallet = route.wallets[step?.toBlockchain];
           if (toWallet) {
@@ -52,9 +73,40 @@ export function useSubscribeToWidgetEvents() {
                 connectedWallet.chain === step?.toBlockchain
             );
             if (toAccount) {
-              void fetchBalances([toAccount]);
+              fetchBalanceAccounts.push(toAccount);
             }
           }
+        }
+
+        if (fetchBalanceAccounts.length > 0) {
+          const customTokens = getCustomTokens();
+          const stepAssets: Asset[] = [
+            {
+              blockchain: step.fromBlockchain,
+              address: step.fromSymbolAddress,
+              symbol: step.fromSymbol,
+            },
+            {
+              blockchain: step.toBlockchain,
+              address: step.toSymbolAddress,
+              symbol: step.toSymbol,
+            },
+          ];
+          const selectedCustomTokens = stepAssets.filter((asset) =>
+            customTokens.some(
+              (token) =>
+                token.blockchain === asset.blockchain &&
+                token.address?.toLocaleLowerCase() ===
+                  asset.address?.toLocaleLowerCase() &&
+                token.symbol?.toLocaleLowerCase() ===
+                  asset.symbol?.toLocaleLowerCase()
+            )
+          );
+
+          void fetchBalances(fetchBalanceAccounts, {
+            selectedCustomTokens,
+            shouldFetchCustomTokens: selectedCustomTokens.length > 0,
+          });
         }
       }
 

--- a/widget/embedded/src/store/slices/settings.ts
+++ b/widget/embedded/src/store/slices/settings.ts
@@ -189,7 +189,7 @@ export const createSettingsSlice: StateCreator<
     });
   },
   setCustomToken: (token) => {
-    void get().fetchCustomTokensBalance({
+    void get().fetchCustomTokensBalances({
       tokens: [token],
       connectedWallets: get().connectedWallets,
     });


### PR DESCRIPTION
# Summary

Currently, there's a bug where if a user imports a custom token and then connects a wallet that supports the blockchain of that token, the custom token’s balance might not be displayed. This issue occurs when the request to fetch wallet balances resolves after the request for custom token balances, causing the custom token balance to be removed from the store once the wallet details request completes.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
