### PR TITLE
feat: add namespace connect and disconnect and get state

### DIFF
--- a/wallets/react/src/legacy/context.ts
+++ b/wallets/react/src/legacy/context.ts
@@ -2,34 +2,34 @@ import type { ProviderContext } from './types.js';
 
 import { createContext } from 'react';
 
-const defaultErrorMesssage = "Context hasn't been initialized yet.";
+const defaultErrorMessage = "Context hasn't been initialized yet.";
 const defaultContext: ProviderContext = {
   async connect() {
-    throw new Error(defaultErrorMesssage);
+    throw new Error(defaultErrorMessage);
   },
   async disconnect() {
-    throw new Error(defaultErrorMesssage);
+    throw new Error(defaultErrorMessage);
   },
   async disconnectAll() {
-    throw new Error(defaultErrorMesssage);
+    throw new Error(defaultErrorMessage);
   },
   async suggestAndConnect() {
-    throw new Error(defaultErrorMesssage);
+    throw new Error(defaultErrorMessage);
   },
   state() {
-    throw new Error(defaultErrorMesssage);
+    throw new Error(defaultErrorMessage);
   },
   canSwitchNetworkTo() {
-    throw new Error(defaultErrorMesssage);
+    throw new Error(defaultErrorMessage);
   },
   providers() {
-    throw new Error(defaultErrorMesssage);
+    throw new Error(defaultErrorMessage);
   },
   getWalletInfo() {
-    throw new Error(defaultErrorMesssage);
+    throw new Error(defaultErrorMessage);
   },
   getSigners() {
-    throw new Error(defaultErrorMesssage);
+    throw new Error(defaultErrorMessage);
   },
 };
 

--- a/wallets/react/src/legacy/types.ts
+++ b/wallets/react/src/legacy/types.ts
@@ -8,6 +8,8 @@ import type {
   LegacyState as WalletState,
   LegacyWalletType as WalletType,
 } from '@rango-dev/wallets-core/legacy';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { NamespaceData } from '@rango-dev/wallets-core/store';
 import type { BlockchainMeta, SignerFactory } from 'rango-types';
 import type { PropsWithChildren } from 'react';
 
@@ -38,10 +40,12 @@ export type ProviderContext = {
     type: WalletType,
     namespaces?: LegacyNamespaceInputForConnect[]
   ): Promise<ConnectResult[]>;
-  disconnect(type: WalletType): Promise<void>;
+  disconnect(type: WalletType, namespaces?: Namespace[]): Promise<void>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   disconnectAll(): Promise<PromiseSettledResult<any>[]>;
-  state(type: WalletType): WalletState;
+  state(
+    type: WalletType
+  ): WalletState & { namespaces?: Map<Namespace, NamespaceData> };
   canSwitchNetworkTo(type: WalletType, network: Network): boolean;
   /**
    * `Provider` in legacy terms means injected instances by wallets into window (e.g. window.ethereum)

--- a/wallets/react/src/legacy/useLegacyProviders.ts
+++ b/wallets/react/src/legacy/useLegacyProviders.ts
@@ -19,6 +19,9 @@ import {
 import { useInitializers } from './hooks.js';
 import { useAutoConnect } from './useAutoConnect.js';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ProviderType = any;
+
 export type LegacyProviderProps = Omit<ProviderProps, 'providers'> & {
   providers: LegacyProviderInterface[];
 };
@@ -86,7 +89,7 @@ export function useLegacyProviders(
       }
     },
     async disconnectAll() {
-      const disconnect_promises: Promise<any>[] = [];
+      const disconnect_promises: Promise<void>[] = [];
 
       /*
        * When a wallet is initializing, a record will be added to `providersState`
@@ -134,7 +137,7 @@ export function useLegacyProviders(
         : false;
     },
     providers() {
-      const providers: { [type in WalletType]?: any } = {};
+      const providers: { [type in WalletType]?: ProviderType } = {};
       availableWallets(providersState).forEach((type) => {
         const wallet = wallets.get(type);
         if (wallet) {

--- a/wallets/react/src/useProviders.ts
+++ b/wallets/react/src/useProviders.ts
@@ -42,18 +42,18 @@ function useProviders(props: ProviderProps) {
       }
       return legacyApi.canSwitchNetworkTo(type, network);
     },
-    async connect(type, network): Promise<ConnectResult[]> {
+    async connect(type, namespaces): Promise<ConnectResult[]> {
       const hubProvider = findProviderByType(hubProviders, type);
       if (hubProvider) {
-        return await hubApi.connect(type, network);
+        return await hubApi.connect(type, namespaces);
       }
 
-      return await legacyApi.connect(type, network);
+      return await legacyApi.connect(type, namespaces);
     },
-    async disconnect(type): Promise<void> {
+    async disconnect(type, namespaces): Promise<void> {
       const hubProvider = findProviderByType(hubProviders, type);
       if (hubProvider) {
-        return await hubApi.disconnect(type);
+        return await hubApi.disconnect(type, namespaces);
       }
 
       return await legacyApi.disconnect(type);


### PR DESCRIPTION
# Summary

Added `connectNamespace`, `disconnectNamespace`, `getNamespaceState` to hub adapter and also some small changes to `lastConnectedWallets` to be able to add some namespaces to already existing namespaces for a provider in storage.

# Related PRs

- https://github.com/rango-exchange/rango-client/pull/1093
- https://github.com/rango-exchange/rango-client/pull/1090

# How did you test this change?

It can be tested after adding detached modal in another PR.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
