### PR TITLE
feat: use psbt for bitcoin on xdefi/ctrl wallet

### DIFF
--- a/wallets/provider-xdefi/src/utxo-signer.ts
+++ b/wallets/provider-xdefi/src/utxo-signer.ts
@@ -1,18 +1,15 @@
-import type { Networks } from '@rango-dev/wallets-shared';
 import type { GenericSigner, Transfer } from 'rango-types';
 
 import {
   getNetworkInstance,
+  Networks,
   XDEFI_WALLET_SUPPORTED_NATIVE_CHAINS,
 } from '@rango-dev/wallets-shared';
-import { SignerError } from 'rango-types';
+import { SignerError, SignerErrorCode } from 'rango-types';
 
 import { xdefiTransfer } from './helpers.js';
 
-/*
- * TODO - replace with real type
- * tslint:disable-next-line: no-any
- */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TransferExternalProvider = any;
 
 export class CustomTransferSigner implements GenericSigner<Transfer> {
@@ -36,6 +33,66 @@ export class CustomTransferSigner implements GenericSigner<Transfer> {
         `blockchain: ${blockchain} transfer not implemented yet.`
       );
     }
+
+    if (blockchain === Networks.BTC) {
+      return await this.#signPsbt(tx);
+    }
+
+    return await this.#signTransferObject(tx);
+  }
+
+  // Interface for PSBT: https://developers.ctrl.xyz/developers/extension-bitcoin#sign-psbt-partially-signed-bitcoin-transaction
+  async #signPsbt(tx: Transfer): Promise<{ hash: string }> {
+    const { asset, psbt } = tx;
+
+    if (!psbt) {
+      throw new Error(
+        'No PSBT found to sign. Ensure a valid PSBT is provided.'
+      );
+    }
+
+    const provider = getNetworkInstance(this.provider, asset.blockchain);
+
+    const signInputs: { [key: string]: number[] } = {};
+    psbt.inputsToSign.forEach((input) => {
+      signInputs[input.address] = input.signingIndexes;
+    });
+
+    const response = await provider
+      .request({
+        method: 'sign_psbt',
+        params: {
+          psbt: psbt.unsignedPsbtBase64,
+          signInputs,
+          allowedSignHash: 1,
+          broadcast: true,
+        },
+      })
+      .catch((error: unknown) => {
+        throw new SignerError(SignerErrorCode.SEND_TX_ERROR, undefined, error);
+      });
+
+    /*
+     * `status` is useful for callback style (e.g. `(err, res) => void`) form of `xfi.request`.
+     * here we are using the promise interface, so it should be always `success` when reach here.
+     *
+     * just for ensuring unexpected behaviors will be handled, we can keep this.
+     *
+     * @see https://docs.xverse.app/sats-connect/wallet-methods/request-methods#response-format-and-error-handling
+     */
+    if (response.status === 'success') {
+      return { hash: response.result.txId };
+    }
+
+    throw new Error(
+      'The operation (sign and broadcast) failed on your wallet.',
+      { cause: response }
+    );
+  }
+
+  async #signTransferObject(tx: Transfer): Promise<{ hash: string }> {
+    const { blockchain } = tx.asset;
+
     const transferProvider = getNetworkInstance(this.provider, blockchain);
 
     const {


### PR DESCRIPTION
# Summary

Switch to PSBT on XDefi.

XDefi supports only utf-8 memos, there are upcoming changes by backend where they want to have support for hex encoded bytes. We will use PSBT here as well to don't encounter any problem eventually.

Fixes RF-2442


# How did you test this change?

You can try a swap using XDefi/CTRL wallet. 

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
