### PR TITLE
fix: fix long token names in widget home page

### DIFF
--- a/widget/ui/src/containers/SwapInput/SwapInput.styles.ts
+++ b/widget/ui/src/containers/SwapInput/SwapInput.styles.ts
@@ -86,6 +86,10 @@ export const formStyles = css({
   alignItems: 'center',
 });
 
+export const TokenSectionContainer = styled('div', {
+  width: '60%',
+});
+
 export const labelStyles = css({
   display: 'flex',
   justifyContent: 'space-between',

--- a/widget/ui/src/containers/SwapInput/SwapInput.tsx
+++ b/widget/ui/src/containers/SwapInput/SwapInput.tsx
@@ -22,6 +22,7 @@ import {
   labelStyles,
   MaxButton,
   textStyles,
+  TokenSectionContainer,
   UsdPrice,
   ValueTypography,
 } from './SwapInput.styles.js';
@@ -83,22 +84,24 @@ export function SwapInput(props: SwapInputPropTypes) {
         </div>
       </div>
       <div className={formStyles()}>
-        <TokenSection
-          chain={props.chain.displayName}
-          chianImageId={
-            props.mode === 'To'
-              ? UI_ID.SWAP_TO_CHAIN_IMAGE_ID
-              : UI_ID.SWAP_FROM_CHAIN_IMAGE_ID
-          }
-          tokenSymbol={props.token.displayName}
-          error={props.error}
-          chainImage={props.chain.image}
-          tokenImage={props.token.image}
-          onClick={props.onClickToken}
-          loading={props.loading}
-          warning={props.token.securityWarning}
-          tooltipContainer={props.tooltipContainer}
-        />
+        <TokenSectionContainer>
+          <TokenSection
+            chain={props.chain.displayName}
+            chianImageId={
+              props.mode === 'To'
+                ? UI_ID.SWAP_TO_CHAIN_IMAGE_ID
+                : UI_ID.SWAP_FROM_CHAIN_IMAGE_ID
+            }
+            tokenSymbol={props.token.displayName}
+            error={props.error}
+            chainImage={props.chain.image}
+            tokenImage={props.token.image}
+            onClick={props.onClickToken}
+            loading={props.loading}
+            warning={props.token.securityWarning}
+            tooltipContainer={props.tooltipContainer}
+          />
+        </TokenSectionContainer>
         <div className={amountStyles()}>
           {props.loading || (props.mode === 'To' && props.fetchingQuote) ? (
             <>

--- a/widget/ui/src/containers/SwapInput/TokenSection.styles.ts
+++ b/widget/ui/src/containers/SwapInput/TokenSection.styles.ts
@@ -1,11 +1,15 @@
 import { ChainImageContainer } from '../../components/ChainToken/ChainToken.styles.js';
-import { Button } from '../../components/index.js';
+import {
+  Button,
+  type TooltipPropTypes,
+  Typography,
+} from '../../components/index.js';
 import { css, darkTheme, styled } from '../../theme.js';
 
 export const Container = styled(Button, {
+  width: '100%',
   maxWidth: '180px',
   minWidth: '130px',
-  flexGrow: 1,
   backgroundColor: 'transparent',
   borderRadius: '$xs',
 
@@ -39,11 +43,16 @@ export const Container = styled(Button, {
       backgroundColor: '$$color !important',
     },
   },
+
+  '& > span': {
+    width: '100%',
+  },
 });
 
 export const chainNameStyles = css();
 
 export const TokenSectionContainer = styled('div', {
+  width: '100%',
   maxWidth: '170px',
   padding: '$2 $5',
   display: 'flex',
@@ -68,6 +77,8 @@ export const tokenChainStyles = css({
   paddingLeft: '$10',
   flexGrow: 1,
   textAlign: 'left',
+  width: '100%',
+  overflow: 'hidden',
 });
 
 export const skeletonStyles = css({
@@ -76,8 +87,30 @@ export const skeletonStyles = css({
 });
 
 export const TitleContainer = styled('div', {
+  width: '100%',
   display: 'flex',
-  justifyContent: 'center',
   alignItems: 'center',
-  flexWrap: 'wrap',
+});
+
+export const Title = styled(Typography, {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+export const SymbolTooltipStyles: TooltipPropTypes['styles'] = {
+  content: {
+    padding: '$10',
+  },
+  root: {
+    zIndex: 10,
+    width: 'calc(100% - 18px)',
+    display: 'flex',
+    justifyContent: 'start',
+  },
+};
+
+export const SymbolTooltipContent = styled(Typography, {
+  maxWidth: 217,
+  lineBreak: 'anywhere',
 });

--- a/widget/ui/src/containers/SwapInput/TokenSection.tsx
+++ b/widget/ui/src/containers/SwapInput/TokenSection.tsx
@@ -8,6 +8,7 @@ import {
   ChainToken,
   Divider,
   Skeleton,
+  Tooltip,
   Typography,
 } from '../../components/index.js';
 
@@ -15,6 +16,9 @@ import {
   chainNameStyles,
   Container,
   skeletonStyles,
+  SymbolTooltipContent,
+  SymbolTooltipStyles,
+  Title,
   TitleContainer,
   tokenChainStyles,
   TokenSectionContainer,
@@ -33,6 +37,9 @@ export function TokenSection(props: TokenSectionProps) {
     warning,
     tooltipContainer,
   } = props;
+
+  const tokenSelected = !error && !loading && !!tokenSymbol;
+
   return (
     <Container variant="default" disabled={error || loading} onClick={onClick}>
       <TokenSectionContainer>
@@ -54,11 +61,28 @@ export function TokenSection(props: TokenSectionProps) {
           ) : (
             <>
               <TitleContainer>
-                <Typography variant="title" size="medium">
-                  {error || (!loading && !tokenSymbol)
-                    ? i18n.t('Select Token')
-                    : tokenSymbol}
-                </Typography>
+                {tokenSelected ? (
+                  <Tooltip
+                    styles={SymbolTooltipStyles}
+                    align="start"
+                    side="bottom"
+                    alignOffset={-15}
+                    sideOffset={15}
+                    container={tooltipContainer}
+                    content={
+                      <SymbolTooltipContent variant="body" size="xsmall">
+                        {tokenSymbol}
+                      </SymbolTooltipContent>
+                    }>
+                    <Title variant="title" size="medium">
+                      {tokenSymbol}
+                    </Title>
+                  </Tooltip>
+                ) : (
+                  <Typography variant="title" size="medium">
+                    {i18n.t('Select Token')}
+                  </Typography>
+                )}
                 {warning && (
                   <>
                     <Divider size={4} direction="horizontal" />


### PR DESCRIPTION
# Summary

Currently, on the homepage, token symbols with too many characters (such as some custom tokens) are not displayed properly, and in some cases, the alert for custom tokens may not appear. In this pull request, we've updated some styles to truncate long token symbols and ensure they are displayed correctly.

# How did you test this change?

You could test with these sample tokens:

- 0x8d546c8e41d6c7a25855d0d9a6e0ef5d3b66808b
- 0xdb8f3858d6750f5772b9c77770807d29ec0395cb

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
