### PR TITLE
fix: wallets playground crash on hub provider info access (temporary fix)

### DIFF
--- a/wallets/provider-slush/src/legacy/index.ts
+++ b/wallets/provider-slush/src/legacy/index.ts
@@ -1,8 +1,13 @@
 import type { LegacyProviderInterface } from '@rango-dev/wallets-core/legacy';
 import type { Connect, WalletInfo } from '@rango-dev/wallets-shared';
-import type { BlockchainMeta, SignerFactory } from 'rango-types';
 
 import { WalletTypes } from '@rango-dev/wallets-shared';
+import {
+  type BlockchainMeta,
+  type SignerFactory,
+  type SuiBlockchainMeta,
+  TransactionType,
+} from 'rango-types';
 
 import { suiWalletInstance } from '../utils.js';
 
@@ -26,8 +31,40 @@ const connect: Connect = async () => {
 export const getSigners: (provider: Provider) => Promise<SignerFactory> =
   signer;
 
-const getWalletInfo: (allBlockChains: BlockchainMeta[]) => WalletInfo = () => {
-  throw new Error('not implemented');
+export const getWalletInfo: (allBlockChains: BlockchainMeta[]) => WalletInfo = (
+  allBlockChains
+) => {
+  const sui = allBlockChains.filter(
+    (blockchain) => blockchain.type === TransactionType.SUI
+  );
+
+  return {
+    name: 'Slush',
+    img: 'https://raw.githubusercontent.com/rango-exchange/assets/main/wallets/slush/icon.svg',
+    installLink: {
+      CHROME:
+        'https://chromewebstore.google.com/detail/slush-%E2%80%94-a-sui-wallet/opcgpfmipidbgpenhmajoajpbobppdil',
+      DEFAULT: 'https://slush.app/download',
+    },
+    color: '#4d40c6',
+    // if you are adding a new namespace, don't forget to also update `properties`
+    needsNamespace: {
+      selection: 'multiple',
+      data: [
+        {
+          label: 'Sui',
+          value: 'Sui',
+          id: 'SUI',
+          getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
+            allBlockchains.filter(
+              (chain): chain is SuiBlockchainMeta =>
+                chain.type === TransactionType.SUI
+            ),
+        },
+      ],
+    },
+    supportedChains: sui,
+  };
 };
 
 const buildLegacyProvider: () => LegacyProviderInterface = () => ({


### PR DESCRIPTION
# Summary

Clicking on wallets in the Playground caused a crash. This was due to a bug in `getWalletInfo` that's being addressed in **PR #1167**. The specific issue here was that `getWalletInfo` for **Slush Wallet** in its *legacy model* was also throwing an error, meaning our fallback mechanism wasn't working.

Fixes # (issue)

I've added a basic `getWalletInfo` implementation to the **legacy version of Slush Wallet**. This is a **temporary fix** to prevent the crash and unblock our current release. 

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
