### PR TITLE
feat: show slippage and rate in swap box

### DIFF
--- a/widget/embedded/src/components/NoResult/NoResult.tsx
+++ b/widget/embedded/src/components/NoResult/NoResult.tsx
@@ -26,7 +26,7 @@ import {
 } from './NoResult.styles';
 
 export function NoResult(props: PropTypes) {
-  const { fetch, error, size = 'small' } = props;
+  const { fetch, error, size = 'small', skipAlerts } = props;
   const disabledLiquiditySources = useAppStore().getDisabledLiquiditySources();
   const toggleAllLiquiditySources = useAppStore().toggleAllLiquiditySources;
 
@@ -37,6 +37,9 @@ export function NoResult(props: PropTypes) {
     () => toggleAllLiquiditySources(swappers, true),
     fetch
   );
+  if (skipAlerts) {
+    info.alert = null;
+  }
 
   return (
     <Container>

--- a/widget/embedded/src/components/NoResult/NoResult.types.ts
+++ b/widget/embedded/src/components/NoResult/NoResult.types.ts
@@ -4,6 +4,7 @@ export interface PropTypes {
   fetch: () => void;
   error: NoResultError | QuoteRequestFailed | null;
   size?: 'small' | 'large';
+  skipAlerts?: boolean;
 }
 
 type AlertAction = {

--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -263,7 +263,7 @@ export function Quote(props: QuoteProps) {
                             variant="body"
                             color="neutral900">
                             {i18n.t({
-                              id: 'Minimum required slippage: {minRequiredSlippage}',
+                              id: 'Minimum suggested slippage: {minRequiredSlippage}',
                               values: {
                                 ...(error?.type ===
                                   QuoteErrorType.INSUFFICIENT_SLIPPAGE && {

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers.ts
@@ -10,10 +10,17 @@ import { errorMessages } from '../../constants/errors';
 import { QuoteErrorType, QuoteWarningType } from '../../types';
 import { getPriceImpactLevel } from '../../utils/quote';
 
-type AlertInfo = {
+export type ActionType =
+  | 'show-info'
+  | 'change-settings'
+  | 'change-slippage'
+  | null;
+
+export type AlertInfo = {
   alertType: 'error' | 'warning';
   title: string;
-  action: 'show-info' | 'change-settings' | null;
+  action: ActionType;
+  actionButtonTitle: string | null;
 };
 
 export function makeAlerts(
@@ -24,7 +31,9 @@ export function makeAlerts(
     alertType: 'warning',
     title: '',
     action: null,
+    actionButtonTitle: null,
   };
+
   if (error) {
     alertInfo.alertType = 'error';
     if (error.type === QuoteErrorType.BRIDGE_LIMIT) {
@@ -38,7 +47,8 @@ export function makeAlerts(
           minRequiredSlippage: error.minRequiredSlippage,
         },
       });
-      alertInfo.action = 'change-settings';
+      alertInfo.action = 'change-slippage';
+      alertInfo.actionButtonTitle = i18n.t('Increase');
     }
 
     return alertInfo;
@@ -75,7 +85,9 @@ export function makeAlerts(
             minRequiredSlippage: warning.minRequiredSlippage,
           },
         });
-        alertInfo.action = 'change-settings';
+        alertInfo.action = 'change-slippage';
+        alertInfo.actionButtonTitle = i18n.t('Increase');
+
         break;
       }
       case QuoteWarningType.HIGH_SLIPPAGE: {
@@ -89,6 +101,19 @@ export function makeAlerts(
     }
 
     return alertInfo;
+  }
+  return null;
+}
+
+export function getRequiredSlippage(
+  warning: QuoteWarning | null,
+  error: BridgeLimitError | InsufficientSlippageError | null
+) {
+  if (error?.type === QuoteErrorType.INSUFFICIENT_SLIPPAGE) {
+    return Number(error.minRequiredSlippage);
+  }
+  if (warning?.type === QuoteWarningType.INSUFFICIENT_SLIPPAGE) {
+    return Number(warning.minRequiredSlippage);
   }
   return null;
 }

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.styles.ts
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.styles.ts
@@ -1,4 +1,4 @@
-import { darkTheme, styled } from '@rango-dev/ui';
+import { Button, darkTheme, styled } from '@rango-dev/ui';
 
 export const Alerts = styled('div', {
   width: '100%',
@@ -31,4 +31,13 @@ export const Action = styled('div', {
   padding: '$2',
   alignSelf: 'flex-start',
   cursor: 'pointer',
+});
+
+export const SwapButton = styled(Button, {
+  '& ._text': {
+    gap: '$5',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
 });

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.types.ts
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.types.ts
@@ -6,11 +6,13 @@ export interface PropTypes {
   showWarningModal: boolean;
   confirmationDisabled: boolean;
   couldChangeSettings: boolean;
+  skipAlerts?: boolean;
   refetchQuote: () => void;
   onOpenWarningModal: () => void;
   onCloseWarningModal: () => void;
   onConfirmWarningModal: () => void;
   onChangeSettings: () => void;
+  onChangeSlippage?: (slippage: number | null) => void;
 }
 
 type ModalPropTypesKeys = keyof Omit<PropTypes, 'extraSpace' | 'loading'>;

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/SlippageWariningModal.tsx
@@ -4,15 +4,16 @@ import type {
 } from '../../types';
 
 import { i18n } from '@lingui/core';
-import { Button, Divider, MessageBox, Typography } from '@rango-dev/ui';
+import { Button, Divider, MessageBox, WarningIcon } from '@rango-dev/ui';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { navigationRoutes } from '../../constants/navigationRoutes';
-import { useAppStore } from '../../store/AppStore';
 import { QuoteWarningType } from '../../types';
 import { getContainer } from '../../utils/common';
 import { WatermarkedModal } from '../common/WatermarkedModal';
+
+import { SwapButton } from './QuoteWarningsAndErrors.styles';
 
 type PropsTypes = {
   open: boolean;
@@ -23,26 +24,13 @@ type PropsTypes = {
 };
 
 export function SlippageWarningModal(props: PropsTypes) {
-  const { customSlippage, slippage } = useAppStore();
   const { open, onClose, onConfirm, warning, confirmationDisabled } = props;
   const navigate = useNavigate();
-  const userSlippage = customSlippage ?? slippage;
 
   return (
     <WatermarkedModal
       anchor="bottom"
       open={open}
-      prefix={
-        <Button
-          size="small"
-          id="widget-slippage-warning-modal-change-settings-btn"
-          variant="ghost"
-          onClick={() => navigate('../' + navigationRoutes.settings)}>
-          <Typography variant="label" size="medium" color="$neutral900">
-            {i18n.t('Change settings')}
-          </Typography>
-        </Button>
-      }
       container={getContainer()}
       onClose={onClose}>
       <MessageBox
@@ -54,10 +42,9 @@ export function SlippageWarningModal(props: PropsTypes) {
         }
         description={
           warning.type === QuoteWarningType.HIGH_SLIPPAGE
-            ? i18n.t({
-                id: ' Caution, your slippage is high (={userSlippage}). Your trade may be front run.',
-                values: { userSlippage },
-              })
+            ? i18n.t(
+                'Caution, your slippage is high. Your trade may be front run.'
+              )
             : i18n.t({
                 id: 'We recommend you to increase slippage to at least {minRequiredSlippage} for this route.',
                 values: {
@@ -67,7 +54,7 @@ export function SlippageWarningModal(props: PropsTypes) {
         }>
         <Divider size={18} />
         <Divider size={32} />
-        <Button
+        <SwapButton
           id="widget-slippage-warning-modal-confirm-anyway-btn"
           size="large"
           type="primary"
@@ -75,7 +62,19 @@ export function SlippageWarningModal(props: PropsTypes) {
           fullWidth
           disabled={confirmationDisabled}
           onClick={onConfirm}>
-          {i18n.t('Confirm anyway')}
+          <WarningIcon color="white" size={16} />
+          {i18n.t('Swap anyway')}
+        </SwapButton>
+        <Divider size={10} />
+        <Button
+          id="widget-slippage-warning-modal-change-slippage-btn"
+          size="large"
+          type="primary"
+          variant="outlined"
+          fullWidth
+          disabled={confirmationDisabled}
+          onClick={() => navigate('../' + navigationRoutes.settings)}>
+          {i18n.t('Change Slippage')}
         </Button>
       </MessageBox>
     </WatermarkedModal>

--- a/widget/embedded/src/components/Slippage/Slippage.styles.ts
+++ b/widget/embedded/src/components/Slippage/Slippage.styles.ts
@@ -32,3 +32,26 @@ export const SlippageChip = styled(Chip, {
   width: '61px',
   flexShrink: 0,
 });
+
+export const SlippageTextFieldContainer = styled('div', {
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderRadius: '$xs',
+  flex: 1,
+  variants: {
+    status: {
+      safe: {
+        borderColor: '$secondary500',
+      },
+      error: {
+        borderColor: '$error500',
+      },
+      warning: {
+        borderColor: '$warning500',
+      },
+      empty: {
+        borderWidth: 0,
+      },
+    },
+  },
+});

--- a/widget/embedded/src/components/Slippage/Slippage.tsx
+++ b/widget/embedded/src/components/Slippage/Slippage.tsx
@@ -20,6 +20,7 @@ import {
   Head,
   SlippageChip,
   SlippageChipsContainer,
+  SlippageTextFieldContainer,
 } from './Slippage.styles';
 import { SlippageTooltipContent } from './SlippageTooltipContent';
 
@@ -90,26 +91,31 @@ export function Slippage() {
             />
           );
         })}
-        <TextField
-          type="number"
-          min="0.01"
-          max="30"
-          step="0.01"
-          onInput={onInput}
-          fullWidth
-          variant="contained"
-          value={customSlippage === null ? '' : customSlippage}
-          color="dark"
-          onChange={onSlippageValueChange}
-          suffix={
-            customSlippage && (
-              <Typography variant="body" size="small">
-                %
-              </Typography>
-            )
-          }
-          placeholder={i18n.t('Custom')}
-        />
+        <SlippageTextFieldContainer
+          status={
+            slippageValidation?.type || (customSlippage ? 'safe' : 'empty')
+          }>
+          <TextField
+            type="number"
+            min="0.01"
+            max="30"
+            step="0.01"
+            onInput={onInput}
+            fullWidth
+            variant="contained"
+            value={customSlippage === null ? '' : customSlippage}
+            color="dark"
+            onChange={onSlippageValueChange}
+            suffix={
+              customSlippage && (
+                <Typography variant="body" size="small">
+                  %
+                </Typography>
+              )
+            }
+            placeholder={i18n.t('Custom')}
+          />
+        </SlippageTextFieldContainer>
       </SlippageChipsContainer>
 
       {slippageValidation && (

--- a/widget/embedded/src/components/SlippageWarningsAndErrors/SlippageWarningsAndErrors.helpers.ts
+++ b/widget/embedded/src/components/SlippageWarningsAndErrors/SlippageWarningsAndErrors.helpers.ts
@@ -1,0 +1,33 @@
+import type { AlertInfo } from '../QuoteWarningsAndErrors/QuoteWarningsAndErrors.helpers';
+
+import { i18n } from '@lingui/core';
+
+import { HIGH_SLIPPAGE, MIN_SLIPPAGE } from '../../constants/swapSettings';
+
+export type ActionType = AlertInfo['action'] | 'reset-slippage';
+
+type Alert = Omit<AlertInfo, 'action'> & {
+  action: ActionType;
+};
+
+export function makeAlerts(slippage: number): Alert | null {
+  let alertInfo: Alert | null = null;
+  if (slippage === MIN_SLIPPAGE) {
+    alertInfo = {
+      alertType: 'error',
+      action: 'reset-slippage',
+      actionButtonTitle: i18n.t('Reset'),
+      title: i18n.t('Slippage cannot be set lower than 0.01%.'),
+    };
+    return alertInfo;
+  } else if (slippage > HIGH_SLIPPAGE) {
+    alertInfo = {
+      alertType: 'warning',
+      action: 'change-settings',
+      actionButtonTitle: i18n.t('Change'),
+      title: i18n.t('Caution, your slippage is high!'),
+    };
+    return alertInfo;
+  }
+  return null;
+}

--- a/widget/embedded/src/components/SlippageWarningsAndErrors/SlippageWarningsAndErrors.tsx
+++ b/widget/embedded/src/components/SlippageWarningsAndErrors/SlippageWarningsAndErrors.tsx
@@ -1,0 +1,48 @@
+import type { ActionType } from './SlippageWarningsAndErrors.helpers';
+import type { PropTypes } from './SlippageWarningsAndErrors.types';
+
+import { Alert, Button } from '@rango-dev/ui';
+import React from 'react';
+
+import { DEFAULT_SLIPPAGE } from '../../constants/swapSettings';
+import { useAppStore } from '../../store/AppStore';
+
+import { makeAlerts } from './SlippageWarningsAndErrors.helpers';
+
+export function SlippageWarningsAndErrors(props: PropTypes) {
+  const { slippage, customSlippage, setSlippage, setCustomSlippage } =
+    useAppStore();
+  const { onChangeSettings } = props;
+  const currentSlippage = customSlippage !== null ? customSlippage : slippage;
+
+  const alertInfo = makeAlerts(currentSlippage);
+
+  const onClickActionButton = (action: ActionType) => {
+    if (action === 'reset-slippage') {
+      setSlippage(DEFAULT_SLIPPAGE);
+      setCustomSlippage(null);
+    } else if (action === 'change-settings') {
+      onChangeSettings();
+    }
+  };
+
+  if (!alertInfo) {
+    return null;
+  }
+  return (
+    <Alert
+      title={alertInfo.title}
+      type={alertInfo.alertType}
+      variant="alarm"
+      action={
+        <Button
+          id="widget-slippage-warning-error-change-settings-or-reset-slippage-btn"
+          size="xxsmall"
+          type={alertInfo.alertType}
+          onClick={() => onClickActionButton(alertInfo.action)}>
+          {alertInfo.actionButtonTitle}
+        </Button>
+      }
+    />
+  );
+}

--- a/widget/embedded/src/components/SlippageWarningsAndErrors/SlippageWarningsAndErrors.types.ts
+++ b/widget/embedded/src/components/SlippageWarningsAndErrors/SlippageWarningsAndErrors.types.ts
@@ -1,0 +1,3 @@
+export interface PropTypes {
+  onChangeSettings: () => void;
+}

--- a/widget/embedded/src/components/SwapMetrics/SwapMetrics.constants.ts
+++ b/widget/embedded/src/components/SwapMetrics/SwapMetrics.constants.ts
@@ -1,0 +1,4 @@
+export const USD_FORMAT_DECIMALS = 2;
+export const USD_EXCHANGE_MINIMUM = 0.001;
+export const SMALL_VALUE_DECIMALS = 14;
+export const LARGE_VALUE_MAX_DIGITS = 10;

--- a/widget/embedded/src/components/SwapMetrics/SwapMetrics.helpers.ts
+++ b/widget/embedded/src/components/SwapMetrics/SwapMetrics.helpers.ts
@@ -1,0 +1,76 @@
+import type { SlippageColorParams } from './SwapMetrics.types';
+
+import BigNumber from 'bignumber.js';
+
+import { QuoteErrorType, QuoteWarningType } from '../../types';
+
+import {
+  LARGE_VALUE_MAX_DIGITS,
+  SMALL_VALUE_DECIMALS,
+  USD_EXCHANGE_MINIMUM,
+  USD_FORMAT_DECIMALS,
+} from './SwapMetrics.constants';
+
+export function getSlippageColor(params: SlippageColorParams) {
+  const { error, isDarkTheme, warning } = params;
+  const { quoteError, slippageError } = error;
+  const { quoteWarning, slippageWarning } = warning;
+  const hasSlippageError =
+    !!slippageError ||
+    quoteError?.type === QuoteErrorType.INSUFFICIENT_SLIPPAGE;
+  const hasSlippageWarning =
+    !!slippageWarning ||
+    quoteWarning?.type === QuoteWarningType.INSUFFICIENT_SLIPPAGE;
+
+  if (hasSlippageError) {
+    return '$error500';
+  } else if (hasSlippageWarning) {
+    return '$warning500';
+  }
+  if (isDarkTheme) {
+    return '$neutral600';
+  }
+  return '$neutral700';
+}
+
+export function getUsdExchangeRate(params: {
+  toTokenUsdPrice: number | null;
+  fromTokenUsdPrice: number | null;
+}) {
+  const { toTokenUsdPrice, fromTokenUsdPrice } = params;
+  if (!toTokenUsdPrice || !fromTokenUsdPrice) {
+    return { rawValue: '0', displayValue: '0' };
+  }
+
+  const toPrice = new BigNumber(toTokenUsdPrice);
+  const fromPrice = new BigNumber(fromTokenUsdPrice);
+  const rawValue = toPrice.dividedBy(fromPrice);
+  let displayValue: string;
+
+  if (rawValue.isLessThan(1)) {
+    displayValue = rawValue.toFixed(SMALL_VALUE_DECIMALS);
+  } else if (rawValue.toFixed(0).length > LARGE_VALUE_MAX_DIGITS) {
+    displayValue = rawValue.toFixed(0).slice(0, LARGE_VALUE_MAX_DIGITS);
+  } else {
+    displayValue = rawValue.toFixed(USD_FORMAT_DECIMALS);
+  }
+  return {
+    displayValue,
+    rawValue: rawValue.toFixed(),
+  };
+}
+
+export function formatTokenValueInUsd(
+  usdExchangeRate: number,
+  tokenUsdPrice: number
+): string {
+  const value = new BigNumber(usdExchangeRate).multipliedBy(tokenUsdPrice);
+  if (value.isLessThan(USD_EXCHANGE_MINIMUM)) {
+    return '$0';
+  }
+  const result = value
+    .decimalPlaces(USD_FORMAT_DECIMALS, BigNumber.ROUND_DOWN)
+    .toFormat(USD_FORMAT_DECIMALS);
+
+  return `$${result}`;
+}

--- a/widget/embedded/src/components/SwapMetrics/SwapMetrics.styles.ts
+++ b/widget/embedded/src/components/SwapMetrics/SwapMetrics.styles.ts
@@ -1,0 +1,32 @@
+import { darkTheme, styled, Typography } from '@rango-dev/ui';
+
+export const Container = styled('div', {
+  display: 'flex',
+  padding: '$4',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+});
+
+export const Rate = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '$2',
+  '& .rate-text': {
+    color: '$neutral700',
+    [`.${darkTheme} &`]: {
+      color: '$neutral700',
+    },
+  },
+  '& ._icon-button': {
+    transform: 'rotate(90deg)',
+    width: '$16',
+    height: '$16',
+  },
+});
+
+export const TokenName = styled(Typography, {
+  maxWidth: '$32',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});

--- a/widget/embedded/src/components/SwapMetrics/SwapMetrics.tsx
+++ b/widget/embedded/src/components/SwapMetrics/SwapMetrics.tsx
@@ -1,0 +1,134 @@
+import type { PropTypes } from './SwapMetrics.types';
+
+import { i18n } from '@lingui/core';
+import {
+  IconButton,
+  ReverseIcon,
+  Skeleton,
+  Tooltip,
+  Typography,
+} from '@rango-dev/ui';
+import React from 'react';
+
+import { useTheme } from '../../hooks/useTheme';
+import { useAppStore } from '../../store/AppStore';
+import { getContainer } from '../../utils/common';
+import { getSlippageValidation } from '../../utils/settings';
+
+import {
+  formatTokenValueInUsd,
+  getSlippageColor,
+  getUsdExchangeRate,
+} from './SwapMetrics.helpers';
+import { Container, Rate, TokenName } from './SwapMetrics.styles';
+
+export function SwapMetrics(props: PropTypes) {
+  const { slippage, customSlippage, quoteTokensRate, changeQuoteTokensRate } =
+    useAppStore();
+  const {
+    quoteError,
+    quoteWarning,
+    fromToken: initialFromToken,
+    toToken: initialToToken,
+    quote,
+    loading,
+  } = props;
+  const currentSlippage = customSlippage !== null ? customSlippage : slippage;
+  const { mode } = useTheme({});
+  const slippageValidation = getSlippageValidation(currentSlippage);
+  const isDarkTheme = mode === 'dark';
+  const isDefaultRate = quoteTokensRate === 'default';
+
+  const error = {
+    quoteError,
+    slippageError:
+      slippageValidation?.type === 'error' ? slippageValidation.message : null,
+  };
+  const warning = {
+    quoteWarning,
+    slippageWarning:
+      slippageValidation?.type === 'warning'
+        ? slippageValidation.message
+        : null,
+  };
+
+  const sourceToken = quote?.swaps[0].from || initialFromToken;
+  const destinationToken =
+    quote?.swaps[quote?.swaps.length - 1].to || initialToToken;
+
+  const fromToken = isDefaultRate ? sourceToken : destinationToken;
+  const toToken = isDefaultRate ? destinationToken : sourceToken;
+
+  const fromAmount = Number(
+    isDefaultRate ? quote?.outputAmount : quote?.requestAmount
+  );
+  const toAmount = Number(
+    isDefaultRate ? quote?.requestAmount : quote?.outputAmount
+  );
+
+  const fromTokenUsdPrice = fromAmount || fromToken.usdPrice;
+  const toTokenUsdPrice = toAmount || toToken.usdPrice;
+
+  const { rawValue: rawExchangeRate, displayValue: displayExchangeRate } =
+    getUsdExchangeRate({
+      toTokenUsdPrice,
+      fromTokenUsdPrice,
+    });
+
+  return (
+    <Container>
+      <Typography
+        variant={!!error || !!warning ? 'label' : 'body'}
+        size={!!error || !!warning ? 'medium' : 'small'}
+        color={getSlippageColor({ error, warning, isDarkTheme })}>
+        {i18n.t('Slippage:')} {currentSlippage}%
+      </Typography>
+      {loading ? (
+        <Skeleton height={16} width={104} variant="rounded" />
+      ) : (
+        fromTokenUsdPrice &&
+        toTokenUsdPrice && (
+          <Rate>
+            <Typography className="rate-text" variant="body" size="small">
+              1
+            </Typography>
+            <TokenName className="rate-text" variant="body" size="small">
+              {toToken.symbol}
+            </TokenName>
+            <IconButton
+              id="widget-home-page-change-rate-button"
+              onClick={changeQuoteTokensRate}>
+              <ReverseIcon size={14} color="secondary" />
+            </IconButton>
+            <Tooltip
+              container={getContainer()}
+              side="top"
+              sideOffset={4}
+              content={
+                <Typography className="rate-text" variant="body" size="small">
+                  {rawExchangeRate}
+                </Typography>
+              }>
+              <Typography className="rate-text" variant="body" size="small">
+                {displayExchangeRate}
+              </Typography>
+            </Tooltip>
+
+            <TokenName className="rate-text" variant="body" size="small">
+              {fromToken.symbol}
+            </TokenName>
+            {fromToken.usdPrice && (
+              <Typography color="neutral600" variant="body" size="small">
+                ~
+                {formatTokenValueInUsd(
+                  Number(rawExchangeRate),
+                  fromToken.usdPrice
+                )}
+              </Typography>
+            )}
+          </Rate>
+        )
+      )}
+    </Container>
+  );
+}

--- a/widget/embedded/src/components/SwapMetrics/SwapMetrics.types.ts
+++ b/widget/embedded/src/components/SwapMetrics/SwapMetrics.types.ts
@@ -1,0 +1,26 @@
+import type { QuoteError, QuoteWarning, SelectedQuote } from '../../types';
+import type { TokenData } from '../TokenList/TokenList.types';
+import type { SwapResultAsset } from 'rango-sdk';
+
+export interface PropTypes {
+  quoteError: QuoteError | null;
+  quoteWarning: QuoteWarning | null;
+  fromToken: TokenData;
+  toToken: TokenData;
+  quote: SelectedQuote | null;
+  loading: boolean;
+}
+
+export type Tokens = {
+  to: TokenData | SwapResultAsset;
+  from: TokenData | SwapResultAsset;
+};
+
+export type SlippageColorParams = {
+  error: { quoteError: QuoteError | null; slippageError: string | null };
+  warning: {
+    quoteWarning: QuoteWarning | null;
+    slippageWarning: string | null;
+  };
+  isDarkTheme: boolean;
+};

--- a/widget/embedded/src/components/SwapMetrics/index.ts
+++ b/widget/embedded/src/components/SwapMetrics/index.ts
@@ -1,0 +1,1 @@
+export { SwapMetrics } from './SwapMetrics';

--- a/widget/embedded/src/hooks/useSwapInput.ts
+++ b/widget/embedded/src/hooks/useSwapInput.ts
@@ -205,7 +205,7 @@ export function useSwapInput({
       }
       return;
     }
-    if (!isPositiveNumber(inputAmount) || inputUsdValue?.eq(0)) {
+    if (!isPositiveNumber(inputAmount) && inputUsdValue?.eq(0)) {
       resetState(false);
       cancelFetch();
       return;

--- a/widget/embedded/src/pages/ConfirmSwapPage.tsx
+++ b/widget/embedded/src/pages/ConfirmSwapPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-magic-numbers */
 import type {
   ConfirmSwap,
   ConfirmSwapFetchResult,
@@ -29,6 +28,7 @@ import { useConfirmSwap } from '../hooks/useConfirmSwap';
 import { useAppStore } from '../store/AppStore';
 import { useQuoteStore } from '../store/quote';
 import { useUiStore } from '../store/ui';
+import { QuoteErrorType, QuoteWarningType } from '../types';
 import { isQuoteWarningConfirmationRequired } from '../utils/quote';
 import { joinList } from '../utils/ui';
 
@@ -121,6 +121,7 @@ export function ConfirmSwapPage() {
           setInputAmount('');
         }, 0);
       } catch (e) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         setDbErrorMessage('Error: ' + (e as any)?.message);
       }
     }
@@ -209,6 +210,10 @@ export function ConfirmSwapPage() {
         error={quoteError}
         couldChangeSettings={false}
         refetchQuote={onRefresh}
+        skipAlerts={
+          quoteError?.type === QuoteErrorType.INSUFFICIENT_SLIPPAGE ||
+          quoteWarning?.type === QuoteWarningType.INSUFFICIENT_SLIPPAGE
+        }
         showWarningModal={showQuoteWarningModal}
         confirmationDisabled={!isActiveTab}
         onOpenWarningModal={() => setShowQuoteWarningModal(true)}

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -10,6 +10,8 @@ import { HeaderButtons } from '../components/HeaderButtons';
 import { Layout, PageContainer } from '../components/Layout';
 import { QuoteWarningsAndErrors } from '../components/QuoteWarningsAndErrors';
 import { SameTokensWarning } from '../components/SameTokensWarning';
+import { SlippageWarningsAndErrors } from '../components/SlippageWarningsAndErrors/SlippageWarningsAndErrors';
+import { SwapMetrics } from '../components/SwapMetrics';
 import { navigationRoutes } from '../constants/navigationRoutes';
 import { ExpandedQuotes } from '../containers/ExpandedQuotes';
 import { Inputs } from '../containers/Inputs';
@@ -22,6 +24,7 @@ import { useUiStore } from '../store/ui';
 import { UiEventTypes } from '../types';
 import { isVariantExpandable } from '../utils/configs';
 import { emitPreventableEvent } from '../utils/events';
+import { getSlippageValidation } from '../utils/settings';
 import { getSwapButtonState, isTokensIdentical } from '../utils/swap';
 
 const MainContainer = styled('div', {
@@ -50,6 +53,7 @@ export function Home() {
     setQuoteWarningsConfirmed,
     updateQuotePartialState,
   } = useQuoteStore();
+
   const [isVisibleExpanded, setIsVisibleExpanded] = useState<boolean>(false);
   const { isLargeScreen, isExtraLargeScreen } = useScreenDetect();
 
@@ -58,10 +62,17 @@ export function Home() {
     config,
     fetchStatus: fetchMetaStatus,
     connectedWallets,
+    customSlippage,
+    slippage,
+    setSlippage,
+    setCustomSlippage,
   } = useAppStore();
 
   const { isActiveTab } = useUiStore();
   const [showQuoteWarningModal, setShowQuoteWarningModal] = useState(false);
+  const currentSlippage = customSlippage !== null ? customSlippage : slippage;
+
+  const slippageValidation = getSlippageValidation(currentSlippage);
 
   const needsToWarnEthOnPath = false;
 
@@ -91,19 +102,16 @@ export function Home() {
 
   const fetchingQuote = hasInputs && fetchMetaStatus === 'success' && loading;
 
+  const currentQuoteWarning =
+    slippageValidation?.quoteValidation || quoteWarning;
+
   const hasValidQuotes =
     !isExpandable || (isExpandable && quotes?.results.length);
-  const hasWarningOrError = quoteWarning || quoteError;
+  const hasWarningOrError = currentQuoteWarning || quoteError;
   const showMessages = hasValidQuotes && hasWarningOrError;
 
-  useEffect(() => {
-    resetQuoteWallets();
-    updateQuotePartialState('refetchQuote', true);
-  }, []);
-
-  useEffect(() => {
-    setIsVisibleExpanded(hasInputs);
-  }, [hasInputs]);
+  const showSwapMetrics = !!fromToken && !!toToken;
+  const showSlippageAlerts = showSwapMetrics && !!slippageValidation;
 
   const onClickRefresh =
     (!!selectedQuote || quoteError) && !showQuoteWarningModal
@@ -126,6 +134,22 @@ export function Home() {
       setSelectedQuote(quote);
     }
   };
+
+  const onChangeSlippage = (slippage: number | null) => {
+    if (slippage) {
+      setSlippage(slippage);
+      setCustomSlippage(null);
+    }
+  };
+
+  useEffect(() => {
+    resetQuoteWallets();
+    updateQuotePartialState('refetchQuote', true);
+  }, []);
+
+  useEffect(() => {
+    setIsVisibleExpanded(hasInputs);
+  }, [hasInputs]);
 
   return (
     <MainContainer>
@@ -194,7 +218,7 @@ export function Home() {
               loading={fetchingQuote}
               error={quoteError}
               tagHidden={false}
-              warning={quoteWarning}
+              warning={currentQuoteWarning}
               type="basic"
               onClickAllRoutes={
                 !!quotes && quotes.results.length > 1
@@ -206,19 +230,33 @@ export function Home() {
               }
             />
           ) : null}
+          {showSwapMetrics && (
+            <>
+              <Divider size={8} />
+              <SwapMetrics
+                quoteError={quoteError}
+                quoteWarning={currentQuoteWarning}
+                fromToken={fromToken}
+                toToken={toToken}
+                quote={selectedQuote}
+                loading={fetchingQuote}
+              />
+            </>
+          )}
 
           {showMessages ? (
             <>
-              <Divider size="10" />
               <QuoteWarningsAndErrors
-                warning={quoteWarning}
+                warning={currentQuoteWarning}
                 error={quoteError}
+                skipAlerts={!!slippageValidation}
                 couldChangeSettings={true}
                 refetchQuote={fetchQuote}
                 showWarningModal={showQuoteWarningModal}
                 confirmationDisabled={!isActiveTab}
                 onOpenWarningModal={() => setShowQuoteWarningModal(true)}
                 onCloseWarningModal={() => setShowQuoteWarningModal(false)}
+                onChangeSlippage={onChangeSlippage}
                 onConfirmWarningModal={() => {
                   setShowQuoteWarningModal(false);
                   setQuoteWarningsConfirmed(true);
@@ -230,6 +268,17 @@ export function Home() {
               />
             </>
           ) : null}
+
+          {showSlippageAlerts && (
+            <>
+              <Divider size="10" />
+              <SlippageWarningsAndErrors
+                onChangeSettings={() =>
+                  onHandleNavigation(navigationRoutes.settings)
+                }
+              />
+            </>
+          )}
           <SameTokensWarning />
         </PageContainer>
       </Layout>

--- a/widget/embedded/src/store/app.ts
+++ b/widget/embedded/src/store/app.ts
@@ -46,6 +46,7 @@ export function createAppStore(initialData?: WidgetConfig) {
             infiniteApprove: state.infiniteApprove,
             preferredBlockchains: state.preferredBlockchains,
             disabledLiquiditySources: state.disabledLiquiditySources,
+            quoteTokensRate: state.quoteTokensRate,
           };
         },
         version: 1,

--- a/widget/embedded/src/store/slices/settings.ts
+++ b/widget/embedded/src/store/slices/settings.ts
@@ -16,6 +16,7 @@ import { isFeatureHidden } from '../../utils/settings';
 import { getSupportedBlockchainsFromConfig } from '../utils';
 
 export type ThemeMode = 'auto' | 'dark' | 'light';
+export type QuoteTokensRate = 'default' | 'reversed';
 
 export interface SettingsSlice {
   theme: ThemeMode;
@@ -30,6 +31,8 @@ export interface SettingsSlice {
   affiliatePercent: number | null;
   affiliateWallets: { [key: string]: string } | null;
   _customTokens: Token[];
+  quoteTokensRate: QuoteTokensRate;
+
   setSlippage: (slippage: number) => void;
   setCustomSlippage: (customSlippage: number | null) => void;
   toggleInfiniteApprove: () => void;
@@ -50,6 +53,7 @@ export interface SettingsSlice {
   setCustomToken: (token: TokenData) => void;
   deleteCustomToken: (token: Token) => void;
   customTokens: () => Token[];
+  changeQuoteTokensRate: () => void;
 }
 
 export const createSettingsSlice: StateCreator<
@@ -69,6 +73,13 @@ export const createSettingsSlice: StateCreator<
   affiliatePercent: null,
   affiliateWallets: null,
   _customTokens: [],
+  quoteTokensRate: 'default',
+
+  changeQuoteTokensRate: () =>
+    set((state) => ({
+      quoteTokensRate:
+        state.quoteTokensRate === 'default' ? 'reversed' : 'default',
+    })),
   addPreferredBlockchain: (blockchain) => {
     const currentPreferredBlockchains = get().preferredBlockchains;
 

--- a/widget/embedded/src/utils/settings.ts
+++ b/widget/embedded/src/utils/settings.ts
@@ -1,4 +1,4 @@
-import type { Features, Routing } from '../types';
+import type { Features, HighSlippageWarning, Routing } from '../types';
 import type { SwapperMeta, SwapperType, Token } from 'rango-sdk';
 
 import { i18n } from '@lingui/core';
@@ -8,6 +8,7 @@ import {
   MAX_SLIPPAGE,
   MIN_SLIPPAGE,
 } from '../constants/swapSettings';
+import { QuoteWarningType } from '../types';
 
 import { removeDuplicateFrom } from './common';
 
@@ -96,9 +97,11 @@ export const addCustomTokensToSupportedTokens = (
     : supportedTokens.concat(customTokens);
 };
 
-export function getSlippageValidation(
-  slippage: number
-): { type: 'error' | 'warning'; message: string } | null {
+export function getSlippageValidation(slippage: number): {
+  type: 'error' | 'warning';
+  message: string;
+  quoteValidation?: HighSlippageWarning;
+} | null {
   if (slippage == MIN_SLIPPAGE) {
     return {
       type: 'error',
@@ -110,6 +113,10 @@ export function getSlippageValidation(
       message: i18n.t(
         'Your transaction is at risk of being frontrun due to high slippage tolerance.'
       ),
+      quoteValidation: {
+        type: QuoteWarningType.HIGH_SLIPPAGE,
+        slippage: slippage.toString(),
+      },
     };
   }
 


### PR DESCRIPTION
# Summary

In this PR, the display of slippage-related warnings and errors on the swap page has been improved. The "Recommended Slippage" warning has also been removed from the swap confirmation page.

Additionally, a new row has been introduced to show both the slippage value (highlighted with appropriate warning or error styles) and the swap rate, which represents the conversion rate from the destination token to the source token.

Users can toggle the direction of the rate (i.e., switch between source and destination tokens), and their selected preference will persist unless manually changed.

Fixes # (issue)


# How did you test this change?

- [ ] Set the slippage to 0 — you should see an error with an option to reset the slippage to the default value.
- [ ] Set the slippage to a value between 5 and 30 — you should see a "High Slippage" warning.
- [ ] Set the slippage to a value lower than 1 and select the AVAX to DAI route — you should see a "Recommended Slippage" warning with an action to update the slippage to the recommended value.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
