### PR TITLE
feat: add derivation path to swap wallets

### DIFF
--- a/wallets/core/src/legacy/types.ts
+++ b/wallets/core/src/legacy/types.ts
@@ -156,6 +156,7 @@ export enum Events {
 export type ProviderConnectResult = {
   accounts: string[];
   chainId: string;
+  derivationPath?: string;
 };
 
 export type GetInstanceOptions = {

--- a/wallets/provider-ledger/src/helpers.ts
+++ b/wallets/provider-ledger/src/helpers.ts
@@ -1,7 +1,11 @@
 import type Transport from '@ledgerhq/hw-transport';
 
 import { getAltStatusMessage } from '@ledgerhq/errors';
-import { ETHEREUM_CHAIN_ID, Networks } from '@rango-dev/wallets-shared';
+import {
+  ETHEREUM_CHAIN_ID,
+  Networks,
+  type ProviderConnectResult,
+} from '@rango-dev/wallets-shared';
 import bs58 from 'bs58';
 
 import { getDerivationPath } from './state.js';
@@ -26,6 +30,7 @@ function getLedgerErrorMessage(statusCode: number): string {
   )}`; // Hexadecimal numbers are more commonly recognized and utilized for representing ledger error codes
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getLedgerError(error: any) {
   if (error?.statusCode) {
     return new Error(getLedgerErrorMessage(error.statusCode));
@@ -50,37 +55,34 @@ export function getLedgerInstance() {
   return instances;
 }
 
-export async function getEthereumAccounts(): Promise<{
-  accounts: string[];
-  chainId: string;
-}> {
+export async function getEthereumAccounts(): Promise<ProviderConnectResult> {
   try {
     const transport = await transportConnect();
+    const derivationPath = getDerivationPath();
 
     const eth = new (await import('@ledgerhq/hw-app-eth')).default(transport);
 
     const accounts: string[] = [];
 
-    const result = await eth.getAddress(getDerivationPath(), false, true);
+    const result = await eth.getAddress(derivationPath, false, true);
     accounts.push(result.address);
 
     return {
       accounts: accounts,
       chainId: ETHEREUM_CHAIN_ID,
+      derivationPath,
     };
-  } catch (error: any) {
+  } catch (error) {
     throw getLedgerError(error);
   } finally {
     await transportDisconnect();
   }
 }
 
-export async function getSolanaAccounts(): Promise<{
-  accounts: string[];
-  chainId: string;
-}> {
+export async function getSolanaAccounts(): Promise<ProviderConnectResult> {
   try {
     const transport = await transportConnect();
+    const derivationPath = getDerivationPath();
 
     const solana = new (await import('@ledgerhq/hw-app-solana')).default(
       transport
@@ -88,14 +90,15 @@ export async function getSolanaAccounts(): Promise<{
 
     const accounts: string[] = [];
 
-    const result = await solana.getAddress(getDerivationPath());
+    const result = await solana.getAddress(derivationPath);
     accounts.push(bs58.encode(result.address));
 
     return {
       accounts: accounts,
       chainId: Networks.SOLANA,
+      derivationPath,
     };
-  } catch (error: any) {
+  } catch (error) {
     throw getLedgerError(error);
   } finally {
     await transportDisconnect();

--- a/wallets/provider-trezor/src/helpers.ts
+++ b/wallets/provider-trezor/src/helpers.ts
@@ -1,6 +1,10 @@
 import type { TrezorConnect } from '@trezor/connect-web';
 
-import { ETHEREUM_CHAIN_ID, Networks } from '@rango-dev/wallets-shared';
+import {
+  ETHEREUM_CHAIN_ID,
+  Networks,
+  type ProviderConnectResult,
+} from '@rango-dev/wallets-shared';
 
 import { getDerivationPath } from './state.js';
 
@@ -34,13 +38,11 @@ export function getTrezorInstance() {
   return instances;
 }
 
-export async function getEthereumAccounts(): Promise<{
-  accounts: string[];
-  chainId: string;
-}> {
+export async function getEthereumAccounts(): Promise<ProviderConnectResult> {
   const TrezorConnect = await getTrezorModule();
+  const derivationPath = getDerivationPath();
   const result = await TrezorConnect.ethereumGetAddress({
-    path: getDerivationPath(),
+    path: derivationPath,
   });
 
   if (!result.success) {
@@ -50,6 +52,7 @@ export async function getEthereumAccounts(): Promise<{
   return {
     accounts: [result.payload.address],
     chainId: ETHEREUM_CHAIN_ID,
+    derivationPath,
   };
 }
 

--- a/wallets/react/src/legacy/types.ts
+++ b/wallets/react/src/legacy/types.ts
@@ -75,6 +75,7 @@ export { Events };
 export type ProviderConnectResult = {
   accounts: string[];
   chainId: string;
+  derivationPath?: string;
 };
 
 export type GetInstanceOptions = {

--- a/wallets/shared/src/rango.ts
+++ b/wallets/shared/src/rango.ts
@@ -243,6 +243,7 @@ export type GetInstance =
 export type ProviderConnectResult = {
   accounts: string[];
   chainId: string;
+  derivationPath?: string;
 };
 
 export interface Wallet {

--- a/widget/embedded/src/containers/Wallets/useUpdates.ts
+++ b/widget/embedded/src/containers/Wallets/useUpdates.ts
@@ -77,7 +77,7 @@ export function useUpdates(params: UseUpdatesParams): UseUpdates {
     );
 
     if (data.length) {
-      void newWalletConnected(data, info.namespace);
+      void newWalletConnected(data, info.namespace, state.derivationPath);
     }
   };
 

--- a/widget/embedded/src/store/slices/wallets.ts
+++ b/widget/embedded/src/store/slices/wallets.ts
@@ -100,7 +100,11 @@ export interface WalletsSlice {
       namespaces?: Namespace[];
     }
   ) => void;
-  addConnectedWallet: (accounts: Wallet[], namespace?: Namespace) => void;
+  addConnectedWallet: (
+    accounts: Wallet[],
+    namespace?: Namespace,
+    derivationPath?: string
+  ) => void;
   setWalletsAsSelected: (
     wallets: { walletType: string; chain: string }[]
   ) => void;
@@ -109,7 +113,8 @@ export interface WalletsSlice {
    */
   newWalletConnected: (
     accounts: Wallet[],
-    namespace?: Namespace
+    namespace?: Namespace,
+    derivationPath?: string
   ) => Promise<void>;
   disconnectNamespaces: (walletType: string, namespaces: Namespace[]) => void;
   /**
@@ -231,7 +236,7 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
         };
       });
     },
-    addConnectedWallet: (accounts, namespace) => {
+    addConnectedWallet: (accounts, namespace, derivationPath) => {
       /*
        * When we are going to add a new account, there are two thing that can be happens:
        * 1. Wallet hasn't add yet.
@@ -276,6 +281,7 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
               walletType: account.walletType,
               selected: shouldMarkWalletAsSelected,
               namespace: namespace,
+              derivationPath: derivationPath,
               loading: false,
               error: false,
             };
@@ -435,13 +441,13 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
         connectedWallets: nextConnectedWalletsWithUpdatedSelectedStatus,
       });
     },
-    newWalletConnected: async (accounts, namespace) => {
+    newWalletConnected: async (accounts, namespace, derivationPath) => {
       eventEmitter.emit(WidgetEvents.WalletEvent, {
         type: WalletEventTypes.CONNECT,
         payload: { walletType: accounts[0].walletType, accounts },
       });
 
-      get().addConnectedWallet(accounts, namespace);
+      get().addConnectedWallet(accounts, namespace, derivationPath);
 
       void get().fetchBalances(accounts);
     },

--- a/widget/embedded/src/types/wallets.ts
+++ b/widget/embedded/src/types/wallets.ts
@@ -6,6 +6,7 @@ export interface Wallet {
   address: string;
   walletType: WalletType;
   isContractWallet?: boolean;
+  derivationPath?: string;
 }
 
 export type Balance = {

--- a/widget/embedded/src/utils/swap.ts
+++ b/widget/embedded/src/utils/swap.ts
@@ -534,13 +534,18 @@ export function getWalletsForNewSwap(selectedWallets: Wallet[]) {
   const wallets = selectedWallets.reduce(
     (
       selectedWalletsMap: {
-        [p: string]: { address: string; walletType: WalletType };
+        [p: string]: {
+          address: string;
+          walletType: WalletType;
+          derivationPath?: string;
+        };
       },
       selectedWallet
     ) => (
       (selectedWalletsMap[selectedWallet.chain] = {
         address: selectedWallet.address,
         walletType: selectedWallet.walletType,
+        derivationPath: selectedWallet.derivationPath,
       }),
       selectedWalletsMap
     ),


### PR DESCRIPTION
# Summary

In HD wallets, a derivation path specifies the location of keys and addresses. We rely on this path for Ledger and Trezor wallets, particularly during connection and transaction signing. As part of redesigning the 1SwapDetailsModal1 and improving the wallet connection flow—which is required to proceed with a transaction—we now need to persist the derivation path within the swap object. This ensures that if a wallet is disconnected, we can reconnect using the same derivation path.
Also you can see the usage of this in the related PR (in this file: `widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.ConnectWallet.tsx`).

# Key changes

- Added `derivationPath` to `ProviderConnectResult` type
- Added `derivationPath` to the return object of `connect` method for Ledger and Trezor wallets
- Updated the wallets slice in the store to include `derivationPath` for connected wallets.
- Modified `getWalletsForNewSwap` to return the derivation path as part of its result as the result of that gets added to the swap object


Fixes # (issue)


# How did you test this change?

You can test this by connecting to a Ledger or Trezor wallet and create a transaction using that wallet and log the swap object or check queues of queue manager of indexedDB and observe that `derivationPath` is added to the `wallets` of `swapDetails`.

# Related PRs

- https://github.com/rango-exchange/rango-client/pull/1124

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
