### PR TITLE
chore: add isSupported flag to getConnectedWalletsDetails result

### DIFF
--- a/widget/embedded/src/store/slices/wallets.ts
+++ b/widget/embedded/src/store/slices/wallets.ts
@@ -60,6 +60,7 @@ interface DeprecatedTokenBalance {
   rawAmount: string;
   decimal: number | null;
   amount: string;
+  isSupported: boolean;
   logo: string | null;
   usdPrice: number | null;
 }
@@ -807,6 +808,7 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
                   rawAmount: balance.amount,
                   decimal: balance.decimals,
                   amount: amount.toString(),
+                  isSupported: !!token,
                   logo: token?.image || null,
                   usdPrice: token?.usdPrice || null,
                 });


### PR DESCRIPTION
# Summary

Added a flag to `getConnectedWalletsDetails` result to indicate that the token related to the `balanceItem` is supported or not by checking if it is included in meta.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
