### PR TITLE
fix: display error message from response instead of default fallback

### DIFF
--- a/widget/embedded/src/constants/errors.ts
+++ b/widget/embedded/src/constants/errors.ts
@@ -52,12 +52,11 @@ export const errorMessages = () => {
 };
 
 export function getQuoteErrorMessage(error: QuoteError) {
-  switch (error.type) {
-    case QuoteErrorType.NO_RESULT:
-      return error.diagnosisMessage ?? errorMessages().noResultError.title;
-    case QuoteErrorType.REQUEST_FAILED:
-      return errorMessages().genericServerError;
-    default:
-      return '';
+  if (error.type === QuoteErrorType.NO_RESULT) {
+    return error.diagnosisMessage ?? errorMessages().noResultError.title;
+  } else if (error.type === QuoteErrorType.REQUEST_FAILED) {
+    return error.diagnosisMessage ?? errorMessages().genericServerError;
   }
+
+  return '';
 }

--- a/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.helpers.ts
+++ b/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.helpers.ts
@@ -158,6 +158,7 @@ export function handleQuoteErrors(error: any): ConfirmSwapFetchResult {
     swap: null,
     error: {
       type: QuoteErrorType.REQUEST_FAILED,
+      diagnosisMessage: error.message,
     },
     warnings: null,
   };

--- a/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.ts
+++ b/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.ts
@@ -72,7 +72,7 @@ export function useConfirmSwap(): ConfirmSwap {
         const { result } = response;
 
         if (!result) {
-          throw new Error('Error fetching updated route');
+          throw new Error(response.error ?? 'Error fetching updated quote');
         }
 
         throwErrorIfResponseIsNotValid({

--- a/widget/embedded/src/types/quote.ts
+++ b/widget/embedded/src/types/quote.ts
@@ -36,7 +36,10 @@ export type InsufficientSlippageError = {
   minRequiredSlippage: string | null;
 };
 
-export type QuoteRequestFailed = { type: QuoteErrorType.REQUEST_FAILED };
+export type QuoteRequestFailed = {
+  type: QuoteErrorType.REQUEST_FAILED;
+  diagnosisMessage?: string;
+};
 export type QuoteRequestCanceled = { type: QuoteErrorType.REQUEST_CANCELED };
 
 export type QuoteError =


### PR DESCRIPTION
# Summary

Show the error message returned in the response instead of using the default one

Fixes # (issue)


# How did you test this change?

1. Connect to the Phantom wallet.
2. Make a swap on the Sui blockchain.
3. At the wallet selection step, add a custom Sui destination and then click Confirm.


# Checklist:

- [x] I have performed a self-review of my code
