### PR TITLE
fix: display correct state in confirm wallets modal

### DIFF
--- a/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/WalletList.tsx
@@ -123,9 +123,7 @@ export function WalletList(props: PropTypes) {
           ? getConciseAddress(address, ACCOUNT_ADDRESS_MAX_CHARACTERS)
           : '';
         const isConnectedButDifferentThanTargetNamespace =
-          isConnected && wallet.isHub
-            ? !conciseAddress
-            : !!wallet.needsNamespace && !conciseAddress;
+          isConnected && !!wallet.needsNamespace && !conciseAddress;
 
         const experimentalChain = isExperimentalChain(blockchains(), chain);
 


### PR DESCRIPTION
# Summary

There was in issue which was causing an incorrect state be displayed for some wallets in confirm wallet modal. This change fixes that issue by checking the wallet state properly.

Fixes #rf-2480
# How did you test this change?

Tested by checking the displayed state for different wallets in different states in confirm wallets modal.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
