### PR TITLE
feat: Implemented Deep Linking for Wallet Providers

### DIFF
--- a/wallets/core/src/builders/provider.ts
+++ b/wallets/core/src/builders/provider.ts
@@ -56,6 +56,6 @@ export class ProviderBuilder {
   }
 
   #isConfigsValid(config: Partial<ProviderConfig>): config is ProviderConfig {
-    return !!config.info;
+    return !!config.metadata;
   }
 }

--- a/wallets/core/src/hub/mod.ts
+++ b/wallets/core/src/hub/mod.ts
@@ -6,10 +6,15 @@ export type {
 export { Namespace } from './namespaces/mod.js';
 
 export { Provider } from './provider/mod.js';
-export type { CommonNamespaces, CommonNamespaceKeys } from './provider/mod.js';
+export type {
+  CommonNamespaces,
+  CommonNamespaceKeys,
+  GenerateDeepLink,
+  DeepLinkContext,
+} from './provider/mod.js';
 
 export { Hub } from './hub.js';
-export type { Store, State, ProviderInfo } from './store/mod.js';
+export type { Store, State, ProviderMetadata } from './store/mod.js';
 export {
   createStore,
   guessProviderStateSelector,

--- a/wallets/core/src/hub/provider/mod.ts
+++ b/wallets/core/src/hub/provider/mod.ts
@@ -5,6 +5,8 @@ export type {
   State,
   Context,
   ProviderBuilderOptions,
+  GenerateDeepLink,
+  DeepLinkContext,
 } from './types.js';
 
 export { Provider } from './provider.js';

--- a/wallets/core/src/hub/provider/provider.test.ts
+++ b/wallets/core/src/hub/provider/provider.test.ts
@@ -6,7 +6,11 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { NamespaceBuilder } from '../../builders/namespace.js';
 import { ProviderBuilder } from '../../builders/provider.js';
-import { garbageWalletInfo } from '../../test-utils/fixtures.js';
+import {
+  garbageWalletDeepLink,
+  garbageWalletInfo,
+  garbageWalletMetaData,
+} from '../../test-utils/fixtures.js';
 import { createStore } from '../store/mod.js';
 
 import { Provider } from './provider.js';
@@ -46,9 +50,7 @@ describe('check providers', () => {
   });
 
   test('Initialize providers correctly', () => {
-    const provider = new Provider('garbage', namespacesMap, {
-      info: garbageWalletInfo,
-    });
+    const provider = new Provider('garbage', namespacesMap, garbageWalletInfo);
 
     const allNamespaces = provider.getAll();
 
@@ -56,48 +58,32 @@ describe('check providers', () => {
   });
 
   test('throw error if state() is called before store initialization', () => {
-    const provider = new Provider('garbage', namespacesMap, {
-      info: garbageWalletInfo,
-    });
+    const provider = new Provider('garbage', namespacesMap, garbageWalletInfo);
 
     expect(() => provider.state()).toThrowError();
   });
 
   test('should return wallet info via info() without store initialization', () => {
-    const provider = new Provider('garbage', namespacesMap, {
-      info: garbageWalletInfo,
-    });
+    const provider = new Provider('garbage', namespacesMap, garbageWalletInfo);
 
     expect(provider.info()).toBe(garbageWalletInfo);
   });
 
   test('should return wallet info via info() after store initialization', () => {
     const store = createStore();
-    const provider = new Provider(
-      'garbage',
-      namespacesMap,
-      {
-        info: garbageWalletInfo,
-      },
-      { store }
-    );
+    const provider = new Provider('garbage', namespacesMap, garbageWalletInfo, {
+      store,
+    });
 
-    expect(provider.info()).toBe(
-      store.getState().providers.list['garbage'].config.info
+    expect(provider.info()).toMatchObject(
+      store.getState().providers.list['garbage'].config
     );
   });
 
   test('access state correctly', () => {
-    const provider = new Provider(
-      'garbage',
-      namespacesMap,
-      {
-        info: garbageWalletInfo,
-      },
-      {
-        store: createStore(),
-      }
-    );
+    const provider = new Provider('garbage', namespacesMap, garbageWalletInfo, {
+      store: createStore(),
+    });
 
     const [getState, setState] = provider.state();
 
@@ -114,16 +100,9 @@ describe('check providers', () => {
   });
   test('update state properly', () => {
     const store = createStore();
-    const provider = new Provider(
-      'garbage',
-      namespacesMap,
-      {
-        info: garbageWalletInfo,
-      },
-      {
-        store,
-      }
-    );
+    const provider = new Provider('garbage', namespacesMap, garbageWalletInfo, {
+      store,
+    });
 
     const [getState, setState] = provider.state();
 
@@ -142,9 +121,7 @@ describe('check providers', () => {
     testNamespaces.set('evm', evm.build());
     testNamespaces.set('solana', solana.build());
 
-    const provider = new Provider('garbage', testNamespaces, {
-      info: garbageWalletInfo,
-    });
+    const provider = new Provider('garbage', testNamespaces, garbageWalletInfo);
 
     const result = await provider.get('solana')?.connect();
 
@@ -159,16 +136,19 @@ describe('check providers', () => {
 
   test('sets config properly', () => {
     const builder = new ProviderBuilder('garbage');
-    builder.config('info', garbageWalletInfo);
+    builder
+      .config('metadata', garbageWalletMetaData)
+      .config('deepLink', garbageWalletDeepLink);
     const provider = builder.build().store(store);
 
-    expect(provider.info()).toStrictEqual(garbageWalletInfo);
+    expect(provider.info()?.metadata).toStrictEqual(garbageWalletMetaData);
+    expect(provider.info()?.deepLink).toStrictEqual(garbageWalletDeepLink);
   });
 
   test('.init should works on Provider', () => {
     const builder = new ProviderBuilder('garbage').config(
-      'info',
-      garbageWalletInfo
+      'metadata',
+      garbageWalletMetaData
     );
     let count = 0;
     builder.init(() => {
@@ -184,8 +164,8 @@ describe('check providers', () => {
 
   test(".init shouldn't do anything when use hasn't set anything", () => {
     const builder = new ProviderBuilder('garbage').config(
-      'info',
-      garbageWalletInfo
+      'metadata',
+      garbageWalletMetaData
     );
     const provider = builder.build().store(store);
     expect(() => {
@@ -197,8 +177,8 @@ describe('check providers', () => {
 
   test('A provider can be found using its namespace', () => {
     const builder = new ProviderBuilder('garbage', { store }).config(
-      'info',
-      garbageWalletInfo
+      'metadata',
+      garbageWalletMetaData
     );
 
     const { evm, solana } = namespaces;
@@ -231,7 +211,7 @@ describe('check providers', () => {
 
     const builder = new ProviderBuilder('garbage', { store })
       .add('evm', evmNamespace)
-      .config('info', garbageWalletInfo);
+      .config('metadata', garbageWalletMetaData);
     const provider = builder.build();
 
     const [getState] = provider.state();

--- a/wallets/core/src/hub/provider/provider.ts
+++ b/wallets/core/src/hub/provider/provider.ts
@@ -9,7 +9,7 @@ import type {
 } from './types.js';
 import type { FindProxiedNamespace } from '../../builders/mod.js';
 import type { AnyFunction, FunctionWithContext } from '../../types/actions.js';
-import type { ProviderConfig, Store } from '../store/mod.js';
+import type { ProviderConfig, ProviderInfo, Store } from '../store/mod.js';
 
 const VERSION = '1.0';
 
@@ -180,12 +180,14 @@ export class Provider {
    * provider.info();
    * ```
    */
-  public info(): ProviderConfig['info'] | undefined {
+  public info(): ProviderInfo | undefined {
     const store = this.#store;
     if (!store) {
-      return this.#configs.info;
+      return this.#configs;
     }
-    return store.getState().providers.list[this.id].config.info;
+    const config = store.getState().providers.list[this.id].config;
+
+    return { metadata: config.metadata, deepLink: config.deepLink };
   }
 
   /**

--- a/wallets/core/src/hub/provider/types.ts
+++ b/wallets/core/src/hub/provider/types.ts
@@ -13,7 +13,10 @@ export type Context = {
   state: () => [GetState, SetState];
 };
 
-export type State = Omit<LegacyState, 'reachable' | 'accounts' | 'network'>;
+export type State = Omit<
+  LegacyState,
+  'reachable' | 'accounts' | 'network' | 'derivationPath'
+>;
 export type SetState = <K extends keyof Pick<State, 'installed'>>(
   name: K,
   value: State[K]
@@ -43,3 +46,15 @@ export type RegisteredNamespaces<K extends keyof T, T> = Map<
 >;
 
 export type ProviderBuilderOptions = { store?: Store };
+export type GenerateDeepLink = (context: DeepLinkContext) => string;
+
+/**
+ * Deeplink parameters context.
+ *
+ * @param targetUrl - URL of the widget in the app to be opened in the in-app browser.
+ * @param appHost - Domain of the app where the widget has been implemented.
+ */
+export type DeepLinkContext = {
+  targetUrl: string;
+  appHost: string;
+};

--- a/wallets/core/src/hub/store/mod.ts
+++ b/wallets/core/src/hub/store/mod.ts
@@ -16,6 +16,10 @@ export type {
   NamespaceConnectedEvent,
   NamespaceSwitchedAccountEvent,
 } from './events.js';
-export type { ProviderInfo, ProviderConfig } from './providers.js';
+export type {
+  ProviderMetadata,
+  ProviderConfig,
+  ProviderInfo,
+} from './providers.js';
 export type { NamespaceConfig, NamespaceData } from './namespaces.js';
 export { createStore } from './store.js';

--- a/wallets/core/src/hub/store/providers.ts
+++ b/wallets/core/src/hub/store/providers.ts
@@ -1,5 +1,8 @@
 import type { Namespace } from '../../namespaces/common/types.js';
-import type { State as InternalProviderState } from '../provider/mod.js';
+import type {
+  GenerateDeepLink,
+  State as InternalProviderState,
+} from '../provider/mod.js';
 import type { BlockchainMeta, SignerFactory } from 'rango-types';
 import type { StateCreator } from 'zustand';
 
@@ -50,7 +53,7 @@ type SignersProperty = Property<
   }
 >;
 
-export type ProviderInfo = {
+export type ProviderMetadata = {
   name: string;
   icon: string;
   extensions: Partial<Record<Browsers, string>>;
@@ -63,8 +66,11 @@ export type ProviderInfo = {
 };
 
 export interface ProviderConfig {
-  info: ProviderInfo;
+  metadata: ProviderMetadata;
+  deepLink?: GenerateDeepLink;
 }
+
+export type ProviderInfo = ProviderConfig;
 
 interface ProviderData {
   installed: boolean;

--- a/wallets/core/src/hub/store/store.test.ts
+++ b/wallets/core/src/hub/store/store.test.ts
@@ -14,7 +14,7 @@ describe('checking store', () => {
   test('new providers can be added to store', () => {
     const id = 'sol-or-something';
     const info = {
-      info: {
+      metadata: {
         name: 'sol grabage wallet',
         icon: 'http://somewhere.world',
         extensions: {
@@ -31,18 +31,16 @@ describe('checking store', () => {
   });
   test('provider can be removed from store', () => {
     const id = 'sol-or-something';
-    const info = {
-      info: {
-        name: 'sol grabage wallet',
-        icon: 'http://somewhere.world',
-        extensions: {
-          homepage: 'http://somewhere.world',
-        },
+    const metadata = {
+      name: 'sol grabage wallet',
+      icon: 'http://somewhere.world',
+      extensions: {
+        homepage: 'http://somewhere.world',
       },
     };
 
     const { getState } = hubStore;
-    getState().providers.addProvider(id, info);
+    getState().providers.addProvider(id, { metadata });
     expect(getState().providers.list[id]).toBeDefined();
     expect(Object.keys(getState().providers.list).length).toBe(1);
     getState().providers.removeProvider(id);

--- a/wallets/core/src/legacy/types.ts
+++ b/wallets/core/src/legacy/types.ts
@@ -1,4 +1,5 @@
 import type { State as WalletState } from './wallet.js';
+import type { GenerateDeepLink } from '../mod.js';
 import type { Namespace } from '../namespaces/common/mod.js';
 import type { BlockchainMeta, SignerFactory } from 'rango-types';
 
@@ -123,7 +124,7 @@ export type WalletInfo = {
   showOnMobile?: boolean;
   isContractWallet?: boolean;
   mobileWallet?: boolean;
-
+  generateDeepLink?: GenerateDeepLink;
   needsDerivationPath?: NeedsDerivationPath;
   needsNamespace?: NeedsNamespace;
 };

--- a/wallets/core/src/mod.ts
+++ b/wallets/core/src/mod.ts
@@ -1,12 +1,14 @@
 export type {
   Store,
   State,
-  ProviderInfo,
+  ProviderMetadata,
   CommonNamespaces,
   CommonNamespaceKeys,
   Subscriber,
   SubscriberCleanUp,
   Context,
+  GenerateDeepLink,
+  DeepLinkContext,
 } from './hub/mod.js';
 export {
   Hub,

--- a/wallets/core/src/test-utils/fixtures.ts
+++ b/wallets/core/src/test-utils/fixtures.ts
@@ -1,9 +1,15 @@
-import type { ProviderConfig } from '../hub/store/mod.js';
+import type { ProviderConfig, ProviderInfo } from '../hub/store/mod.js';
 
-export const garbageWalletInfo: ProviderConfig['info'] = {
+export const garbageWalletMetaData: ProviderConfig['metadata'] = {
   name: 'Garbage Wallet',
   icon: 'https://somewhereininternet.com/icon.svg',
   extensions: {
     homepage: 'https://app.rango.exchange',
   },
+};
+export const garbageWalletDeepLink: ProviderConfig['deepLink'] = () =>
+  'garbage link';
+export const garbageWalletInfo: ProviderInfo = {
+  metadata: garbageWalletMetaData,
+  deepLink: garbageWalletDeepLink,
 };

--- a/wallets/core/tests/hub.test.ts
+++ b/wallets/core/tests/hub.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, test } from 'vitest';
 import { NamespaceBuilder, ProviderBuilder } from '../src/builders/mod.js';
 import { Hub } from '../src/hub/hub.js';
 import { createStore, type Store } from '../src/hub/store/mod.js';
-import { garbageWalletInfo } from '../src/test-utils/fixtures.js';
+import { garbageWalletMetaData } from '../src/test-utils/fixtures.js';
 
 describe('check hub', () => {
   const walletName = 'garbage-wallet';
@@ -41,8 +41,8 @@ describe('check hub', () => {
       .action('connect', evmConnect)
       .build();
     const garbageWalletBuilder = new ProviderBuilder(walletName).config(
-      'info',
-      garbageWalletInfo
+      'metadata',
+      garbageWalletMetaData
     );
     garbageWalletBuilder.add('evm', evmNamespace);
     const garbageWallet = garbageWalletBuilder.build();
@@ -62,8 +62,8 @@ describe('check hub', () => {
   });
   test('should remove wallet from both hub and store', async () => {
     const garbageWalletBuilder = new ProviderBuilder(walletName).config(
-      'info',
-      garbageWalletInfo
+      'metadata',
+      garbageWalletMetaData
     );
     const garbageWallet = garbageWalletBuilder.build();
 

--- a/wallets/core/tests/providers.test.ts
+++ b/wallets/core/tests/providers.test.ts
@@ -14,7 +14,7 @@ import {
   NamespaceBuilder,
   ProviderBuilder,
 } from '../src/builders/mod.js';
-import { garbageWalletInfo } from '../src/test-utils/fixtures.js';
+import { garbageWalletMetaData } from '../src/test-utils/fixtures.js';
 
 describe('check Provider works with Blockchain correctly', () => {
   const walletName = 'garbage-wallet';
@@ -53,8 +53,8 @@ describe('check Provider works with Blockchain correctly', () => {
       .build();
 
     const garbageWalletBuilder = new ProviderBuilder(walletName).config(
-      'info',
-      garbageWalletInfo
+      'metadata',
+      garbageWalletMetaData
     );
     garbageWalletBuilder.add('evm', evmNamespace);
     garbageWalletBuilder.add('solana', solanaNamespace);
@@ -117,8 +117,8 @@ describe('check Provider works with Blockchain correctly', () => {
       .build();
 
     const garbageWalletBuilder = new ProviderBuilder('garbage-wallet').config(
-      'info',
-      garbageWalletInfo
+      'metadata',
+      garbageWalletMetaData
     );
     garbageWalletBuilder.add('evm', evmNamespace);
 

--- a/wallets/provider-phantom/src/constants.ts
+++ b/wallets/provider-phantom/src/constants.ts
@@ -1,4 +1,4 @@
-import { type ProviderInfo } from '@rango-dev/wallets-core';
+import { type ProviderMetadata } from '@rango-dev/wallets-core';
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { Networks } from '@rango-dev/wallets-shared';
 import {
@@ -23,7 +23,7 @@ export const EVM_SUPPORTED_CHAINS = [
 export const WALLET_ID = 'phantom';
 export const WALLET_NAME_IN_WALLET_STANDARD = 'Phantom';
 
-export const info: ProviderInfo = {
+export const metadata: ProviderMetadata = {
   name: 'Phantom',
   icon: 'https://raw.githubusercontent.com/rango-exchange/assets/main/wallets/phantom/icon.svg',
   extensions: {

--- a/wallets/provider-phantom/src/provider.ts
+++ b/wallets/provider-phantom/src/provider.ts
@@ -1,6 +1,6 @@
 import { ProviderBuilder } from '@rango-dev/wallets-core';
 
-import { info, WALLET_ID } from './constants.js';
+import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';
 import { solana } from './namespaces/solana.js';
 import { sui } from './namespaces/sui.js';
@@ -17,7 +17,14 @@ const buildProvider = () =>
         console.debug('[phantom] instance detected.', context);
       }
     })
-    .config('info', info)
+    .config('metadata', metadata)
+    .config('deepLink', (context) => {
+      const ref = `https://${context.appHost}`;
+      const deepLinkDestination = `${context.targetUrl}?autoConnect=${WALLET_ID}`;
+      return `https://phantom.app/ul/browse/${encodeURIComponent(
+        deepLinkDestination
+      )}?ref=${encodeURIComponent(ref)}`;
+    })
     .add('solana', solana)
     .add('evm', evm)
     .add('utxo', utxo)

--- a/wallets/provider-rabby/src/constants.ts
+++ b/wallets/provider-rabby/src/constants.ts
@@ -1,4 +1,4 @@
-import { type ProviderInfo } from '@rango-dev/wallets-core';
+import { type ProviderMetadata } from '@rango-dev/wallets-core';
 import { type BlockchainMeta, evmBlockchains } from 'rango-types';
 
 import getSigners from './signer.js';
@@ -6,7 +6,7 @@ import { evmRabby } from './utils.js';
 
 export const WALLET_ID = 'rabby';
 
-export const info: ProviderInfo = {
+export const metadata: ProviderMetadata = {
   name: 'Rabby',
   icon: 'https://raw.githubusercontent.com/rango-exchange/assets/main/wallets/rabby/icon.svg',
   extensions: {

--- a/wallets/provider-rabby/src/provider.ts
+++ b/wallets/provider-rabby/src/provider.ts
@@ -1,6 +1,6 @@
 import { ProviderBuilder } from '@rango-dev/wallets-core';
 
-import { info, WALLET_ID } from './constants.js';
+import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';
 import { rabby as rabbyInstance } from './utils.js';
 
@@ -13,7 +13,7 @@ const buildProvider = () =>
         console.debug('[rabby] instance detected.', context);
       }
     })
-    .config('info', info)
+    .config('metadata', metadata)
     .add('evm', evm)
     .build();
 

--- a/wallets/provider-slush/src/constants.ts
+++ b/wallets/provider-slush/src/constants.ts
@@ -1,4 +1,4 @@
-import { type ProviderInfo } from '@rango-dev/wallets-core';
+import { type ProviderMetadata } from '@rango-dev/wallets-core';
 import {
   type BlockchainMeta,
   type SuiBlockchainMeta,
@@ -10,7 +10,7 @@ import getSigners from './signer.js';
 export const WALLET_ID = 'slush';
 export const WALLET_NAME_IN_WALLET_STANDARD = 'Slush';
 
-export const info: ProviderInfo = {
+export const metadata: ProviderMetadata = {
   name: 'Slush',
   icon: 'https://raw.githubusercontent.com/rango-exchange/assets/main/wallets/slush/icon.svg',
   extensions: {

--- a/wallets/provider-slush/src/provider.ts
+++ b/wallets/provider-slush/src/provider.ts
@@ -1,6 +1,6 @@
 import { ProviderBuilder } from '@rango-dev/wallets-core';
 
-import { info, WALLET_ID } from './constants.js';
+import { metadata, WALLET_ID } from './constants.js';
 import { sui } from './namespaces/sui.js';
 import { suiWalletInstance } from './utils.js';
 
@@ -13,7 +13,7 @@ const buildProvider = () =>
         console.debug('[slush] instance detected.', context);
       }
     })
-    .config('info', info)
+    .config('metadata', metadata)
     .add('sui', sui)
     .build();
 

--- a/wallets/provider-trustwallet/src/constants.ts
+++ b/wallets/provider-trustwallet/src/constants.ts
@@ -1,4 +1,4 @@
-import { type ProviderInfo } from '@rango-dev/wallets-core';
+import { type ProviderMetadata } from '@rango-dev/wallets-core';
 import {
   type BlockchainMeta,
   evmBlockchains,
@@ -10,7 +10,7 @@ import { getInstanceOrThrow } from './utils.js';
 
 export const WALLET_ID = 'trust-wallet';
 
-export const info: ProviderInfo = {
+export const metadata: ProviderMetadata = {
   name: 'Trust Wallet',
   icon: 'https://raw.githubusercontent.com/rango-exchange/assets/main/wallets/trustwallet/icon.svg',
   extensions: {

--- a/wallets/provider-trustwallet/src/provider.ts
+++ b/wallets/provider-trustwallet/src/provider.ts
@@ -1,6 +1,6 @@
 import { ProviderBuilder } from '@rango-dev/wallets-core';
 
-import { info, WALLET_ID } from './constants.js';
+import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';
 import { solana } from './namespaces/solana.js';
 import { trustWallet as trustwalletInstance } from './utils.js';
@@ -15,7 +15,10 @@ const buildProvider = () =>
         console.debug('[trustwallet] instance detected.', context);
       }
     })
-    .config('info', info)
+    .config('metadata', metadata)
+    .config('deepLink', (context) => {
+      return `https://link.trustwallet.com/open_url?coin_id=60&url=${context.targetUrl}?autoConnect=${WALLET_ID}`;
+    })
     .add('evm', evm)
     .add('solana', solana)
     .build();

--- a/wallets/provider-unisat/src/constants.ts
+++ b/wallets/provider-unisat/src/constants.ts
@@ -1,6 +1,6 @@
 import type { BlockchainMeta, TransferBlockchainMeta } from 'rango-types';
 
-import { type ProviderInfo } from '@rango-dev/wallets-core';
+import { type ProviderMetadata } from '@rango-dev/wallets-core';
 import { Networks } from '@rango-dev/wallets-shared';
 
 import getSigners from './signer.js';
@@ -8,7 +8,7 @@ import { getInstanceOrThrow } from './utils.js';
 
 export const WALLET_ID = 'unisat';
 
-export const info: ProviderInfo = {
+export const metadata: ProviderMetadata = {
   name: 'UniSat',
   icon: 'https://raw.githubusercontent.com/rango-exchange/assets/main/wallets/unisat/icon.svg',
   extensions: {

--- a/wallets/provider-unisat/src/legacy/index.ts
+++ b/wallets/provider-unisat/src/legacy/index.ts
@@ -8,7 +8,7 @@ import {
   type TransferBlockchainMeta,
 } from 'rango-types';
 
-import { info, WALLET_ID } from '../constants.js';
+import { metadata, WALLET_ID } from '../constants.js';
 import signer from '../signer.js';
 import { type Provider, unisat as unisat_instance } from '../utils.js';
 
@@ -28,11 +28,11 @@ const getWalletInfo: (allBlockChains: BlockchainMeta[]) => WalletInfo = (
   }
 
   return {
-    name: info.name,
-    img: info.icon,
+    name: metadata.name,
+    img: metadata.icon,
     installLink: {
-      CHROME: info.extensions.chrome,
-      DEFAULT: info.extensions.homepage || '',
+      CHROME: metadata.extensions.chrome,
+      DEFAULT: metadata.extensions.homepage || '',
     },
     color: '#e9983d',
     needsNamespace: {

--- a/wallets/provider-unisat/src/provider.ts
+++ b/wallets/provider-unisat/src/provider.ts
@@ -1,6 +1,6 @@
 import { ProviderBuilder } from '@rango-dev/wallets-core';
 
-import { info, WALLET_ID } from './constants.js';
+import { metadata, WALLET_ID } from './constants.js';
 import { utxo } from './namespaces/utxo.js';
 import { unisat as unisatInstance } from './utils.js';
 
@@ -14,7 +14,7 @@ const buildProvider = () =>
         console.debug('[unisat] instance detected.', context);
       }
     })
-    .config('info', info)
+    .config('metadata', metadata)
     .add('utxo', utxo)
     .build();
 

--- a/wallets/react/src/hub/types.ts
+++ b/wallets/react/src/hub/types.ts
@@ -1,7 +1,7 @@
 import type {
   CommonNamespaces,
   FindProxiedNamespace,
-  ProviderInfo,
+  ProviderMetadata,
 } from '@rango-dev/wallets-core';
 
 export type AllProxiedNamespaces = FindProxiedNamespace<
@@ -9,4 +9,4 @@ export type AllProxiedNamespaces = FindProxiedNamespace<
   CommonNamespaces
 >;
 
-export type ExtensionLink = keyof ProviderInfo['extensions'];
+export type ExtensionLink = keyof ProviderMetadata['extensions'];

--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -154,7 +154,9 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
       }
       const namespacesProperty = provider
         .info()
-        ?.properties?.find((property) => property.name === 'namespaces');
+        ?.metadata?.properties?.find(
+          (property) => property.name === 'namespaces'
+        );
 
       if (!dataRef.current.allBlockChains) {
         throw new Error(`Blockchains are not available`);
@@ -320,7 +322,7 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
         throw new Error('Your provider should have required `info`.');
       }
 
-      const providerProperties = info.properties;
+      const providerProperties = info.metadata.properties;
 
       const signerProperty = providerProperties?.find(
         (property) => property.name === 'signers'
@@ -346,12 +348,14 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
         DEFAULT: '',
       };
 
+      const { metadata, deepLink } = info;
+      const { extensions } = metadata;
       // `extensions` in legacy format was uppercase and also `DEFAULT` was used instead of `homepage`
-      Object.keys(info.extensions).forEach((k) => {
+      Object.keys(extensions).forEach((k) => {
         const key = k as ExtensionLink;
 
         if (key === 'homepage') {
-          installLink.DEFAULT = info.extensions[key] || '';
+          installLink.DEFAULT = extensions[key] || '';
         }
 
         const allowedKeys: ExtensionLink[] = [
@@ -365,11 +369,11 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
             WalletInfo['installLink'],
             string
           >;
-          installLink[upperCasedKey] = info.extensions[key] || '';
+          installLink[upperCasedKey] = extensions[key] || '';
         }
       });
 
-      const providerProperties = info.properties;
+      const providerProperties = metadata.properties;
 
       const namespacesProperty = providerProperties?.find(
         (property) => property.name === 'namespaces'
@@ -382,8 +386,8 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
       );
 
       return {
-        name: info.name,
-        img: info.icon,
+        name: metadata.name,
+        img: metadata.icon,
         installLink: installLink,
         // We don't have this values anymore, fill them with some values that communicate this.
         color: 'red',
@@ -397,9 +401,9 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
         showOnMobile: detailsProperty?.value?.showOnMobile,
         needsNamespace: namespacesProperty?.value,
         needsDerivationPath: derivationPathProperty?.value,
-
+        generateDeepLink: deepLink,
         isHub: true,
-        properties: wallet.info()?.properties,
+        properties: metadata.properties,
       };
     },
     providers() {

--- a/wallets/react/src/hub/utils.ts
+++ b/wallets/react/src/hub/utils.ts
@@ -74,7 +74,7 @@ export function getSupportedChainsFromProvider(
 ) {
   const namespacesProperty = provider
     .info()
-    ?.properties?.find((property) => property.name === 'namespaces');
+    ?.metadata.properties?.find((property) => property.name === 'namespaces');
 
   const supportedChains =
     namespacesProperty?.value.data.flatMap((namespace) =>

--- a/wallets/react/src/legacy/types.ts
+++ b/wallets/react/src/legacy/types.ts
@@ -1,4 +1,8 @@
-import type { ProviderInfo, VersionedProviders } from '@rango-dev/wallets-core';
+import type {
+  GenerateDeepLink,
+  ProviderMetadata,
+  VersionedProviders,
+} from '@rango-dev/wallets-core';
 import type {
   LegacyNamespaceInputForConnect,
   LegacyProviderInterface,
@@ -31,7 +35,7 @@ export type ConnectResult = {
 export type Providers = { [type in WalletType]?: InstanceType };
 
 export type ExtendedWalletInfo = WalletInfo & {
-  properties?: ProviderInfo['properties'];
+  properties?: ProviderMetadata['properties'];
   isHub?: boolean;
 };
 
@@ -165,6 +169,7 @@ export interface WalletActions {
   // Optional, but should be provided at the same time.
   suggest?: Suggest;
   switchNetwork?: SwitchNetwork;
+  generateDeepLink?: GenerateDeepLink;
   getSigners: (provider: InstanceType) => Promise<SignerFactory>;
   canSwitchNetworkTo?: CanSwitchNetwork;
   canEagerConnect?: CanEagerConnect;

--- a/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
@@ -15,6 +15,7 @@ import React, { useEffect, useState } from 'react';
 
 import { useWallets } from '../..';
 import { WIDGET_UI_ID } from '../../constants';
+import { useDeepLink } from '../../hooks/useDeepLink';
 import { useWalletList } from '../../hooks/useWalletList';
 import { useAppStore } from '../../store/AppStore';
 import { useUiStore } from '../../store/ui';
@@ -38,7 +39,7 @@ export function WalletList(props: PropTypes) {
   const { chain, quoteChains, isSelected, selectWallet, limit, onShowMore } =
     props;
   const isActiveTab = useUiStore.use.isActiveTab();
-
+  const { checkHasDeepLink, getWalletLink } = useDeepLink();
   const { blockchains, connectedWallets } = useAppStore();
   const [selectedWalletToConnect, setSelectedWalletToConnect] =
     useState<ExtendedModalWalletInfo>();
@@ -159,7 +160,9 @@ export function WalletList(props: PropTypes) {
           }
         };
 
-        const info = makeInfo(wallet.state);
+        const info = makeInfo(wallet.state, {
+          hasDeepLink: checkHasDeepLink(wallet.type),
+        });
 
         const getWalletDescription = () => {
           if (couldAddExperimentalChain) {
@@ -226,6 +229,7 @@ export function WalletList(props: PropTypes) {
               </WatermarkedModal>
             )}
             <SelectableWallet
+              hasDeepLink={checkHasDeepLink(wallet.type)}
               key={wallet.type}
               id="widget-wallets-list-selectable-wallet-btn"
               description={getWalletDescription()}
@@ -234,6 +238,7 @@ export function WalletList(props: PropTypes) {
               selected={isSelected(wallet.type, chain)}
               disabled={!isActiveTab}
               {...wallet}
+              link={getWalletLink(wallet.type)}
             />
           </React.Fragment>
         );

--- a/widget/embedded/src/hooks/useDeepLink.ts
+++ b/widget/embedded/src/hooks/useDeepLink.ts
@@ -1,0 +1,48 @@
+import type { InstallObjects } from '@rango-dev/wallets-shared';
+
+import { useWallets } from '@rango-dev/wallets-react';
+import { detectMobileScreens } from '@rango-dev/wallets-shared';
+
+import { useAppStore } from '../store/AppStore';
+
+export function useDeepLink() {
+  const { getWalletInfo } = useWallets();
+  const { config } = useAppStore();
+  const isMobileScreen = detectMobileScreens();
+
+  function getWalletDeepLink(walletType: string): string | undefined {
+    const wallet = getWalletInfo(walletType);
+    const appHost = config.deepLinking?.appHost;
+    const targetUrl = config.deepLinking?.targetUrl;
+    if (!appHost || !targetUrl) {
+      return;
+    }
+    return wallet.generateDeepLink?.({
+      appHost,
+      targetUrl,
+    });
+  }
+
+  /**
+   * Returns the appropriate wallet link based on the given wallet type.
+   *
+   * If a deep link is available and the user is on a mobile screen, the deep link is returned.
+   * Otherwise, it falls back to returning the wallet's install link.
+   *
+   * @param {string} walletType - The type of the wallet (e.g., 'metamask', 'trust-wallet').
+   * @returns {string | InstallObjects} - A deep link string if available on mobile, or an install link object otherwise.
+   */
+  function getWalletLink(walletType: string): string | InstallObjects {
+    const deepLink = getWalletDeepLink(walletType);
+    if (deepLink && isMobileScreen) {
+      return deepLink;
+    }
+    const wallet = getWalletInfo(walletType);
+    return wallet.installLink;
+  }
+
+  function checkHasDeepLink(walletType: string): boolean {
+    return !!getWalletDeepLink(walletType) && isMobileScreen;
+  }
+  return { getWalletDeepLink, getWalletLink, checkHasDeepLink };
+}

--- a/widget/embedded/src/hooks/useWalletList.ts
+++ b/widget/embedded/src/hooks/useWalletList.ts
@@ -20,6 +20,7 @@ import {
   sortWalletsBasedOnConnectionState,
 } from '../utils/wallets';
 
+import { useDeepLink } from './useDeepLink';
 import { useStatefulConnect } from './useStatefulConnect/useStatefulConnect';
 
 interface Params {
@@ -44,6 +45,7 @@ export function useWalletList(params?: Params): API {
   const { state, getWalletInfo } = useWallets();
   const blockchains = useAppStore().blockchains();
   const { handleDisconnect } = useStatefulConnect();
+  const { checkHasDeepLink } = useDeepLink();
 
   /** It can be what has been set by widget config or as a fallback we use all the supported wallets by our library */
   const listAvailableWalletTypes = configWalletsToWalletName(
@@ -60,7 +62,8 @@ export function useWalletList(params?: Params): API {
   wallets = detectMobileScreens()
     ? wallets.filter(
         (wallet) =>
-          wallet.showOnMobile !== false && state(wallet.type).installed
+          wallet.showOnMobile !== false &&
+          (state(wallet.type).installed || checkHasDeepLink(wallet.type))
       )
     : wallets;
 

--- a/widget/embedded/src/pages/WalletsPage.tsx
+++ b/widget/embedded/src/pages/WalletsPage.tsx
@@ -15,6 +15,7 @@ import React, { useState } from 'react';
 
 import { Layout, PageContainer } from '../components/Layout';
 import { StatefulConnectModal } from '../components/StatefulConnectModal';
+import { useDeepLink } from '../hooks/useDeepLink';
 import { useWalletList } from '../hooks/useWalletList';
 import { useAppStore } from '../store/AppStore';
 import { useUiStore } from '../store/ui';
@@ -45,7 +46,7 @@ export function WalletsPage() {
   const blockchains = useAppStore().blockchains();
   const { config } = useAppStore();
   const { state } = useWallets();
-
+  const { checkHasDeepLink, getWalletLink } = useDeepLink();
   const [selectedWalletToConnect, setSelectedWalletToConnect] =
     useState<WalletInfoWithExtra>();
   const isActiveTab = useUiStore.use.isActiveTab();
@@ -95,6 +96,7 @@ export function WalletsPage() {
               wallet,
               namespacesState
             );
+
             return (
               <Wallet
                 key={key}
@@ -104,6 +106,8 @@ export function WalletsPage() {
                     ? WalletState.PARTIALLY_CONNECTED
                     : wallet.state
                 }
+                hasDeepLink={checkHasDeepLink(wallet.type)}
+                link={getWalletLink(wallet.type)}
                 container={getContainer()}
                 onClick={() => handleWalletItemClick(wallet)}
                 isLoading={fetchMetaStatus === 'loading'}

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -175,7 +175,19 @@ export type TrezorManifest = {
   appUrl: string;
   email: string;
 };
-
+/**
+ * `DeepLinking`
+ *
+ * @property {string} [targetUrl]
+ * - The URL to be opened in the provider's in-app browser.
+ *
+ * @property {string} [appHost]
+ * - The full domain of the app, excluding the protocol (https://), path, and query parameters.
+ */
+export type DeepLinking = {
+  targetUrl: string;
+  appHost: string;
+};
 /**
  *
  * @property {string} manifestUrl - The URL of the TON Connect [manifest]{@link https://github.com/ton-connect/docs/blob/main/requests-responses.md#app-manifest}, containing the Dapp metadata to be displayed in the user’s wallet.
@@ -223,6 +235,7 @@ export type TonConnectConfig = {
  * @property {WidgetTheme} theme - The `theme` property is a part of the `WidgetConfig` type and is
  * used to specify the visual theme of the widget. It is of type `WidgetTheme`, which is an interface
  * that defines the various properties of the theme, such as colors, fonts, and others.
+ * @property {DeepLinking} deepLinking - Configures deep linking parameters for providers that support it.
  * @property {boolean} externalWallets
  * If `externalWallets` is `true`, you should add `WidgetWallets` to your app.
  * @property {boolean} excludeLiquiditySources - The `excludeLiquiditySources` property is a boolean value that when you
@@ -265,6 +278,7 @@ export type WidgetConfig = {
   defaultCustomDestinations?: { [blockchain: string]: string };
   language?: Language;
   theme?: WidgetTheme;
+  deepLinking?: DeepLinking;
   externalWallets?: boolean;
   excludeLiquiditySources?: boolean;
   features?: Features;

--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -96,7 +96,6 @@ export function mapWalletTypesToWalletInfo(
       const blockchainTypes = removeDuplicateFrom(
         supportedChains.map((item) => item.type)
       );
-
       const state = mapStatusToWalletState(getState(type));
       return {
         title: name,
@@ -113,7 +112,6 @@ export function mapWalletTypesToWalletInfo(
       };
     });
 }
-
 export function walletAndSupportedChainsNames(
   supportedBlockchains: BlockchainMeta[]
 ): Network[] | null {

--- a/widget/ui/src/components/Wallet/ClickableWallet.tsx
+++ b/widget/ui/src/components/Wallet/ClickableWallet.tsx
@@ -20,8 +20,16 @@ import {
 import { WalletState } from './Wallet.types.js';
 
 function Wallet(props: WalletPropTypes) {
-  const { title, type, image, onClick, isLoading, disabled = false } = props;
-  const info = makeInfo(props.state);
+  const {
+    title,
+    type,
+    image,
+    onClick,
+    isLoading,
+    disabled = false,
+    hasDeepLink,
+  } = props;
+  const info = makeInfo(props.state, { hasDeepLink });
 
   if (isLoading) {
     return (
@@ -43,7 +51,8 @@ function Wallet(props: WalletPropTypes) {
       <Tooltip
         container={props.container}
         content={info.tooltipText}
-        side="top">
+        side="top"
+      >
         {children}
       </Tooltip>
     );
@@ -59,7 +68,8 @@ function Wallet(props: WalletPropTypes) {
         } else {
           onClick(type);
         }
-      }}>
+      }}
+    >
       <WalletImageContainer>
         <Image src={image} size={35} />
       </WalletImageContainer>
@@ -73,7 +83,8 @@ function Wallet(props: WalletPropTypes) {
           variant="body"
           size="xsmall"
           noWrap={false}
-          color={info.color}>
+          color={info.color}
+        >
           {info.description}
         </Typography>
       </Text>

--- a/widget/ui/src/components/Wallet/Wallet.helpers.ts
+++ b/widget/ui/src/components/Wallet/Wallet.helpers.ts
@@ -1,10 +1,10 @@
-import type { Info } from './Wallet.types.js';
+import type { Info, MakeInfoOptions } from './Wallet.types.js';
 
 import { i18n } from '@lingui/core';
 
 import { WalletState } from './Wallet.types.js';
 
-export function makeInfo(state: WalletState): Info {
+export function makeInfo(state: WalletState, options?: MakeInfoOptions): Info {
   switch (state) {
     case WalletState.CONNECTED:
       return {
@@ -19,6 +19,13 @@ export function makeInfo(state: WalletState): Info {
         tooltipText: i18n.t('Connect other chains'),
       };
     case WalletState.NOT_INSTALLED:
+      if (options?.hasDeepLink) {
+        return {
+          color: 'info500',
+          description: i18n.t('Open'),
+          tooltipText: i18n.t('Open'),
+        };
+      }
       return {
         color: 'info500',
         description: i18n.t('Install'),

--- a/widget/ui/src/components/Wallet/Wallet.types.ts
+++ b/widget/ui/src/components/Wallet/Wallet.types.ts
@@ -21,7 +21,9 @@ export type WalletInfo = {
   needsNamespace?: LegacyWalletInfo['needsNamespace'];
   needsDerivationPath?: LegacyWalletInfo['needsDerivationPath'];
 };
-
+export interface MakeInfoOptions {
+  hasDeepLink: boolean;
+}
 export interface Info {
   color: string;
   description: string;
@@ -42,6 +44,7 @@ export interface WalletPropTypes {
   link: InstallObjects | string;
   type: WalletType;
   onClick: (type: WalletType) => void;
+  hasDeepLink: boolean;
   selected?: boolean;
   description?: string;
   isLoading?: boolean;

--- a/widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx
+++ b/widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.tsx
@@ -8,7 +8,8 @@ import { Modal, Wallet } from '../../components/index.js';
 import { ModalContent } from './ConnectWalletsModal.styles.js';
 
 export function ConnectWalletsModal(props: ConnectWalletsModalPropTypes) {
-  const { open, list, onSelect, onClose, id } = props;
+  const { open, list, onSelect, onClose, id, checkHasDeepLink, getWalletLink } =
+    props;
 
   return (
     <Modal
@@ -18,10 +19,17 @@ export function ConnectWalletsModal(props: ConnectWalletsModalPropTypes) {
       id={id}
       styles={{
         container: { width: '75%', maxWidth: '30rem', height: '60%' },
-      }}>
+      }}
+    >
       <ModalContent>
         {list.map((info) => (
-          <Wallet {...info} key={info.title} onClick={onSelect} />
+          <Wallet
+            {...info}
+            key={info.title}
+            onClick={onSelect}
+            hasDeepLink={checkHasDeepLink(info.type)}
+            link={getWalletLink(info.type)}
+          />
         ))}
       </ModalContent>
     </Modal>

--- a/widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.types.ts
+++ b/widget/ui/src/containers/ConnectWalletsModal/ConnectWalletsModal.types.ts
@@ -1,10 +1,12 @@
 import type { WalletInfo } from '../../components/index.js';
-import type { WalletType } from '@rango-dev/wallets-shared';
+import type { InstallObjects, WalletType } from '@rango-dev/wallets-shared';
 
 export interface ConnectWalletsModalPropTypes {
   open: boolean;
   list: WalletInfo[];
   onSelect: (walletType: WalletType) => void;
+  getWalletLink: (walletType: WalletType) => string | InstallObjects;
+  checkHasDeepLink: (walletType: WalletType) => boolean;
   id: string;
   onClose: () => void;
   error?: string;


### PR DESCRIPTION
### Summary
In this PR, I've implemented deep linking for five wallet providers:
- Trust Wallet
- Phantom
- OKX
- Coinbase
- Bitget

### Implementation Details
Initially, I attempted to use install links to handle deep linking. However, this approach was not suitable because:
- Each provider has a different way of creating deep links.
- A function was required to dynamically generate deep links based on the target URL.

To address this, I introduced a `generateDeepLink` method, which:
- Generates deep links for different providers.
- Is added to the providers' definitions in both **hub** and **legacy providers**.
- Requires modifications in **core** and **hub** to support the changes.

For each provider, I implemented a `generateDeepLink` method to handle their specific deep linking format.

### Handling Target URLs
Since our widget is used on different websites, I needed the website’s address to create deep links dynamically. The following parameters are now included:
- **targetURL**: The URL that will be opened inside in-app browsers of the wallets.
- **appDomain**: The app's domain, excluding the protocol (`https://`), path, and query parameters (since some providers require a clean domain for deep linking).

To support this, I:
- Used the widget’s configuration.
- Added two new configuration options.

### UX Improvement: Open Instead of "Not Installed"
I implemented logic to check if a provider supports deep links and adjusted the UI accordingly:
- Instead of showing "Not Installed" for unsupported providers on mobile browsers, it now displays **Open**, which is more intuitive.


### Further Investigation: Deep Linking Support in Different Wallets

#### MetaMask
- The MetaMask SDK includes an `openDeeplink` function ([docs](https://docs.metamask.io/sdk/reference/sdk-options/#opendeeplink)), but it lacks further details.
- MetaMask provides a [deep link generator](https://metamask.github.io/metamask-deeplinks/), which I used to generate the link: `https://metamask.app.link/dapp/app.rango.exchange`. However, this did not open the webview in the MetaMask app for our website.
- I investigated how different DEXs support MetaMask deep linking:
  
  | DEX | Support |
  |-----|---------|
  | [Uniswap](https://app.uniswap.org/) | Not Supported |
  | [Fluid](https://fluid.instadapp.io/) | Not Supported |
  | [Curve](https://curve.fi/dex/) | Not Working |
  | [Balancer](https://balancer.fi/) | Not Working |
  | [Sushi](https://www.sushi.com/) | Not Working |
  | [Wagmi](https://app.wagmi.com/) | Not Supported |
  | [Timeless](https://timelessfi.com/) | Not Supported |
  | [Pendle](https://app.pendle.finance/) | Not Working |
  | [Dodo](https://app.dodoex.io/) | Not Working |
  | [Integral](https://app.integral.link/) | Not Working |
  
  At this point, I did not find any other viable solution.

#### Phantom
- Phantom's [documentation](https://docs.phantom.com/phantom-deeplinks/other-methods/browse) provides a deep link format: `https://phantom.app/ul/browse/https%3A%2F%2Fapp.rango.exchange?ref=https%3A%2F%2Fapp.rango.exchange`.
- I tested this, and it successfully opened the webview in Phantom.

#### Rabby
- I could not find any documentation on deep linking for Rabby.

#### OKX
- OKX provides a [deep linking guide](https://www.okx.com/web3/build/docs/waas/app-universal-link).

#### Trust Wallet
- Trust Wallet has a [deep linking guide](https://developer.trustwallet.com/developer/develop-for-trust/deeplinking).
- However, deep linking does not work without specifying a `coin_id`, which is a SLIP-44 index ([reference](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)).
- Using `60` (ETH), everything worked as expected.

#### Bitget
- Bitget provides a [deep linking guide](https://docs.bitkeep.com/en/docs/guide/mobile/Deeplink.html#access-dapp).
- I created a deep link following their instructions, and it worked.

#### Keplr
- Keplr has a [deep linking guide](https://docs.keplr.app/api/mobile/deeplink).
- I attempted several deep links based on their documentation, but none successfully opened our website in their browser:
  - `https://deeplink.keplr.app/web-browser?url=https://app.rango.exchange/bridge?autoConnect=keplr` (Did not work)
  - `https://deeplink.keplr.app/web-browser?url=https%3A%2F%2Fapp.rango.exchange%2Fbridge%3FautoConnect%3Dkeplr` (Did not work)
  - `https://deeplink.keplr.app/web-browser?url=app.rango.exchange` (Did not work)
  - `intent://web-browser?url=app.osmosis.zone#Intent;package=com.chainapsis.keplr;scheme=keplrwallet;end;` (Did not work)
  - The only working URL I found was `https://deeplink.keplr.app/show-address?chainId=osmosis-1`, which is not useful for our use case.
- I checked how other DEXs implement Keplr deep linking and found no successful implementations.
- Tested platforms:
  - [Uniswap](https://app.uniswap.org/)
  - [PancakeSwap](https://pancakeswap.finance/)
  - [Fluid](https://fluid.instadapp.io/)
  - [Curve](https://curve.fi/dex/)
  - [Balancer](https://balancer.fi/)
  - [Sushi](https://www.sushi.com/)
  - [Wagmi](https://app.wagmi.com/)
  - [Timeless](https://timelessfi.com/)
  - [Pendle](https://app.pendle.finance/)
  - [Dodo](https://app.dodoex.io/)
  - [Integral](https://app.integral.link/)
  - [Raydium](https://raydium.io/)
  - [Invariant](https://invariant.app/)
  - [Drift](https://app.drift.trade/)
  - [Phoenix](https://app.phoenix.trade/)
  - [Stabble](https://app.stabble.org/)
  - [Pump.fun](https://pump.fun/)
  - [Lifinity](https://lifinity.io/)
  - [Orca](https://www.orca.so/)
  - [Meteora](https://www.meteora.ag/)
  - [Cropper](https://app.cropper.finance/)

At this point, I did not find any other viable solution for Keplr deep linking.


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
