### PR TITLE
fix: if data exceed 90 days, bottom axis should be shown correctly

### DIFF
--- a/widget/charts/src/components/BarChart/BarChart.constants.ts
+++ b/widget/charts/src/components/BarChart/BarChart.constants.ts
@@ -1,3 +1,5 @@
+import type { BottomAxisData } from './BarChart.types.js';
+
 export const DEFAULT_MARGIN = { top: 40, right: 0, bottom: 0, left: 20 };
 
 export const TOOLTIP_DELAY_MS = 100;
@@ -18,7 +20,11 @@ export const DEFAULT_CHART_COLORS: string[] = [
   '#F4C932',
 ];
 
-export const bottomAxisData = {
+export const bottomAxisData: {
+  [key: string]: {
+    [key: number]: BottomAxisData;
+  };
+} = {
   desktop: {
     7: { numBottomAxis: 7, startBottomAxis: 0, intervalBottomAxis: 1 },
     30: { numBottomAxis: 6, startBottomAxis: 4, intervalBottomAxis: 5 },

--- a/widget/charts/src/components/BarChart/BarChart.helpers.ts
+++ b/widget/charts/src/components/BarChart/BarChart.helpers.ts
@@ -146,3 +146,8 @@ export const prepareBarChartData = (chartOption: ChartOptionsType) => {
   });
   return { chartData, colorBucketMap, buckets };
 };
+
+export const getEvenlySpacedNumber = (max: number, count: number) => {
+  const interval = max / count;
+  return Math.round(interval);
+};

--- a/widget/charts/src/components/BarChart/BarChart.tsx
+++ b/widget/charts/src/components/BarChart/BarChart.tsx
@@ -2,6 +2,7 @@
 import type {
   BarChartPropTypes,
   BarStackDataType,
+  BottomAxisData,
   TooltipDataType,
 } from './BarChart.types.js';
 import type { BarGroupBar, SeriesPoint } from '@visx/shape/lib/types';
@@ -35,6 +36,7 @@ import {
 import {
   generateTickValues,
   getDaysRange,
+  getEvenlySpacedNumber,
   getTotalValue,
   getTotalValueDates,
 } from './BarChart.helpers.js';
@@ -64,10 +66,22 @@ export const BarChart = (props: BarChartPropTypes) => {
 
   const isMobile = useIsMobile();
   const daysRange = getDaysRange(data.length);
-  const bottomAxis =
-    width < 700
-      ? bottomAxisData.mobile[daysRange]
-      : bottomAxisData.desktop[daysRange];
+
+  let bottomAxis: BottomAxisData;
+  if (data.length > 90) {
+    const count = 7;
+    const interval = getEvenlySpacedNumber(data.length, count);
+    bottomAxis = {
+      numBottomAxis: count,
+      intervalBottomAxis: interval,
+      startBottomAxis: interval - 10,
+    };
+  } else {
+    bottomAxis =
+      width < 700
+        ? bottomAxisData.mobile[daysRange]
+        : bottomAxisData.desktop[daysRange];
+  }
 
   const { intervalBottomAxis, numBottomAxis, startBottomAxis } = bottomAxis;
 

--- a/widget/charts/src/components/BarChart/BarChart.types.ts
+++ b/widget/charts/src/components/BarChart/BarChart.types.ts
@@ -42,3 +42,9 @@ export type ChartOptionsType = {
   barChartColors: string[];
   label?: string;
 };
+
+export interface BottomAxisData {
+  numBottomAxis: number;
+  startBottomAxis: number;
+  intervalBottomAxis: number;
+}


### PR DESCRIPTION
# Summary

We are working on setting Custom Period range by server, if data is more than 90, the label shown messy.

Fixes RF-2431

<img width="750" alt="labels" src="https://github.com/user-attachments/assets/3823f2a9-b1d5-4c17-8a05-32ce12b2257b" />

# How did you test this change?

You should link the `charts` in `explorer`.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
