### PR TITLE
fix: layout shift on custom slippage input

### DIFF
--- a/widget/embedded/src/components/Slippage/Slippage.styles.ts
+++ b/widget/embedded/src/components/Slippage/Slippage.styles.ts
@@ -34,23 +34,23 @@ export const SlippageChip = styled(Chip, {
 });
 
 export const SlippageTextFieldContainer = styled('div', {
-  borderWidth: 1,
-  borderStyle: 'solid',
+  outlineWidth: 1,
+  outlineStyle: 'solid',
   borderRadius: '$xs',
   flex: 1,
   variants: {
     status: {
       safe: {
-        borderColor: '$secondary500',
+        outlineColor: '$secondary500',
       },
       error: {
-        borderColor: '$error500',
+        outlineColor: '$error500',
       },
       warning: {
-        borderColor: '$warning500',
+        outlineColor: '$warning500',
       },
       empty: {
-        borderWidth: 0,
+        outlineWidth: 0,
       },
     },
   },


### PR DESCRIPTION
# Summary

We are experiencing a layout shift when typing numbers into the custom slippage input field.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
