### PR TITLE
fix: fix banner not showing on initial page load

### DIFF
--- a/widget/embedded/src/components/Layout/Layout.tsx
+++ b/widget/embedded/src/components/Layout/Layout.tsx
@@ -4,7 +4,7 @@ import type { PropsWithChildren } from 'react';
 
 import { useManager } from '@rango-dev/queue-manager-react';
 import { BottomLogo, Divider, Header } from '@rango-dev/ui';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { WIDGET_UI_ID } from '../../constants';
 import { useIframe } from '../../hooks/useIframe';
@@ -46,6 +46,7 @@ function Layout(props: PropsWithChildren<PropTypes>) {
 
   const hasWatermark = watermark === 'FULL';
   const { activeTheme } = useTheme(theme || {});
+  const [showBanner, setShowBanner] = useState(false);
 
   const isConnectWalletHidden = isFeatureHidden(
     'connectWalletButton',
@@ -78,20 +79,21 @@ function Layout(props: PropsWithChildren<PropTypes>) {
 
   const scrollViewRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const showBanner = useMemo(() => {
-    const anyRouteExists =
+
+  useEffect(() => {
+    const noRoutesAvailable =
       (__UNSTABLE_OR_INTERNAL__?.swapBoxBanner?.routes?.length ?? 0) === 0;
     const routesMatched =
       !!__UNSTABLE_OR_INTERNAL__?.swapBoxBanner?.routes?.some((route) =>
         location.pathname.endsWith(route)
       );
 
-    return (
-      __UNSTABLE_OR_INTERNAL__?.swapBoxBanner &&
-      (anyRouteExists || routesMatched)
+    setShowBanner(
+      !!__UNSTABLE_OR_INTERNAL__?.swapBoxBanner &&
+        (noRoutesAvailable || routesMatched)
     );
   }, [
-    __UNSTABLE_OR_INTERNAL__?.swapBoxBanner?.routes?.length,
+    __UNSTABLE_OR_INTERNAL__?.swapBoxBanner?.routes?.toString(),
     location.pathname,
   ]);
 


### PR DESCRIPTION
# Summary

There was a problem on showing swap box banner on initial page loads on production environment. The problem was related to that the banner was showing if `showBanner` flag was equal to try. `showBanner` was calculated in a `useMemo` with these dependencies: `__UNSTABLE_OR_INTERNAL__?.swapBoxBanner?.routes?.toString()`. Considering this implementation, if `__UNSTABLE_OR_INTERNAL__` is populated after the initial render (e.g., through an async operation or late initialization), `useMemo` will cache the initial undefined state and won't update until one of the dependencies changes.
In this PR, that is handled using a `useEffect` hook to detect that if `__UNSTABLE_OR_INTERNAL__` is injected.

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
