### PR TITLE
fix: wrap the error to make sure it is rethrown in the switch network

### DIFF
--- a/wallets/core/src/namespaces/evm/utils.ts
+++ b/wallets/core/src/namespaces/evm/utils.ts
@@ -48,6 +48,10 @@ export async function switchOrAddNetwork(
       await suggestNetwork(instance, chain);
     }
 
+    if (error instanceof Error) {
+      throw error;
+    }
+
     /*
      * Wrap the error to ensure it's an instance of Error.
      * In the `connect` flow, we rethrow the error in `cleanAccountSubscriber` only if it's an instance of Error.

--- a/wallets/core/src/namespaces/evm/utils.ts
+++ b/wallets/core/src/namespaces/evm/utils.ts
@@ -34,7 +34,7 @@ export async function switchOrAddNetwork(
     const chainId = typeof chain === 'string' ? chain : chain.chainId;
     await switchNetwork(instance, chainId);
   } catch (switchError) {
-    const error = switchError as { code: number };
+    const error = switchError as { code: number; message: string };
 
     const NOT_FOUND_CHAIN_ERROR_CODE = 4902;
     if (
@@ -47,6 +47,12 @@ export async function switchOrAddNetwork(
        */
       await suggestNetwork(instance, chain);
     }
-    throw switchError;
+
+    /*
+     * Wrap the error to ensure it's an instance of Error.
+     * In the `connect` flow, we rethrow the error in `cleanAccountSubscriber` only if it's an instance of Error.
+     * If it's not, the error gets swallowed. This ensures proper error propagation.
+     */
+    throw new Error(error.message || 'Error encountered during network switch');
   }
 }


### PR DESCRIPTION
### Fix: prevent infinite loop on network switch cancellation in Trust Wallet

There was an issue with Trust Wallet where, when a user canceled the network switch request, 
the error was observed in the `or` branch of the `connect` action—specifically in `cleanAccountSubscriber`. 

However, the error wasn't rethrown because `cleanAccountSubscriber` only rethrows errors 
that are instances of `Error`. Since the cancellation error wasn't always a proper `Error` object, 
it got swallowed silently.

As a result, the task remained unblocked in the queue manager, but since no account was returned 
from `connect`, the queue manager kept retrying to switch networks, causing an infinite loop.

This PR wraps the caught error in a proper `Error` object to ensure it gets rethrown 
and handled correctly, preventing the loop.


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
