### PR TITLE
feat: improve swap details page switch network modal

### DIFF
--- a/queue-manager/rango-preset/src/actions/executeTransaction.ts
+++ b/queue-manager/rango-preset/src/actions/executeTransaction.ts
@@ -17,7 +17,6 @@ import {
   isNetworkMatchedForTransaction,
   isRequiredWalletConnected,
   isWalletNull,
-  resetNetworkStatus,
   signTransaction,
   updateNetworkStatus,
 } from '../helpers';
@@ -49,11 +48,8 @@ export async function executeTransaction(
   };
 
   const swap = getStorage().swapDetails;
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const currentStep = getCurrentStep(swap)!;
 
-  // Resetting network status, so we will set it again during the running of this task.
-  resetNetworkStatus(actions);
+  const currentStep = getCurrentStep(swap)!;
 
   /* Make sure wallet is connected and also the connected wallet is matched with tx by checking address. */
   const isWrongAddress = !isRequiredWalletConnected(swap, context.state).ok;
@@ -110,7 +106,7 @@ export async function executeTransaction(
   // Update network to mark it as network changed successfully.
   updateNetworkStatus(actions, {
     message: '',
-    details: 'Wallet network changed successfully',
+    details: 'The network has been successfully changed.',
     status: PendingSwapNetworkStatus.NetworkChanged,
   });
 

--- a/queue-manager/rango-preset/src/helpers.ts
+++ b/queue-manager/rango-preset/src/helpers.ts
@@ -18,6 +18,7 @@ import type {
   QueueInfo,
   QueueName,
   QueueType,
+  SetStorage,
 } from '@rango-dev/queue-manager-core';
 import type {
   Meta,
@@ -537,7 +538,7 @@ export function markRunningSwapAsSwitchingNetwork({
   const { type } = getRequiredWallet(swap);
   const fromNamespace = getCurrentNamespaceOf(swap, currentStep);
   const reason = `Change ${type} wallet network to ${fromNamespace.network}`;
-  const reasonDetail = `Please change your ${type} wallet network to ${fromNamespace.network}.`;
+  const reasonDetail = `We’re switching the connected network to ${fromNamespace.network}. Please check your wallet.`;
 
   const currentTime = new Date();
   swap.lastNotificationTime = currentTime.getTime().toString();
@@ -768,7 +769,10 @@ export function resetNetworkStatus(
 }
 
 export function updateNetworkStatus(
-  actions: ExecuterActions<SwapStorage, SwapActionTypes, SwapQueueContext>,
+  actions: Pick<
+    ExecuterActions<SwapStorage, SwapActionTypes, SwapQueueContext>,
+    'getStorage' | 'setStorage'
+  >,
   data: {
     message: string;
     details: string;
@@ -906,8 +910,20 @@ export function onBlockForChangeNetwork(
             queue.unblock();
           })
           .catch((error) => {
-            // ignore switch network errors
-            console.log({ error });
+            // Update network to mark it as network change failed.
+            updateNetworkStatus(
+              {
+                getStorage: queue.getStorage.bind(queue) as () => SwapStorage,
+                setStorage: queue.setStorage.bind(
+                  queue
+                ) as SetStorage<SwapStorage>,
+              },
+              {
+                message: error.message,
+                details: error.message,
+                status: PendingSwapNetworkStatus.NetworkChangeFailed,
+              }
+            );
           });
       }
     }

--- a/wallets/shared/src/helpers.ts
+++ b/wallets/shared/src/helpers.ts
@@ -86,6 +86,8 @@ export async function switchOrAddNetworkForMetamaskCompatibleWallets(
         method: 'wallet_addEthereumChain',
         params: [targetChain],
       });
+      // Return if target chain has been added successfully
+      return;
     }
     throw switchError;
   }

--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -1,5 +1,6 @@
 import type { SwapDetailsProps } from './SwapDetails.types';
 import type { ModalState } from '../SwapDetailsModal';
+import type { SwitchNetworkModalState } from '../SwapDetailsModal/SwapDetailsModal.types';
 
 import { i18n } from '@lingui/core';
 import {
@@ -71,6 +72,8 @@ import {
   titleStepsStyles,
 } from './SwapDetails.styles';
 
+const SUCCESS_SWITCH_NETWORK_MODAL_CLOSE_DELAY = 3000;
+
 export function SwapDetails(props: SwapDetailsProps) {
   const { swap, requestId, onDelete, onCancel } = props;
   const { canSwitchNetworkTo, connect, getWalletInfo } = useWallets();
@@ -82,10 +85,14 @@ export function SwapDetails(props: SwapDetailsProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalState, setModalState] = useState<ModalState>(null);
+  const [switchNetworkModalState, setSwitchNetworkModalState] =
+    useState<SwitchNetworkModalState | null>(null);
   const [showCompletedModal, setShowCompletedModal] = useState<
     'success' | 'failed' | null
   >(null);
-  const showSwitchNetworkRef = useRef(false);
+
+  const modalStateRef = useRef(modalState);
+  const switchNetworkModalStateRef = useRef(switchNetworkModalState);
 
   const getNotifications = useNotificationStore.use.getNotifications();
   const removeNotification = useNotificationStore.use.removeNotification();
@@ -102,42 +109,27 @@ export function SwapDetails(props: SwapDetailsProps) {
     setIsModalOpen(false);
   };
 
-  useEffect(() => {
-    const existNotification = notifications.find(
-      (n) => n.requestId === swap.requestId
-    );
-    if (existNotification) {
-      if (swap.status === 'success' || swap.status === 'failed') {
-        setShowCompletedModal(swap.status);
-        removeNotification(swap.requestId);
-        handleCloseModal();
-      } else if (showCompletedModal) {
-        setShowCompletedModal(null);
-      }
-    }
-  }, [swap.status, swap.requestId]);
-
-  useEffect(() => {
-    if (showSwitchNetwork) {
-      handleChangeModalState(PendingSwapNetworkStatus.WaitingForNetworkChange);
-    } else if (
-      currentStepNetworkStatus ===
-      PendingSwapNetworkStatus.WaitingForConnectingWallet
-    ) {
-      handleChangeModalState(
-        PendingSwapNetworkStatus.WaitingForConnectingWallet
-      );
-    } else if (
-      currentStepNetworkStatus === PendingSwapNetworkStatus.NetworkChanged
-    ) {
-      handleChangeModalState(PendingSwapNetworkStatus.NetworkChanged);
-    }
-
-    if (!showSwitchNetwork && showSwitchNetworkRef.current) {
-      handleCloseModal();
-    }
-    showSwitchNetworkRef.current = showSwitchNetwork;
-  }, [currentStepNetworkStatus]);
+  const handleShowSwitchNetworkLoading = () => {
+    setSwitchNetworkModalState({
+      type: 'loading',
+      title: i18n.t('Change Network'),
+      description: `We’re switching the connected network to ${currentStepNamespace?.network}. Please check your wallet.`,
+    });
+  };
+  const handleShowSwitchNetworkSucceeded = () => {
+    setSwitchNetworkModalState({
+      type: 'success',
+      title: i18n.t('Network Changed'),
+      description: 'The network has been successfully changed.',
+    });
+  };
+  const handleShowSwitchNetworkFailed = (error?: Error) => {
+    setSwitchNetworkModalState({
+      type: 'error',
+      title: i18n.t('Network Switch Failed'),
+      description: error?.message || stepMessage.detailedMessage.content,
+    });
+  };
 
   const lastConvertedTokenInFailedSwap =
     getLastConvertedTokenInFailedSwap(swap);
@@ -152,34 +144,60 @@ export function SwapDetails(props: SwapDetailsProps) {
   const swapDate = getSwapDate(swap);
   const shouldRetry = shouldRetrySwap(swap);
 
-  const isMobileWallet = (walletType: string): boolean =>
+  const checkIsMobileWallet = (walletType: string): boolean =>
     !!getWalletInfo(walletType)?.mobileWallet;
 
-  const showSwitchNetwork =
-    currentStepNetworkStatus ===
-      PendingSwapNetworkStatus.WaitingForNetworkChange &&
-    !!currentStepNamespace &&
+  const stepIsBlockedForSwitchNetwork =
+    !!currentStepNetworkStatus &&
+    [
+      PendingSwapNetworkStatus.WaitingForNetworkChange,
+      PendingSwapNetworkStatus.NetworkChangeFailed,
+    ].includes(currentStepNetworkStatus);
+  const isMobileWallet =
     !!currentStepWallet?.walletType &&
-    (isMobileWallet(currentStepWallet.walletType) ||
-      canSwitchNetworkTo(
-        currentStepWallet.walletType,
-        currentStepNamespace.network,
-        currentStepNamespace
-      ));
+    checkIsMobileWallet(currentStepWallet.walletType);
+  const canSwitchNetworkToRequiredNetwork =
+    !!currentStepWallet &&
+    !!currentStepNamespace &&
+    canSwitchNetworkTo(
+      currentStepWallet.walletType,
+      currentStepNamespace.network,
+      currentStepNamespace
+    );
 
-  const switchNetwork = showSwitchNetwork
-    ? connect.bind(null, currentStepWallet.walletType, [
+  const switchNetworkIsAvailable =
+    !!currentStepNamespace &&
+    stepIsBlockedForSwitchNetwork &&
+    (isMobileWallet || canSwitchNetworkToRequiredNetwork);
+
+  const handleSwitchNetwork = () => {
+    if (switchNetworkIsAvailable) {
+      handleShowSwitchNetworkLoading();
+      connect(currentStepWallet.walletType, [
         {
           namespace: currentStepNamespace.namespace,
           network: currentStepNamespace.network,
         },
       ])
-    : undefined;
+        .then(() => {
+          handleShowSwitchNetworkSucceeded();
+        })
+        .catch((error: unknown) => {
+          handleShowSwitchNetworkFailed(error as Error);
+        });
+    }
+  };
+
+  const handleSwitchNetworkClick = () => {
+    handleChangeModalState('switchNetwork');
+    handleSwitchNetwork();
+  };
 
   const stepMessage = getSwapMessages(swap, currentStep, getWalletInfo);
   const steps = getSteps({
     swap,
-    switchNetwork,
+    switchNetworkIsAvailable,
+    handleSwitchNetworkClick,
     showNetworkModal: currentStepNetworkStatus,
     setNetworkModal: handleChangeModalState,
     message: stepMessage,
@@ -275,6 +293,83 @@ export function SwapDetails(props: SwapDetailsProps) {
         )}
       </ErrorMessages>
     );
+
+  useEffect(() => {
+    const existNotification = notifications.find(
+      (n) => n.requestId === swap.requestId
+    );
+    if (existNotification) {
+      if (swap.status === 'success' || swap.status === 'failed') {
+        setShowCompletedModal(swap.status);
+        removeNotification(swap.requestId);
+        handleCloseModal();
+      } else if (showCompletedModal) {
+        setShowCompletedModal(null);
+      }
+    }
+  }, [swap.status, swap.requestId]);
+
+  useEffect(() => {
+    if (switchNetworkIsAvailable) {
+      handleChangeModalState('switchNetwork');
+      if (
+        currentStepNetworkStatus ===
+        PendingSwapNetworkStatus.WaitingForNetworkChange
+      ) {
+        handleShowSwitchNetworkLoading();
+        return;
+      }
+      if (
+        currentStepNetworkStatus ===
+        PendingSwapNetworkStatus.NetworkChangeFailed
+      ) {
+        handleShowSwitchNetworkFailed();
+        return;
+      }
+      return;
+    }
+
+    if (
+      currentStepNetworkStatus ===
+      PendingSwapNetworkStatus.WaitingForConnectingWallet
+    ) {
+      handleChangeModalState('connectWallet');
+      return;
+    }
+
+    if (currentStepNetworkStatus === PendingSwapNetworkStatus.NetworkChanged) {
+      handleChangeModalState('switchNetwork');
+      handleShowSwitchNetworkSucceeded();
+      return;
+    }
+
+    if (modalState && ['connectWallet', 'switchNetwork'].includes(modalState)) {
+      handleCloseModal();
+    }
+  }, [currentStepNetworkStatus]);
+
+  useEffect(() => {
+    modalStateRef.current = modalState;
+    switchNetworkModalStateRef.current = switchNetworkModalState;
+
+    // Close switch network success modal with a delay
+    if (
+      modalState === 'switchNetwork' &&
+      switchNetworkModalState?.type === 'success'
+    ) {
+      const timeout = setTimeout(() => {
+        if (
+          modalStateRef.current === 'switchNetwork' &&
+          switchNetworkModalStateRef.current?.type === 'success'
+        ) {
+          handleCloseModal();
+        }
+      }, SUCCESS_SWITCH_NETWORK_MODAL_CLOSE_DELAY);
+
+      return () => clearTimeout(timeout);
+    }
+    return;
+  }, [modalState, switchNetworkModalState]);
 
   return (
     <Layout
@@ -419,11 +514,13 @@ export function SwapDetails(props: SwapDetailsProps) {
       <SwapDetailsModal
         isOpen={isModalOpen}
         state={modalState}
+        switchNetworkModalState={switchNetworkModalState}
         onClose={handleCloseModal}
         onCancel={onCancel}
         onDelete={onDelete}
         message={stepMessage.detailedMessage.content}
         swap={swap}
+        handleSwitchNetwork={handleSwitchNetworkClick}
       />
       <SwapDetailsCompleteModal
         open={!!showCompletedModal}

--- a/widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx
+++ b/widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.Warning.tsx
@@ -6,8 +6,14 @@ import { PendingSwapNetworkStatus } from 'rango-types';
 import React from 'react';
 
 export function WarningAlert(props: WaningAlertsProps) {
-  const { switchNetwork, setNetworkModal, message, showNetworkModal } = props;
-  if (!!switchNetwork) {
+  const {
+    switchNetworkIsAvailable,
+    handleSwitchNetworkClick,
+    setNetworkModal,
+    message,
+    showNetworkModal,
+  } = props;
+  if (!!switchNetworkIsAvailable) {
     return (
       <Alert
         type="warning"
@@ -19,10 +25,8 @@ export function WarningAlert(props: WaningAlertsProps) {
             size="xxsmall"
             type="warning"
             onClick={() => {
-              setNetworkModal(PendingSwapNetworkStatus.WaitingForNetworkChange);
-              switchNetwork().catch((e) => {
-                console.log(e);
-              });
+              setNetworkModal('switchNetwork');
+              handleSwitchNetworkClick();
             }}>
             {i18n.t('Change')}
           </Button>
@@ -44,9 +48,7 @@ export function WarningAlert(props: WaningAlertsProps) {
             size="xxsmall"
             type="warning"
             onClick={() => {
-              setNetworkModal(
-                PendingSwapNetworkStatus.WaitingForConnectingWallet
-              );
+              setNetworkModal('connectWallet');
             }}>
             {i18n.t('Connect')}
           </Button>

--- a/widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx
+++ b/widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.tsx
@@ -12,7 +12,8 @@ import { WarningAlert } from './SwapDetailsAlerts.Warning';
 
 export function SwapDetailsAlerts(props: SwapAlertsProps) {
   const {
-    switchNetwork,
+    switchNetworkIsAvailable,
+    handleSwitchNetworkClick,
     showNetworkModal,
     setNetworkModal,
     message,
@@ -75,7 +76,8 @@ export function SwapDetailsAlerts(props: SwapAlertsProps) {
       )}
       {step.status !== 'failed' && hasWarning && (
         <WarningAlert
-          switchNetwork={switchNetwork}
+          switchNetworkIsAvailable={switchNetworkIsAvailable}
+          handleSwitchNetworkClick={handleSwitchNetworkClick}
           showNetworkModal={showNetworkModal}
           setNetworkModal={setNetworkModal}
           message={message}

--- a/widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.types.ts
+++ b/widget/embedded/src/components/SwapDetailsAlerts/SwapDetailsAlerts.types.ts
@@ -1,6 +1,5 @@
 import type { getSwapMessages } from '../../utils/swap';
 import type { ModalState } from '../SwapDetailsModal';
-import type { ConnectResult } from '@rango-dev/wallets-react';
 import type { SwapperMeta } from 'rango-sdk';
 import type {
   BlockchainMeta,
@@ -15,7 +14,8 @@ export interface SwapAlertsProps extends WaningAlertsProps {
 }
 
 export interface WaningAlertsProps extends FailedAlertsProps {
-  switchNetwork: (() => Promise<ConnectResult[]>) | undefined;
+  switchNetworkIsAvailable: boolean;
+  handleSwitchNetworkClick: () => void;
   showNetworkModal: PendingSwapNetworkStatus | null | undefined;
   setNetworkModal: (network: ModalState) => void;
 }

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.NetworkState.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.NetworkState.tsx
@@ -1,17 +1,31 @@
 import type { NetworkStateContentProps } from './SwapDetailsModal.types';
 
 import { i18n } from '@lingui/core';
-import { MessageBox } from '@rango-dev/ui';
+import { Button, Divider, MessageBox } from '@rango-dev/ui';
 import React from 'react';
 
 export const NetworkStateContent = (props: NetworkStateContentProps) => {
-  const { status, message } = props;
+  const { switchNetworkModalState, handleSwitchNetwork } = props;
 
-  const type = status === 'waitingForNetworkChange' ? 'loading' : 'success';
-  const title =
-    status === 'waitingForNetworkChange'
-      ? i18n.t('Change Network')
-      : i18n.t('Network Changed');
-
-  return <MessageBox type={type} title={title} description={message} />;
+  return (
+    <>
+      <MessageBox
+        type={switchNetworkModalState.type}
+        title={switchNetworkModalState.title}
+        description={switchNetworkModalState.description}
+      />
+      {switchNetworkModalState.type === 'error' && (
+        <>
+          <Divider size="30" />
+          <Button
+            id="widget-switch-network-try-again"
+            type="primary"
+            size="large"
+            onClick={handleSwitchNetwork}>
+            {i18n.t('Try Again')}
+          </Button>
+        </>
+      )}
+    </>
+  );
 };

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.tsx
@@ -11,18 +11,32 @@ import { NetworkStateContent } from './SwapDetailsModal.NetworkState';
 import { WalletStateContent } from './SwapDetailsModal.WalletState';
 
 export function SwapDetailsModal(props: ModalPropTypes) {
-  const { isOpen, state, onClose, onDelete, onCancel, swap, message } = props;
+  const {
+    isOpen,
+    state,
+    switchNetworkModalState,
+    onClose,
+    onDelete,
+    onCancel,
+    swap,
+    message,
+    handleSwitchNetwork,
+  } = props;
 
   return (
     <WatermarkedModal
       open={isOpen}
       onClose={onClose}
       container={getContainer()}>
-      {state === 'waitingForConnectingWallet' && (
+      {state === 'connectWallet' && (
         <WalletStateContent swap={swap} message={message} onClose={onClose} />
       )}
-      {(state === 'waitingForNetworkChange' || state === 'networkChanged') && (
-        <NetworkStateContent message={message} status={state} />
+      {state === 'switchNetwork' && switchNetworkModalState && (
+        <NetworkStateContent
+          message={message}
+          switchNetworkModalState={switchNetworkModalState}
+          handleSwitchNetwork={handleSwitchNetwork}
+        />
       )}
       {state === 'delete' && (
         <DeleteContent

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.types.ts
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.types.ts
@@ -1,20 +1,29 @@
 import type { TargetNamespace } from '@rango-dev/queue-manager-rango-preset';
 import type { LegacyWalletType } from '@rango-dev/wallets-core/legacy';
-import type { PendingSwap, PendingSwapNetworkStatus } from 'rango-types';
+import type { PendingSwap } from 'rango-types';
 
 export type ModalState =
-  | Exclude<PendingSwapNetworkStatus, PendingSwapNetworkStatus.WaitingForQueue>
+  | 'connectWallet'
+  | 'switchNetwork'
   | 'delete'
   | 'cancel'
   | null;
+
+export type SwitchNetworkModalState = {
+  type: 'success' | 'loading' | 'error';
+  title: string;
+  description: string;
+};
 export interface ModalPropTypes {
   isOpen: boolean;
   onClose: () => void;
   onCancel: () => void;
   onDelete: () => void;
   state: ModalState;
+  switchNetworkModalState: SwitchNetworkModalState | null;
   swap: PendingSwap;
   message: string;
+  handleSwitchNetwork: () => void;
 }
 
 export interface CompleteModalPropTypes {
@@ -46,7 +55,8 @@ export interface WalletStateContentProps {
 
 export interface NetworkStateContentProps {
   message: string;
-  status: 'networkChanged' | 'waitingForNetworkChange';
+  switchNetworkModalState: SwitchNetworkModalState;
+  handleSwitchNetwork: () => void;
 }
 
 export interface InstallWalletContentProps {

--- a/widget/embedded/src/utils/swap.ts
+++ b/widget/embedded/src/utils/swap.ts
@@ -716,6 +716,13 @@ export function getSwapMessages(
       case PendingSwapNetworkStatus.WaitingForNetworkChange:
         message = message || i18n.t('Waiting for changing wallet network');
         break;
+      case PendingSwapNetworkStatus.NetworkChangeFailed:
+        message =
+          message ||
+          i18n.t(
+            'The network switch could not be completed. Please try again, or switch the network manually in your wallet.'
+          );
+        break;
       default:
         message = message || '';
         break;


### PR DESCRIPTION
# Summary

Improved switch network modal in swap details page adding success and error states so if the switch network process fail for any reason, a modal containing the appropriate message will be displayed with "try again" option and if the switch network process success,  a success modal will be displayed.

## Key changed

- Removed `resetNetworkStatus` in `actions/executeTransaction` so switch network stay open after successfully switching network
- Added calling `updateNetworkStatus` with appropriate params to display switch network failed modal on switch network failure
- Improved changing and maintaining the state of swap details modal
- Applied required ui changes to switch network modal in swap details page.

Related PR: https://github.com/rango-exchange/rango-types/pull/50

# How did you test this change?

Tested by running a transaction with a different required network other than the active network in the wallet and observed loading, success, error states for switch network modal.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
