### PR TITLE
fix: make widget compatible with rango-types

### DIFF
--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.helpers.tsx
@@ -19,4 +19,8 @@ export const modalNetworkValues: Record<
     type: 'success',
     title: i18n.t('Network Changed'),
   },
+  [PendingSwapNetworkStatus.NetworkChangeFailed]: {
+    type: 'warning',
+    title: i18n.t('Network Change Failed'),
+  },
 };


### PR DESCRIPTION
# Summary

After upgrading `rango-types` a new value as `NetworkChangeFailed` is added to `PendingSwapNetworkStatus`. This change should be applied to make `@rango-dev/widget-embedded` compatible with the latest version of `rango-types`.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
