### PR TITLE
chore: add concurrency configuration for sequential publish workflow runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
       - 'main'
       - 'next'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary

This PR updates the Publish workflow to add a concurrency configuration. The workflow now groups runs by `${{ github.workflow }}-${{ github.ref }}`, ensuring that only one workflow run per branch (for 'main' and 'next') is active at any given time. For more info you can check [this ](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs) reference.

## Details
- Concurrency Grouping:
The group is dynamically generated using the workflow name and the Git ref. This means each branch gets its own concurrency group.

- Behavior Changes:
With this setting, if a new commit is pushed while a workflow run is still active, the new run will be queued. This sequential execution per branch prevents overlapping runs and potential race conditions.

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
