### PR TITLE
fix: error rethrow in or cases

### DIFF
--- a/wallets/core/src/hub/namespaces/namespace.ts
+++ b/wallets/core/src/hub/namespaces/namespace.ts
@@ -422,13 +422,18 @@ class Namespace<T extends Actions<T>> {
         return orActions.reduce((prev, orAction) => {
           return orAction(context, prev);
         }, actionError);
-      } catch {
+      } catch (orActionError) {
+        if (orActionError instanceof Error) {
+          orActionError.cause = actionError;
+          throw orActionError;
+        }
         const errorMessage = OR_ELSE_ACTION_FAILED_ERROR(
           `${actionName.toString()} for ${this.namespaceId} namespace.`
         );
-        throw new Error(errorMessage, {
+        const standardOrActionError = new Error(String(orActionError), {
           cause: actionError,
         });
+        throw new Error(errorMessage, { cause: standardOrActionError });
       }
     } else {
       throw actionError;

--- a/wallets/core/src/namespaces/common/mod.ts
+++ b/wallets/core/src/namespaces/common/mod.ts
@@ -1,5 +1,6 @@
 export * as actions from './actions.js';
 export * as builders from './builders.js';
+export { standardizeAndThrowError } from './or.js';
 export {
   intoConnectionFinished,
   recommended as afterRecommended,

--- a/wallets/core/src/namespaces/common/or.ts
+++ b/wallets/core/src/namespaces/common/or.ts
@@ -1,0 +1,32 @@
+import type { Context } from '../../hub/namespaces/mod.js';
+
+/**
+ * Standardizes an unknown error into an Error object and throws it.
+ * If the input is already an Error, it's thrown directly.
+ * Otherwise, a new Error is created with the input's message or string representation.
+ *
+ * @param context - The context.
+ * @param e - The unknown error object.
+ * @throws {Error} - The standardized Error object.
+ */
+export function standardizeAndThrowError(context: Context, e: unknown): never {
+  if (e instanceof Error) {
+    throw e;
+  }
+
+  let errorMessage: string;
+  if (
+    typeof e === 'object' &&
+    e !== null &&
+    'message' in e &&
+    typeof e.message === 'string'
+  ) {
+    errorMessage = e.message;
+  } else if (typeof e === 'string') {
+    errorMessage = e;
+  } else {
+    errorMessage = String(e);
+  }
+
+  throw new Error(errorMessage);
+}

--- a/wallets/core/src/namespaces/evm/actions.ts
+++ b/wallets/core/src/namespaces/evm/actions.ts
@@ -111,9 +111,7 @@ export function changeAccountSubscriber(
         evmInstance.removeListener('accountsChanged', eventCallback);
       }
 
-      if (err instanceof Error) {
-        throw err;
-      }
+      return err;
     },
   ];
 }

--- a/wallets/core/src/namespaces/solana/actions.ts
+++ b/wallets/core/src/namespaces/solana/actions.ts
@@ -51,9 +51,7 @@ export function changeAccountSubscriber(
       };
       solanaInstance.on('accountChanged', eventCallback);
 
-      if (err instanceof Error) {
-        throw err;
-      }
+      return err;
     },
     (_context, err) => {
       const solanaInstance = instance();
@@ -62,9 +60,7 @@ export function changeAccountSubscriber(
         solanaInstance.off('accountChanged', eventCallback);
       }
 
-      if (err instanceof Error) {
-        throw err;
-      }
+      return err;
     },
   ];
 }

--- a/wallets/core/src/namespaces/sui/actions.ts
+++ b/wallets/core/src/namespaces/sui/actions.ts
@@ -56,9 +56,7 @@ export function changeAccountSubscriber(
         unsubscriber();
       }
 
-      if (err instanceof Error) {
-        throw err;
-      }
+      return err;
     },
   ];
 }

--- a/wallets/provider-phantom/src/namespaces/evm.ts
+++ b/wallets/provider-phantom/src/namespaces/evm.ts
@@ -1,7 +1,10 @@
 import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
 
 import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import { builders as commonBuilders } from '@rango-dev/wallets-core/namespaces/common';
+import {
+  builders as commonBuilders,
+  standardizeAndThrowError,
+} from '@rango-dev/wallets-core/namespaces/common';
 import { actions, builders } from '@rango-dev/wallets-core/namespaces/evm';
 
 import { WALLET_ID } from '../constants.js';
@@ -21,6 +24,7 @@ const connect = builders
   .action(actions.connect(evmPhantom))
   .before(changeAccountSubscriber)
   .or(changeAccountCleanup)
+  .or(standardizeAndThrowError)
   .build();
 
 const disconnect = commonBuilders

--- a/wallets/provider-phantom/src/namespaces/solana.ts
+++ b/wallets/provider-phantom/src/namespaces/solana.ts
@@ -2,7 +2,10 @@ import type { CaipAccount } from '@rango-dev/wallets-core/namespaces/common';
 import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
 
 import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import { builders as commonBuilders } from '@rango-dev/wallets-core/namespaces/common';
+import {
+  builders as commonBuilders,
+  standardizeAndThrowError,
+} from '@rango-dev/wallets-core/namespaces/common';
 import {
   actions,
   builders,
@@ -53,6 +56,7 @@ const connect = builders
   })
   .before(changeAccountSubscriber)
   .or(changeAccountCleanup)
+  .or(standardizeAndThrowError)
   .build();
 
 const disconnect = commonBuilders

--- a/wallets/provider-phantom/src/namespaces/sui.ts
+++ b/wallets/provider-phantom/src/namespaces/sui.ts
@@ -2,7 +2,10 @@ import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
 import type { SuiActions } from '@rango-dev/wallets-core/namespaces/sui';
 
 import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import { builders as commonBuilders } from '@rango-dev/wallets-core/namespaces/common';
+import {
+  builders as commonBuilders,
+  standardizeAndThrowError,
+} from '@rango-dev/wallets-core/namespaces/common';
 import { actions, builders } from '@rango-dev/wallets-core/namespaces/sui';
 
 import { WALLET_ID, WALLET_NAME_IN_WALLET_STANDARD } from '../constants.js';
@@ -20,6 +23,7 @@ const connect = builders
   })
   .before(changeAccountSubscriber)
   .or(changeAccountCleanup)
+  .or(standardizeAndThrowError)
   .build();
 
 const disconnect = commonBuilders

--- a/wallets/provider-phantom/src/namespaces/utxo.ts
+++ b/wallets/provider-phantom/src/namespaces/utxo.ts
@@ -1,4 +1,3 @@
-import type { CaipAccount } from '@rango-dev/wallets-core/namespaces/common';
 import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
 import type {
   ProviderAPI,
@@ -11,6 +10,10 @@ import {
   type Subscriber,
   type SubscriberCleanUp,
 } from '@rango-dev/wallets-core';
+import {
+  type CaipAccount,
+  standardizeAndThrowError,
+} from '@rango-dev/wallets-core/namespaces/common';
 import { builders as commonBuilders } from '@rango-dev/wallets-core/namespaces/common';
 import {
   builders,
@@ -106,9 +109,7 @@ function getChangeAccountSubscriber(
         bitcoinInstance.off('accountsChanged', eventCallback);
       }
 
-      if (err instanceof Error) {
-        throw err;
-      }
+      return err;
     },
   ];
 }
@@ -141,6 +142,7 @@ const connect = builders
   })
   .before(changeAccountSubscriber)
   .or(changeAccountCleanup)
+  .or(standardizeAndThrowError)
   .build();
 
 const disconnect = commonBuilders


### PR DESCRIPTION
# Summary


Some wallet providers, such as Trust Wallet, do not throw errors using the standard `Error` object. This behavior can lead to issues when attempting to catch and rethrow these errors consistently.

This update refactors the `tryRunOrOperators` function to capture the responses returned by `or` actions. If a response is an instance of `Error`, it is rethrown directly. If not, it is wrapped in a new `Error` object. This approach ensures that all `or` actions consistently return proper `Error` instances.

To support this change, the only existing `or` action, `cleanAccountSubscribers`, has been updated accordingly.


Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
