### PR TITLE
fix: adjust the warning alert position for custom tokens on the homepage

### DIFF
--- a/widget/ui/src/containers/SwapInput/TokenSection.styles.ts
+++ b/widget/ui/src/containers/SwapInput/TokenSection.styles.ts
@@ -104,7 +104,7 @@ export const SymbolTooltipStyles: TooltipPropTypes['styles'] = {
   },
   root: {
     zIndex: 10,
-    width: 'calc(100% - 18px)',
+    maxWidth: 'calc(100% - 18px)',
     display: 'flex',
     justifyContent: 'start',
   },


### PR DESCRIPTION
# Summary

A large gap appears between the token symbol and the warning alert when there are few characters; this spacing should be removed : 
<img width="307" alt="5" src="https://github.com/user-attachments/assets/59e13c5f-10fa-41fc-b1ff-8170f6641d76" />

Fixes # (issue)

Use max-width instead of width for the token symbol element.

# How did you test this change?

Import custom tokens with symbols of varying lengths, including both short and long character counts:
29nZcMWKbq6kPr6icM9tLrYWQor2eACWr1ifrVU1pump
0xe95a392047c46359807e3fbb263492298bcd35f9

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
