### PR TITLE
chore: set up husky hooks for pre-merge-commit and post-merge

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+. "$(dirname "$0")/post-commit"

--- a/.husky/pre-merge-commit
+++ b/.husky/pre-merge-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+. "$(dirname "$0")/pre-commit"


### PR DESCRIPTION
# Summary

Currently, when merging one branch into another, the pre-commit and post-commit hooks do not trigger for the merge commit. Instead, Git provides separate hooks—pre-merge-commit and post-merge—that can be used to achieve the same behavior.

The pre-merge-commit hook should replicate the behavior of pre-commit, and the post-merge hook should mirror the behavior of post-commit.


# How did you test this change?

To test this, you can merge one branch into another using the --no-ff flag to ensure a merge commit is created. The behavior should match that of the pre-commit and post-commit hooks.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
