### PR TITLE
fix: change `faker.number.float` precision option to `multipleOf`

### DIFF
--- a/widget/embedded/src/utils/validation.test.ts
+++ b/widget/embedded/src/utils/validation.test.ts
@@ -12,7 +12,7 @@ const FAKER_SEED = 14;
 const THREE_MAX_DECIMAL = 3;
 const FOUR_MAX_DECIMAL = 4;
 const SMALL_INT = { min: 1, max: 9 };
-const FLOAT_OPTS = { min: 0, max: 100, precision: 0.01 };
+const FLOAT_OPTS = { min: 0, max: 100, multipleOf: 0.01 };
 faker.seed(FAKER_SEED);
 
 describe('check validation behaviors', () => {


### PR DESCRIPTION
# Summary
The precision option of `faker.number.float` [will be deprecated](https://fakerjs.dev/api/number.html#float) in the next major version. This PR changes it to `multipleOf` instead, hence removing the warnings from the [CI logs](https://github.com/rango-exchange/rango-client/actions/runs/15557618986/job/43802006925#step:7:41):
```python
[@faker-js/faker]: faker.number.float({ precision }) is deprecated since v8.4 and will be removed in v9.0. Please use faker.number.float({ multipleOf }) instead.
```

# How did you test this change?
Run the test suite.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
