### PR TITLE
fix: handle null publicKey from okx Solana provider

### DIFF
--- a/wallets/provider-okx/src/helpers.ts
+++ b/wallets/provider-okx/src/helpers.ts
@@ -23,15 +23,20 @@ export async function getSolanaAccounts(
 ): Promise<ProviderConnectResult[]> {
   const solanaInstance = await instance.get(Networks.SOLANA);
   const results: ProviderConnectResult[] = [];
-
   if (solanaInstance) {
     const solanaResponse = await solanaInstance.connect();
-    const account = solanaResponse.publicKey.toString();
+    if (!!solanaResponse) {
+      const account = solanaResponse.publicKey.toString();
 
-    results.push({
-      accounts: account ? [account] : [],
-      chainId: Networks.SOLANA,
-    });
+      results.push({
+        accounts: account ? [account] : [],
+        chainId: Networks.SOLANA,
+      });
+    } else {
+      throw new Error(
+        'Failed to connect to Solana wallet or publicKey is missing.'
+      );
+    }
   }
 
   return results;


### PR DESCRIPTION
# Summary

Handle the case where solanaInstance.connect() returns null or a missing publicKey.
Throws a clear error instead of attempting to access undefined values.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
