### PR TITLE
fix: turn autocomplete off for history search input

### DIFF
--- a/widget/embedded/src/pages/HistoryPage.tsx
+++ b/widget/embedded/src/pages/HistoryPage.tsx
@@ -161,6 +161,7 @@ export function HistoryPage() {
             placeholder={i18n.t('Search Transaction')}
             id="widget-history-search-transaction-input"
             autoFocus
+            autoComplete="off"
             onChange={handleSearch}
             style={{ height: 36 }}
             value={searchedFor}


### PR DESCRIPTION
# Summary

This PR addresses an issue where the search input on the History page retained its last value upon re-entry, even after navigating away without explicitly clearing it.

Fixes # (issue)
This PR resolves the issue by disabling autocomplete for the search input field on the History page.

# How did you test this change?

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
