### PR TITLE
fix: fix phantom transaction failure on sui namespace disabled

### DIFF
--- a/wallets/core/src/namespaces/sui/mod.ts
+++ b/wallets/core/src/namespaces/sui/mod.ts
@@ -3,6 +3,6 @@ export type { ProviderAPI, SuiActions } from './types.js';
 export * as actions from './actions.js';
 export * as builders from './builders.js';
 export * as chains from './chains.js';
-export { getInstanceOrThrow } from './utils.js';
+export { getInstanceOrThrow, getInstance } from './utils.js';
 
 export { CAIP_NAMESPACE, CAIP_SUI_CHAIN_ID } from './constants.js';

--- a/wallets/core/src/namespaces/sui/utils.ts
+++ b/wallets/core/src/namespaces/sui/utils.ts
@@ -15,7 +15,7 @@ type SuiWalletStandard = WalletWithFeatures<
 /**
  * @param name each wallet has a name in WalletStandard. you should pass that value
  */
-export function getInstanceOrThrow(name: string): SuiWalletStandard {
+export function getInstance(name: string): SuiWalletStandard | undefined {
   const wallet = getWallets()
     .get()
     .find(
@@ -23,11 +23,20 @@ export function getInstanceOrThrow(name: string): SuiWalletStandard {
         wallet.name === name && wallet.chains.includes(SUI_MAINNET_CHAIN)
     );
 
+  return wallet as SuiWalletStandard;
+}
+
+/**
+ * @param name each wallet has a name in WalletStandard. you should pass that value
+ */
+export function getInstanceOrThrow(name: string): SuiWalletStandard {
+  const wallet = getInstance(name);
+
   if (!wallet) {
     throw new Error(
       "We couldn't find the Sui instance on your wallet. It may be fixed by refreshing the page."
     );
   }
 
-  return wallet as SuiWalletStandard;
+  return wallet;
 }

--- a/wallets/provider-phantom/src/legacy/signer.ts
+++ b/wallets/provider-phantom/src/legacy/signer.ts
@@ -2,7 +2,7 @@ import type { Provider } from '../utils.js';
 import type { SignerFactory } from 'rango-types';
 
 import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
-import { getInstanceOrThrow } from '@rango-dev/wallets-core/namespaces/sui';
+import { getInstance as getSuiInstance } from '@rango-dev/wallets-core/namespaces/sui';
 import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -15,8 +15,7 @@ export default async function getSigners(
   const evmProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const bitcoinInstance = getNetworkInstance(provider, Networks.BTC);
 
-  // TODO: This goes through error if SUI disabled
-  const suiProvider = getInstanceOrThrow(WALLET_NAME_IN_WALLET_STANDARD);
+  const suiProvider = getSuiInstance(WALLET_NAME_IN_WALLET_STANDARD);
 
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
@@ -26,6 +25,8 @@ export default async function getSigners(
   signers.registerSigner(TxType.SOLANA, new DefaultSolanaSigner(solProvider));
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(evmProvider));
   signers.registerSigner(TxType.TRANSFER, new BTCSigner(bitcoinInstance));
-  signers.registerSigner(TxType.SUI, new DefaultSuiSigner(suiProvider));
+  if (!!suiProvider) {
+    signers.registerSigner(TxType.SUI, new DefaultSuiSigner(suiProvider));
+  }
   return signers;
 }


### PR DESCRIPTION
# Summary

Fixed transaction failure on Phantom when Sui namespace is disabled. The bug was related to `getInstanceOrThrow` related to Sui namespace.


# How did you test this change?

It can be tested by signing any transaction using Phantom wallet when Sui namespace is disabled in Phantom.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
