### PR TITLE
feat: add slippage validation on Settings page

### DIFF
--- a/widget/embedded/src/constants/swapSettings.ts
+++ b/widget/embedded/src/constants/swapSettings.ts
@@ -8,6 +8,6 @@ export const DEFAULT_SLIPPAGE = 1;
 
 export const HIGH_SLIPPAGE = 5;
 
-export const MAX_SLIPPAGE = 100;
+export const MAX_SLIPPAGE = 30;
 
-export const MIN_SLIPPGAE = 0;
+export const MIN_SLIPPAGE = 0;

--- a/widget/embedded/src/store/slices/settings.ts
+++ b/widget/embedded/src/store/slices/settings.ts
@@ -30,7 +30,6 @@ export interface SettingsSlice {
   affiliatePercent: number | null;
   affiliateWallets: { [key: string]: string } | null;
   _customTokens: Token[];
-
   setSlippage: (slippage: number) => void;
   setCustomSlippage: (customSlippage: number | null) => void;
   toggleInfiniteApprove: () => void;
@@ -70,7 +69,6 @@ export const createSettingsSlice: StateCreator<
   affiliatePercent: null,
   affiliateWallets: null,
   _customTokens: [],
-
   addPreferredBlockchain: (blockchain) => {
     const currentPreferredBlockchains = get().preferredBlockchains;
 

--- a/widget/embedded/src/utils/settings.ts
+++ b/widget/embedded/src/utils/settings.ts
@@ -1,6 +1,14 @@
 import type { Features, Routing } from '../types';
 import type { SwapperMeta, SwapperType, Token } from 'rango-sdk';
 
+import { i18n } from '@lingui/core';
+
+import {
+  HIGH_SLIPPAGE,
+  MAX_SLIPPAGE,
+  MIN_SLIPPAGE,
+} from '../constants/swapSettings';
+
 import { removeDuplicateFrom } from './common';
 
 export type UniqueSwappersGroupType = {
@@ -87,3 +95,23 @@ export const addCustomTokensToSupportedTokens = (
     ? supportedTokens
     : supportedTokens.concat(customTokens);
 };
+
+export function getSlippageValidation(
+  slippage: number
+): { type: 'error' | 'warning'; message: string } | null {
+  if (slippage == MIN_SLIPPAGE) {
+    return {
+      type: 'error',
+      message: i18n.t('Slippage must be greater than or equal to 0.01'),
+    };
+  } else if (slippage > HIGH_SLIPPAGE && slippage <= MAX_SLIPPAGE) {
+    return {
+      type: 'warning',
+      message: i18n.t(
+        'Your transaction is at risk of being frontrun due to high slippage tolerance.'
+      ),
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
# Summary

Four different ranges are defined for the slippage value:

**Error: x < 0.01**
- Show an error alert. This occurs only when the slippage value is 0.

**Standard: 0.01 ≤ x ≤ 5**
- No alerts. Acceptable range.

**High: 5 < x ≤ 30**
- Show a warning alert.

**Unacceptable: x > 30**
- Automatically set slippage to 30.
---------------------------------------------------------------------------------------------

- Limit the slippage input to a maximum of two decimal places.
- Ensure all visual feedback (error/warning alerts) is properly handled for both light and dark modes.



# Checklist:

- [ ] I have performed a self-review of my code
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
