### PR TITLE
feat: add wallet name to waiting for connect wallet warning message

### DIFF
--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -171,7 +171,7 @@ export function SwapDetails(props: SwapDetailsProps) {
       ])
     : undefined;
 
-  const stepMessage = getSwapMessages(swap, currentStep);
+  const stepMessage = getSwapMessages(swap, currentStep, getWalletInfo);
   const steps = getSteps({
     swap,
     switchNetwork,


### PR DESCRIPTION
# Summary

Updated the warning message related to step waiting for connecting wallet in swap details page from "Waiting for connecting wallet" to "Connect {walletName}".


# How did you test this change?

You can test this by observing the warning message in swap details page for a step which is blocked for connecting the required wallet.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
