### PR TITLE
feat: display detached modal when fully connected wallet is clicked

### DIFF
--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
@@ -7,10 +7,7 @@ import { WalletState } from '@rango-dev/ui';
 import { useWallets } from '@rango-dev/wallets-react';
 import { useReducer } from 'react';
 
-import {
-  checkIsWalletPartiallyConnected,
-  type ExtendedModalWalletInfo,
-} from '../../utils/wallets';
+import { type ExtendedModalWalletInfo } from '../../utils/wallets';
 
 import {
   isStateOnDerivationPathStep,
@@ -148,14 +145,12 @@ export function useStatefulConnect(): UseStatefulConnect {
       }
     }
 
+    // If the wallet is a hub wallet and it is connected (fully or partially) and it contains more than one namespace, we should display detached modal
     if (!!wallet.isHub) {
-      const walletState = state(wallet.type);
-      const namespacesState = walletState.namespaces;
-      const isPartiallyConnected = checkIsWalletPartiallyConnected(
-        wallet,
-        namespacesState
-      );
-      if (isPartiallyConnected) {
+      const needsNamespace = wallet.properties?.find(
+        (item) => item.name === 'namespaces'
+      )?.value;
+      if (needsNamespace?.data.length && needsNamespace.data.length > 1) {
         dispatch({
           type: 'detached',
           payload: {


### PR DESCRIPTION
# Summary

Before this change, clicking on a fully connected hub wallet which contains more than one namespace in Wallets page was resulting in disconnecting the wallet. In this PR, this behavior is changed so Detached modal will be displayed in this situation.

Fixes # 2467


# How did you test this change?

Tested by connecting to the all supported namespaces by Phantom wallet and then clicking on the wallet item in Wallets page and observing that Detached modal is displayed instead of disconnecting the wallet.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
