### PR TITLE
fix: avoid hub recreation

### DIFF
--- a/wallets/core/src/hub/hub.ts
+++ b/wallets/core/src/hub/hub.ts
@@ -80,6 +80,18 @@ export class Hub {
     this.#providers.set(id, provider);
     return this;
   }
+  remove(id: string) {
+    const providerToRemove = this.#providers.get(id);
+
+    if (!providerToRemove) {
+      throw new Error(`Provider not found: No provider exists with ID "${id}"`);
+    }
+
+    this.#options.store?.getState().providers.removeProvider(id);
+    this.#providers.delete(id);
+
+    return this;
+  }
 
   get(providerId: string): Provider | undefined {
     return this.#providers.get(providerId);
@@ -96,6 +108,7 @@ export class Hub {
     output.forEach((result) => {
       const namespaces: NamespaceState[] = [];
       result.namespaces.forEach((b) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const [getNamespaceState] = b as ReturnType<Namespace<any>['state']>;
 
         namespaces.push(getNamespaceState());

--- a/wallets/core/src/hub/provider/provider.test.ts
+++ b/wallets/core/src/hub/provider/provider.test.ts
@@ -16,6 +16,7 @@ describe('check providers', () => {
     evm: NamespaceBuilder<EvmActions>;
     solana: NamespaceBuilder<SolanaActions>;
   };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let namespacesMap: Map<any, any>;
   let store: Store;
 
@@ -39,6 +40,7 @@ describe('check providers', () => {
     return () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore-next-line
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
       (store = undefined), (namespaces = undefined);
     };
   });
@@ -52,7 +54,6 @@ describe('check providers', () => {
 
     expect(allNamespaces.size).toBe(2);
   });
-
   test("throw an error if store hasn't set and try to access .state() and .info()", () => {
     const provider = new Provider('garbage', namespacesMap, {
       info: garbageWalletInfo,

--- a/wallets/core/src/hub/provider/provider.ts
+++ b/wallets/core/src/hub/provider/provider.ts
@@ -296,10 +296,12 @@ export class Provider {
 
     this.#namespaces.forEach((namespace) => {
       if (hookName === 'after') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         namespace.after(actionName as any, cb, {
           context,
         });
       } else if (hookName === 'before') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         namespace.before(actionName as any, cb, {
           context,
         });

--- a/wallets/core/src/hub/store/providers.ts
+++ b/wallets/core/src/hub/store/providers.ts
@@ -73,6 +73,7 @@ type ProviderState = {
 };
 interface ProviderActions {
   addProvider: (id: string, config: ProviderConfig) => void;
+  removeProvider: (id: string) => void;
   updateStatus: <K extends keyof ProviderData>(
     id: string,
     key: K,
@@ -114,6 +115,13 @@ const providersStore: ProvidersStateCreator = (set, get) => ({
     set(
       produce((state: State) => {
         state.providers.list[id] = item;
+      })
+    );
+  },
+  removeProvider: (id) => {
+    set(
+      produce((state: State) => {
+        delete state.providers.list[id];
       })
     );
   },

--- a/wallets/core/src/hub/store/selectors.ts
+++ b/wallets/core/src/hub/store/selectors.ts
@@ -28,7 +28,7 @@ export function guessProviderStateSelector(
   );
 
   // Returning provider state value directly.
-  const installed = state.providers.list[providerId].data.installed;
+  const installed = !!state.providers.list[providerId]?.data.installed;
 
   /*
    * If any namespaces returns `true`, we consider the whole provider for this field to be `true`.

--- a/wallets/core/src/hub/store/store.test.ts
+++ b/wallets/core/src/hub/store/store.test.ts
@@ -29,4 +29,24 @@ describe('checking store', () => {
     expect(getState().providers.list[id]).toBeDefined();
     expect(Object.keys(getState().providers.list).length).toBe(1);
   });
+  test('provider can be removed from store', () => {
+    const id = 'sol-or-something';
+    const info = {
+      info: {
+        name: 'sol grabage wallet',
+        icon: 'http://somewhere.world',
+        extensions: {
+          homepage: 'http://somewhere.world',
+        },
+      },
+    };
+
+    const { getState } = hubStore;
+    getState().providers.addProvider(id, info);
+    expect(getState().providers.list[id]).toBeDefined();
+    expect(Object.keys(getState().providers.list).length).toBe(1);
+    getState().providers.removeProvider(id);
+    expect(getState().providers.list[id]).toBeUndefined();
+    expect(Object.keys(getState().providers.list).length).toBe(0);
+  });
 });

--- a/wallets/core/tests/hub.test.ts
+++ b/wallets/core/tests/hub.test.ts
@@ -60,4 +60,25 @@ describe('check hub', () => {
       'eip155:0x1:0x0000000000000000000000000000000000000000',
     ]);
   });
+  test('should remove wallet from both hub and store', async () => {
+    const garbageWalletBuilder = new ProviderBuilder(walletName).config(
+      'info',
+      garbageWalletInfo
+    );
+    const garbageWallet = garbageWalletBuilder.build();
+
+    const myHub = new Hub({
+      store,
+    }).add(garbageWallet.id, garbageWallet);
+
+    expect(myHub.get(garbageWallet.id)).toBe(garbageWallet);
+    expect(Object.entries(store.getState().providers.list)).toHaveLength(1);
+    expect(store.getState().providers.list[garbageWallet.id]).toBeTruthy();
+
+    myHub.remove(garbageWallet.id);
+
+    expect(myHub.get(garbageWallet.id)).toBeUndefined();
+    expect(Object.entries(store.getState().providers.list)).toHaveLength(0);
+    expect(store.getState().providers.list[garbageWallet.id]).toBeUndefined();
+  });
 });

--- a/wallets/react/src/hub/useHubRefs.ts
+++ b/wallets/react/src/hub/useHubRefs.ts
@@ -3,7 +3,7 @@ import type { Provider, Store } from '@rango-dev/wallets-core';
 import { createStore, Hub } from '@rango-dev/wallets-core';
 import { useRef } from 'react';
 
-import { checkProviderListsEquality } from './utils.js';
+import { synchronizeHubWithConfigProviders } from './utils.js';
 
 export function useHubRefs(providers: Provider[]) {
   const store = useRef<Store | null>(null);
@@ -38,14 +38,11 @@ export function useHubRefs(providers: Provider[]) {
   function getHub(): Hub {
     const hubProviders = hub.current?.getAll();
 
-    if (
-      !hub.current ||
-      !hubProviders ||
-      // If hub does not contain a provider, it should be added
-      !checkProviderListsEquality(Array.from(hubProviders.values()), providers)
-    ) {
+    if (!hub.current || !hubProviders) {
       return createHub();
     }
+
+    synchronizeHubWithConfigProviders(hub.current, providers);
     return hub.current;
   }
 


### PR DESCRIPTION
# Summary

Previously, in the `getHub` method, we checked if:
- the hub does not exist, **or**
- there is no hub provider,  
to decide whether to create a new hub.

However, there was a **third condition**: if the requested providers from the config did not match the available providers on the hub, we would also recreate the hub.

After investigating, we found the reason for this: sometimes, in the playground, the filter was changed, and the requested provider was not available on the hub anymore. Recreating the hub prevented errors indicating that a requested provider didn’t exist.  
**However, this approach reset the state of providers.**

In our first attempt to fix this, we tried re-initiating the providers:  
[Previous PR #1101](https://github.com/rango-exchange/rango-client/pull/1101)

But with that approach, the **connected state** was getting reset.

---

## Changes in this PR

- **Removed** the third condition in `getHub`.  
  Now, the hub will only be created if it doesn't exist.
- In the `providers` function of the adapter:
  - **First**, add any missing providers to the hub.
  - **Then**, filter the available providers on the hub to match the requested ones.

---

## Why?

This ensures:
- We no longer unnecessarily reset the connected state.
- We dynamically manage missing providers without needing to recreate the hub.
- A more stable and predictable provider state.

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
