### PR TITLE
fix: autocomplete off for search inputs

### DIFF
--- a/widget/embedded/src/pages/HistoryPage.tsx
+++ b/widget/embedded/src/pages/HistoryPage.tsx
@@ -161,7 +161,6 @@ export function HistoryPage() {
             placeholder={i18n.t('Search Transaction')}
             id="widget-history-search-transaction-input"
             autoFocus
-            autoComplete="off"
             onChange={handleSearch}
             style={{ height: 36 }}
             value={searchedFor}

--- a/widget/ui/src/components/TextField/TextField.tsx
+++ b/widget/ui/src/components/TextField/TextField.tsx
@@ -66,6 +66,7 @@ function TextFieldComponent(
         className="_text-field">
         {prefix || null}
         <Input
+          autoComplete="off"
           {...inputAttributes}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}


### PR DESCRIPTION
# Summary

I've **disabled autocomplete** for all search inputs across the application. This change addresses recent issues where browser autocomplete was being unintentionally triggered.


Fixes # (issue)

Previously, assigning **IDs to our input fields** was causing browsers to enable their native autocomplete features, leading to unexpected and inconsistent behavior within our search functionalities. This fix explicitly sets `autocomplete="off"` for all search input elements, effectively preventing browsers from offering unwanted suggestions and ensuring a smoother user experience.



# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
