### PR TITLE
fix: namespace conflict when connecting multiple namespaces

### DIFF
--- a/widget/embedded/src/components/WalletStatefulConnect/NamespaceDetachedItem.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/NamespaceDetachedItem.tsx
@@ -12,7 +12,7 @@ import {
   Typography,
 } from '@rango-dev/ui';
 import { useWallets } from '@rango-dev/wallets-react';
-import React, { useEffect, useLayoutEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useAppStore } from '../../store/AppStore';
 import { getConciseAddress } from '../../utils/wallets';
@@ -33,7 +33,7 @@ import { SupportedChainsList } from './SupportedChainsList';
 export const NamespaceDetachedItem = function NamespaceDetachedItem(
   props: NamespaceDetachedItemPropTypes
 ) {
-  const { walletType, namespace, initialConnect } = props;
+  const { walletType, namespace } = props;
   const blockchains = useAppStore().blockchains();
   const { connect, disconnect, state } = useWallets();
   const [error, setError] = useState<Error | null>(null);
@@ -45,12 +45,6 @@ export const NamespaceDetachedItem = function NamespaceDetachedItem(
   const firstAccountArray = namespaceState.accounts?.[0]?.split(':');
 
   useEffect(() => setErrorIsExpanded(false), [error]);
-
-  useLayoutEffect(() => {
-    if (initialConnect) {
-      void handleConnectNamespace(walletType, namespace.value);
-    }
-  }, []);
 
   const handleConnectNamespace = async (
     walletType: string,

--- a/widget/embedded/src/components/WalletStatefulConnect/Namespaces.types.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Namespaces.types.tsx
@@ -28,7 +28,6 @@ export type NamespaceItemPropTypes =
 
 export type NamespaceDetachedItemPropTypes = {
   walletType: string;
-  initialConnect?: boolean;
   namespace: LegacyNamespaceMeta;
 };
 


### PR DESCRIPTION
## 🛠️ Fix: Prevent Simultaneous Namespace Connection Errors in Detached Modal

### Problem

When attempting to connect multiple namespaces (e.g., Solana and EVM) through certain wallets (such as Trust Wallet), an error was thrown. This occurred because the new detached modal was trying to connect all namespaces simultaneously, which some wallets do not support.

### Solution

This PR introduces a fix by aggregating the connection requests in the detached modal, ensuring that connections happen sequentially instead of in parallel. This change prevents the wallet from throwing errors due to simultaneous connection attempts.

### ✅ How to Reproduce the Error

1. Use the current Trust Wallet deployments.
2. Ensure the wallet is **not connected** beforehand.
3. Attempt to connect to **both Solana and EVM** at the same time.
4. Observe the error in the current implementation.

### 🔁 How to Verify the Fix

Follow the same steps above using this PR branch. The error should no longer occur, confirming that the namespace connections are now handled correctly.


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
