### PR TITLE
fix: abort all namespace connections if user rejects one connect request

### DIFF
--- a/wallets/core/src/hub/mod.ts
+++ b/wallets/core/src/hub/mod.ts
@@ -1,4 +1,8 @@
-export type { Subscriber, SubscriberCleanUp } from './namespaces/mod.js';
+export type {
+  Subscriber,
+  SubscriberCleanUp,
+  Context,
+} from './namespaces/mod.js';
 export { Namespace } from './namespaces/mod.js';
 
 export { Provider } from './provider/mod.js';

--- a/wallets/core/src/mod.ts
+++ b/wallets/core/src/mod.ts
@@ -6,6 +6,7 @@ export type {
   CommonNamespaceKeys,
   Subscriber,
   SubscriberCleanUp,
+  Context,
 } from './hub/mod.js';
 export {
   Hub,

--- a/wallets/core/src/namespaces/evm/utils.ts
+++ b/wallets/core/src/namespaces/evm/utils.ts
@@ -50,3 +50,17 @@ export async function switchOrAddNetwork(
     throw switchError;
   }
 }
+
+const EIP_1193_USER_REJECTION_ERROR_CODE = 4001;
+export function isUserRejectionError(error: unknown): boolean {
+  // EIP-1193 user rejection error can be in error.code or error.cause.code
+  if (typeof error === 'object' && error !== null) {
+    const code = (error as { code?: number }).code;
+    const causeCode = (error as { cause?: { code?: number } }).cause?.code;
+    return (
+      code === EIP_1193_USER_REJECTION_ERROR_CODE ||
+      causeCode === EIP_1193_USER_REJECTION_ERROR_CODE
+    );
+  }
+  return false;
+}

--- a/wallets/provider-trustwallet/src/namespaces/evm.ts
+++ b/wallets/provider-trustwallet/src/namespaces/evm.ts
@@ -8,7 +8,10 @@ import {
 import { actions, builders } from '@rango-dev/wallets-core/namespaces/evm';
 
 import { WALLET_ID } from '../constants.js';
-import { evmTrustWallet } from '../utils.js';
+import {
+  evmTrustWallet,
+  standardizeTrustWalletInAppBrowserError,
+} from '../utils.js';
 
 const [changeAccountSubscriber, changeAccountCleanup] =
   actions.changeAccountSubscriber(evmTrustWallet);
@@ -18,6 +21,7 @@ const connect = builders
   .action(actions.connect(evmTrustWallet))
   .before(changeAccountSubscriber)
   .or(changeAccountCleanup)
+  .or(standardizeTrustWalletInAppBrowserError)
   .or(standardizeAndThrowError)
   .build();
 

--- a/wallets/provider-trustwallet/src/namespaces/solana.ts
+++ b/wallets/provider-trustwallet/src/namespaces/solana.ts
@@ -8,7 +8,10 @@ import {
 import { actions, builders } from '@rango-dev/wallets-core/namespaces/solana';
 
 import { WALLET_ID } from '../constants.js';
-import { solanaTrustWallet } from '../utils.js';
+import {
+  solanaTrustWallet,
+  standardizeTrustWalletInAppBrowserError,
+} from '../utils.js';
 
 const [changeAccountSubscriber, changeAccountCleanup] =
   actions.changeAccountSubscriber(solanaTrustWallet);
@@ -18,6 +21,7 @@ const connect = builders
   .action(actions.connect(solanaTrustWallet))
   .before(changeAccountSubscriber)
   .or(changeAccountCleanup)
+  .or(standardizeTrustWalletInAppBrowserError)
   .or(standardizeAndThrowError)
   .build();
 

--- a/wallets/provider-trustwallet/src/utils.ts
+++ b/wallets/provider-trustwallet/src/utils.ts
@@ -1,8 +1,8 @@
+import type { Context } from '@rango-dev/wallets-core';
 import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Provider = Record<string, any>;
 export function trustWallet(): Provider | null {
@@ -48,4 +48,19 @@ export function solanaTrustWallet(): SolanaProviderApi {
   }
 
   return solanaInstance as SolanaProviderApi;
+}
+
+// Considering that the errors thrown in Trust Wallet in-app browser do not follow EIP-1193, we detect such errors and standardize them.
+export function standardizeTrustWalletInAppBrowserError(
+  _context: Context,
+  error: unknown
+) {
+  if (typeof error === 'string' && error === 'cancelled') {
+    const error = new Error('User rejected the request') as Error & {
+      code: number;
+    };
+    error.code = 4001;
+    return error;
+  }
+  return error;
 }

--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -4,6 +4,7 @@ import type { Provider } from '@rango-dev/wallets-core';
 import type { LegacyNamespaceInputForConnect } from '@rango-dev/wallets-core/legacy';
 import type { VersionedProviders } from '@rango-dev/wallets-core/utils';
 
+import { utils } from '@rango-dev/wallets-core/namespaces/evm';
 import { type WalletInfo } from '@rango-dev/wallets-shared';
 import { useEffect, useRef, useState } from 'react';
 import { Ok, Result } from 'ts-results';
@@ -43,7 +44,13 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
     allBlockChains: params.allBlockChains,
   });
 
-  const queueTask = createQueue();
+  const queueTask = createQueue({
+    onError: (error, actions) => {
+      if (utils.isUserRejectionError(error)) {
+        actions.removeCurrentKeyFromQueue();
+      }
+    },
+  });
 
   useEffect(() => {
     dataRef.current = {


### PR DESCRIPTION
# Summary

Currently, if user select multiple namespace to connect to and rejects the connect request in wallet for one namespace, widget will try to connect to other remaining namespaces resulting in multiple connect requests on wallet which can be annoying for the user. In this PR, this behavior is changed by checking for the code of error related to failed connect request and if it is equal to 4001 (which is documented [here](https://eips.ethereum.org/EIPS/eip-1193#provider-errors) for Ethereum wallets and also is accepted by [Solana wallets](https://docs.phantom.com/solana/errors)) the connection for remaining namespaces will be aborted.

Fixes # 2399


# How did you test this change?

Tested by trying to connect to all namespaces on Phantom and Trust wallet and rejecting the connect request in wallet and observing that remaining connect errors fail without triggering any connect request to the wallet.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
