### PR TITLE
fix: show correct terms in routing section of cross-chain transactions

### DIFF
--- a/widget/ui/src/components/StepDetails/StepDetails.tsx
+++ b/widget/ui/src/components/StepDetails/StepDetails.tsx
@@ -74,13 +74,21 @@ const StepDetailsComponent = forwardRef<HTMLDivElement, StepDetailsProps>(
             </SwapperImage>
             <Divider direction="horizontal" size={8} />
             <Typography size="medium" variant="label">
-              {i18n.t({
-                id: 'Swap on {fromChain} via {swapper}',
-                values: {
-                  fromChain: step.from.chain.displayName,
-                  swapper: step.swapper.displayName,
-                },
-              })}
+              {step.from.chain.displayName === step.to.chain.displayName
+                ? i18n.t({
+                    id: 'Swap on {fromChain} via {swapper}',
+                    values: {
+                      fromChain: step.from.chain.displayName,
+                      swapper: step.swapper.displayName,
+                    },
+                  })
+                : i18n.t({
+                    id: 'Bridge from {fromChain} via {swapper}',
+                    values: {
+                      fromChain: step.from.chain.displayName,
+                      swapper: step.swapper.displayName,
+                    },
+                  })}
             </Typography>
           </div>
         )}


### PR DESCRIPTION
### Description

Fixes a labeling issue in the routing section for cross-chain transactions. The term **"Bridge"** is now correctly displayed when `fromChain !== toChain`.

### Fixes

- Added a condition to check if `fromChain !== toChain`.
- If true, the label now shows **"Bridge"** instead of **"Swap"**, following the same logic as in:
  [SwapToken.tsx#L113](https://github.com/rango-exchange/rango-client/blob/4bd8209c3eb4cd11c163ba7ccc41259475a336fd/widget/ui/src/components/SwapListItem/SwapToken.tsx#L113)

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
