### PR TITLE
fix: resolve error on get wallet info in playground

### DIFF
--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
@@ -14,7 +14,6 @@ import React from 'react';
 
 import { MultiSelect } from '../../components/MultiSelect';
 import { useConfigStore } from '../../store/config';
-import { useMetaStore } from '../../store/meta';
 
 import {
   connectButtonStyles,
@@ -27,12 +26,10 @@ import { getWalletsList } from './FunctionalLayout.utils';
 export function WalletSection() {
   const { state, connect, disconnect } = useWallets();
   const { onChangeWallets, onChangeBooleansConfig, config } = useConfigStore();
-  const {
-    meta: { blockchains },
-  } = useMetaStore();
 
   const { externalWallets, wallets, multiWallets } = config;
-  const allWalletList = getWalletsList(config, blockchains);
+  const { getWalletInfo } = useWallets();
+  const allWalletList = getWalletsList(config, getWalletInfo);
 
   const onChangeExternalWallet = (checked: boolean) => {
     if (!checked) {

--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.utils.ts
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.utils.ts
@@ -1,7 +1,7 @@
 import type { MapSupportedList } from '../../components/MultiSelect/MultiSelect.types';
-import type { WalletTypes } from '@rango-dev/wallets-shared';
+import type { ExtendedWalletInfo } from '@rango-dev/wallets-react';
+import type { WalletType, WalletTypes } from '@rango-dev/wallets-shared';
 import type { WidgetConfig } from '@rango-dev/widget-embedded';
-import type { BlockchainMeta } from 'rango-sdk';
 
 import { allProviders as getAllProviders } from '@rango-dev/provider-all';
 import { pickVersion, type VersionedProviders } from '@rango-dev/wallets-core';
@@ -9,10 +9,21 @@ import { pickVersion, type VersionedProviders } from '@rango-dev/wallets-core';
 import { getCategoryNetworks } from '../../utils/blockchains';
 import { excludedWallets } from '../../utils/common';
 
+function getProviderId(versionedProvider: VersionedProviders) {
+  try {
+    const provider = pickVersion(versionedProvider, '1.0.0')[1];
+    return provider.id;
+  } catch {
+    // Fallback to legacy version, if target version doesn't exists.
+    const provider = pickVersion(versionedProvider, '0.0.0')[1];
+    return provider.config.type;
+  }
+}
+
 // Considering that the wallets list of the config used for `WidgetProvider` gets filtered by the selected wallets here, we can not directly use `getWalletInfo` of `useWallets` to get the info related to each wallet item because the required provider for an unselected wallet item will not be passed to `Provider`.
 export function getWalletsList(
   config: WidgetConfig,
-  blockchains: BlockchainMeta[]
+  getWalletInfo: (type: WalletType) => ExtendedWalletInfo
 ): MapSupportedList[] {
   const envs = {
     walletconnect2: {
@@ -30,50 +41,24 @@ export function getWalletsList(
   };
   const allProviders = getAllProviders(envs);
   const allBuiltProviders = allProviders.map((build) => build());
-  const walletsList: MapSupportedList[] = [];
-  allBuiltProviders.forEach((versionedProvider: VersionedProviders) => {
-    let provider;
-    try {
-      provider = pickVersion(versionedProvider, '1.0.0')[1];
-      if (excludedWallets.includes(provider.id as WalletTypes)) {
-        return;
-      }
-      const info = provider.info();
+  const providersIdList = allBuiltProviders.map(getProviderId);
+  const notExcludedProvidersIdList = providersIdList.filter(
+    (providerId) => !excludedWallets.includes(providerId as WalletTypes)
+  );
+  const walletsList: MapSupportedList[] = notExcludedProvidersIdList.map(
+    (providerId: string) => {
+      const info = getWalletInfo(providerId);
       if (!info) {
         throw new Error('Provider info is not available.');
       }
-      const providerProperties = info?.properties;
-      const namespacesProperty = providerProperties?.find(
-        (property) => property.name === 'namespaces'
-      );
-      const supportedChainsNames = namespacesProperty?.value.data
-        .flatMap((obj) => obj.chains)
-        .map((chain) => chain.name);
 
-      const supportedChains = blockchains?.filter((blockchain) =>
-        supportedChainsNames?.includes(blockchain.name)
-      );
-      walletsList.push({
+      return {
         title: info.name,
-        logo: info.icon,
-        name: provider.id,
-        supportedNetworks: getCategoryNetworks(supportedChains),
-      });
-    } catch {
-      // Fallback to legacy version, if target version doesn't exists.
-      provider = pickVersion(versionedProvider, '0.0.0')[1];
-      if (excludedWallets.includes(provider.config.type as WalletTypes)) {
-        return;
-      }
-      const walletInfo = provider.getWalletInfo(blockchains);
-      walletsList.push({
-        title: walletInfo.name,
-        logo: walletInfo.img,
-        name: provider.config.type,
-        supportedNetworks: getCategoryNetworks(walletInfo.supportedChains),
-      });
+        logo: info.img,
+        name: providerId,
+        supportedNetworks: getCategoryNetworks(info.supportedChains),
+      };
     }
-  });
-
+  );
   return walletsList;
 }


### PR DESCRIPTION
# Summary

This PR addresses an issue encountered in retrieving hub wallet information within the functional settings on the playground. The problem stemmed from calling info method on hub wallets, triggering a 'You need to set your store using .store method first.' error due to the store not being configured for the hub. Directly accessing provider information led to this error. The error was caught by checking information on the legacy provider, but the `getWalletInfo` method was not implemented for the slush wallet in the legacy provider, causing the playground to crash. This PR resolves this issue by obtaining the necessary information through the getWalletInfo method provided by the `useWallets` hook.
# How did you test this change?

Tested by checking wallets list in functional settings on playground.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
