### PR TITLE
fix: fix incorrect state after connecting evm namespace on hub wallets

### DIFF
--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -21,6 +21,7 @@ import { LastConnectedWalletsFromStorage } from './lastConnectedWallets.js';
 import { useHubRefs } from './useHubRefs.js';
 import {
   getLegacyProvider,
+  getSupportedChainsFromProvider,
   mapHubEventsToLegacy,
   transformHubResultToLegacyResult,
   tryConvertNamespaceNetworkToChainInfo,
@@ -92,7 +93,7 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
               getHub(),
               event,
               dataRef.current.onUpdateState,
-              api
+              dataRef.current.allBlockChains
             );
           } catch (e) {
             console.error(e);
@@ -322,18 +323,16 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
         (property) => property.name === 'details'
       );
 
-      const supportedChains =
-        namespacesProperty?.value.data.flatMap((namespace) =>
-          namespace.getSupportedChains(params.allBlockChains || [])
-        ) || [];
-
       return {
         name: info.name,
         img: info.icon,
         installLink: installLink,
         // We don't have this values anymore, fill them with some values that communicate this.
         color: 'red',
-        supportedChains,
+        supportedChains: getSupportedChainsFromProvider(
+          wallet,
+          dataRef.current.allBlockChains
+        ),
         isContractWallet: detailsProperty?.value?.isContractWallet,
         mobileWallet: detailsProperty?.value?.mobileWallet,
         // if set to false here, it will not show the wallet in mobile in anyways. to be compatible with old behavior, undefined is more appropirate.


### PR DESCRIPTION
# Summary

There was a problem in the process of connecting EVM namespace on hub wallets. The root cause was that the event for connecting to the EVM namespace was being propagated with an incorrect payload, specifically, an empty `supportedBlockchains` field in `eventInfo` which led to an incorrect wallet state in the "Confirm Wallets" modal. The issue was originated by that the `api` object passed to `mapHubEventsToLegacy` function, which was being used to get the supported chains for wallets, was stale which was resulting in an empty list for `supportedBlockchains` when calling `getWalletInfo`. In this PR, the issue is fixed by passing a fresh reference to meta.allBlockchains into mapHubEventsToLegacy, ensuring supported chains are processed correctly.


# How did you test this change?

Tested by connecting EVM namespace on `Phantom` wallet and creating an EVM transaction using `Phantom` wallet and observing that the whole flow works s expected.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
