### PR TITLE
fix: optional namespace removal to prevent error for wallets without autoconnect

### DIFF
--- a/wallets/react/src/hub/lastConnectedWallets.ts
+++ b/wallets/react/src/hub/lastConnectedWallets.ts
@@ -119,12 +119,12 @@ export class LastConnectedWalletsFromStorage {
     const storageState = persistor.getItem(this.#storageKey) || {};
 
     const currentProviderNamespaces = storageState[providerId];
-    const newProviderNamespaces = currentProviderNamespaces.filter(
+    const newProviderNamespaces = currentProviderNamespaces?.filter(
       (namespace) => !namespaceIds.includes(namespace.namespace)
     );
 
     this.#removeWalletsFromHub([providerId]);
-    if (newProviderNamespaces.length > 0) {
+    if (newProviderNamespaces?.length > 0) {
       this.#addWalletToHub(providerId, newProviderNamespaces);
     }
   }


### PR DESCRIPTION
### Fix: prevent error on disconnect for wallets without auto-connect support

Wallets that do not support auto-connect are not stored in localStorage 
as part of the last connected wallets list. 

There was an error during disconnect, specifically when trying to filter 
the last connected wallets by the current wallet. Since there was no 
entry in localStorage for these wallets, the object was `undefined`, 
leading to a runtime error.

This PR makes the access to the last connected wallets optional, 
preventing the error when the value is missing.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
