### PR TITLE
chore: remove pre-merge-commit and post-merge hooks

### DIFF
--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
-. "$(dirname "$0")/post-commit"

--- a/.husky/pre-merge-commit
+++ b/.husky/pre-merge-commit
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
-. "$(dirname "$0")/pre-commit"


### PR DESCRIPTION
# Summary

The pre-merge-commit and post-merge hooks modify commit hashes after pulling any branch from the origin, which causes divergence when attempting to push the updated branch back to origin. For now, we've removed these hooks to resolve the issue and will work on finding a proper way to reintroduce them without causing divergence.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
