### PR TITLE
fix: handle long names and numbers

### DIFF
--- a/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.styles.ts
+++ b/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.styles.ts
@@ -1,4 +1,4 @@
-import { Button, darkTheme, styled } from '@rango-dev/ui';
+import { Button, darkTheme, styled, Typography } from '@rango-dev/ui';
 
 export const StyledLink = styled('a', {
   textDecoration: 'none',
@@ -58,4 +58,17 @@ export const Container = styled('div', {
 
 export const StyledButton = styled(Button, {
   minHeight: '$40',
+});
+
+export const TokenSymbolText = styled(Typography, {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  maxWidth: '96px',
+});
+
+export const FlexCenteredContainer = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
 });

--- a/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.tsx
+++ b/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.tsx
@@ -1,7 +1,14 @@
 import type { PropTypes } from './CustomTokenModal.types';
 
 import { i18n } from '@lingui/core';
-import { Divider, ExternalLinkIcon, Image, Typography } from '@rango-dev/ui';
+import {
+  Divider,
+  ExternalLinkIcon,
+  Image,
+  InfoIcon,
+  Tooltip,
+  Typography,
+} from '@rango-dev/ui';
 import React from 'react';
 
 import { DEFAULT_TOKEN_IMAGE_SRC } from '../../constants/customTokens';
@@ -10,8 +17,15 @@ import { WatermarkedModal } from '../common/WatermarkedModal';
 
 import { CUSTOM_TOKEN_LEARN_MORE_LINK } from './CustomTokenModal.constants';
 import { generateExplorerLink } from './CustomTokenModal.helpers';
-import { Container, StyledButton, StyledLink } from './CustomTokenModal.styles';
+import {
+  Container,
+  FlexCenteredContainer,
+  StyledButton,
+  StyledLink,
+  TokenSymbolText,
+} from './CustomTokenModal.styles';
 
+const MAX_SYMBOL_LENGTH_THRESHOLD = 9;
 export function CustomTokenModal(props: PropTypes) {
   const { open, onClose, token, onExit, onSubmitClick, blockchain } = props;
 
@@ -35,9 +49,17 @@ export function CustomTokenModal(props: PropTypes) {
           type="circular"
         />
         <Divider size={4} />
-        <Typography variant="title" size="medium">
-          {token.symbol}
-        </Typography>
+        <FlexCenteredContainer>
+          <TokenSymbolText variant="title" size="medium">
+            {token.symbol}
+          </TokenSymbolText>
+          {token.symbol.length > MAX_SYMBOL_LENGTH_THRESHOLD && (
+            <Tooltip content={token.symbol} container={getContainer()}>
+              <InfoIcon size={12} color="gray" />
+            </Tooltip>
+          )}
+        </FlexCenteredContainer>
+
         <Typography variant="body" size="small" className="_blockchain-name">
           {blockchain.displayName}
         </Typography>

--- a/widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.styles.ts
+++ b/widget/embedded/src/components/LoadingSwapDetails/LoadingSwapDetails.styles.ts
@@ -25,12 +25,6 @@ export const quoteSummaryItemStyles = css({
   alignItems: 'center',
 });
 
-export const tokenAmountStyles = css({
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-});
-
 export const costStyles = css({
   paddingTop: '$15',
   display: 'flex',

--- a/widget/embedded/src/components/Quote/Quote.styles.ts
+++ b/widget/embedded/src/components/Quote/Quote.styles.ts
@@ -196,17 +196,6 @@ export const rowStyles = css({
     marginLeft: '-$8',
   },
 });
-export const basicInfoStyles = css({
-  display: 'flex',
-  alignItems: 'center',
-  '.usd-value': {
-    $$color: '$colors$neutral600',
-    [`.${darkTheme} &`]: {
-      $$color: '$colors$neutral700',
-    },
-    color: '$$color',
-  },
-});
 
 export const Trigger = styled(Collapsible.Trigger, {
   display: 'flex',
@@ -343,23 +332,28 @@ export const HorizontalSeparator = styled('div', {
   borderColor: '$$color',
 });
 
-export const FrameIcon = styled('div', {
-  width: '$16',
-  height: '$16',
-  justifyContent: 'center',
-  alignItems: 'center',
+export const BasicInfoOutput = styled('div', {
   display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: '$2',
+  flex: '1 1 auto',
+  minWidth: 0,
 });
 
-export const BasicInfoOutput = styled(Typography, {
+export const TokenNameText = styled(Typography, {
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  letterSpacing: 0.4,
+  whiteSpace: 'nowrap',
+  maxWidth: '$30',
 });
 
-export const ContainerInfoOutput = styled('div', {
-  display: 'flex',
-  flexWrap: 'wrap',
+export const AmountText = styled(Typography, {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  minWidth: 0,
+  flex: '0 1 auto',
 });
 
 export const MoreStep = styled('div', {
@@ -395,4 +389,13 @@ export const Line = styled('div', {
   [`.${darkTheme} &`]: {
     borderTopColor: '$neutral800',
   },
+});
+
+export const UsdValueText = styled(Typography, {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  flex: '0 1 auto',
+  minWidth: 0,
+  flexShrink: 3,
 });

--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -13,6 +13,7 @@ import {
   StepDetails,
   TokenAmount,
   Typography,
+  useIsTruncated,
 } from '@rango-dev/ui';
 import BigNumber from 'bignumber.js';
 import React, { useRef, useState } from 'react';
@@ -57,11 +58,9 @@ import { getTotalFeeInUsd, getUsdFeeOfStep } from '../../utils/swap';
 
 import {
   AllRoutesButton,
+  AmountText,
   BasicInfoOutput,
-  basicInfoStyles,
-  ContainerInfoOutput,
   Content,
-  FrameIcon,
   HorizontalSeparator,
   Line,
   QuoteContainer,
@@ -70,6 +69,8 @@ import {
   summaryHeaderStyles,
   summaryStyles,
   TagContainer,
+  TokenNameText,
+  UsdValueText,
 } from './Quote.styles';
 import { QuoteCostDetails } from './QuoteCostDetails';
 import { QuoteSummary } from './QuoteSummary';
@@ -97,11 +98,6 @@ export function Quote(props: QuoteProps) {
   const userSlippage = customSlippage || slippage;
   const [expanded, setExpanded] = useState(props.expanded);
   const quoteRef = useRef<HTMLButtonElement | null>(null);
-  const roundedInput = numberToString(
-    input.value,
-    TOKEN_AMOUNT_MIN_DECIMALS,
-    TOKEN_AMOUNT_MAX_DECIMALS
-  );
   const roundedOutput = numberToString(
     output.value,
     TOKEN_AMOUNT_MIN_DECIMALS,
@@ -241,6 +237,7 @@ export function Quote(props: QuoteProps) {
                         <Typography
                           size="xsmall"
                           variant="body"
+                          className="from-amount-text"
                           color="neutral900">
                           {i18n.t({
                             id: 'Yours: {amount} {symbol}',
@@ -328,6 +325,15 @@ export function Quote(props: QuoteProps) {
   const feeWarning = totalFee.gte(new BigNumber(GAS_FEE_MAX));
   const timeWarning =
     totalDurationSeconds / SECONDS_IN_MINUTE >= ROUTE_TIME_MAX;
+  const inputValueRef = useRef<HTMLSpanElement | null>(null);
+  const isInputValueTruncated = useIsTruncated(input.value, inputValueRef);
+  const outputValueRef = useRef<HTMLSpanElement | null>(null);
+  const isOutputValueTruncated = useIsTruncated(output.value, outputValueRef);
+  const usdValueRef = useRef<HTMLSpanElement | null>(null);
+  const isUsdValueTruncated = useIsTruncated(
+    roundedOutputUsdValue,
+    usdValueRef
+  );
 
   const lastStep = steps[numberOfSteps - 1];
   const firstStep = steps[0];
@@ -428,31 +434,52 @@ export function Quote(props: QuoteProps) {
           )}
         </div>
         {type === 'basic' && (
-          <div className={basicInfoStyles()}>
-            <FrameIcon>
-              <InfoIcon size={12} color="gray" />
-            </FrameIcon>
-            <ContainerInfoOutput>
-              <BasicInfoOutput size="small" variant="body">
-                {`${roundedInput} ${firstStep.from.token.displayName} = `}
-              </BasicInfoOutput>
+          <BasicInfoOutput>
+            <AmountText ref={inputValueRef} size="small" variant="body">
+              {input.value}
+            </AmountText>
+            {isInputValueTruncated && (
+              <NumericTooltip
+                content={input.value}
+                container={container}
+                open={!input.value ? false : undefined}>
+                <InfoIcon size={12} color="gray" />
+              </NumericTooltip>
+            )}
+            <TokenNameText size="small" variant="body">
+              {steps[0]?.from.token.displayName}
+            </TokenNameText>
+            <Typography size="small" variant="body">
+              =
+            </Typography>
+            <AmountText ref={outputValueRef} size="small" variant="body">
+              {output.value}
+            </AmountText>
+            {isOutputValueTruncated && (
               <NumericTooltip
                 content={output.value}
                 container={container}
                 open={!output.value ? false : undefined}>
-                <BasicInfoOutput size="small" variant="body">
-                  &nbsp;
-                  {`${roundedOutput} ${lastStep.to.token.displayName}`}
-                </BasicInfoOutput>
+                <InfoIcon size={12} color="gray" />
               </NumericTooltip>
-            </ContainerInfoOutput>
-            <NumericTooltip content={output.usdValue} container={container}>
-              <Divider size={2} direction="horizontal" />
-              <Typography color="$neutral600" size="xsmall" variant="body">
-                {`($${roundedOutputUsdValue})`}
-              </Typography>
-            </NumericTooltip>
-          </div>
+            )}
+            <TokenNameText size="small" variant="body">
+              {lastStep?.to.token.displayName}
+            </TokenNameText>
+            <Divider size={2} direction="horizontal" />
+            <UsdValueText
+              ref={usdValueRef}
+              color="$neutral600"
+              size="xsmall"
+              variant="body">
+              {`($${roundedOutputUsdValue})`}
+            </UsdValueText>
+            {isUsdValueTruncated && (
+              <NumericTooltip content={output.usdValue} container={container}>
+                <InfoIcon size={12} color="gray" />
+              </NumericTooltip>
+            )}
+          </BasicInfoOutput>
         )}
         {type === 'list-item' && (
           <TokenAmount

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/HighValueLossWarningModal.tsx
@@ -16,8 +16,6 @@ import {
   GAS_FEE_MIN_DECIMALS,
   PERCENTAGE_CHANGE_MAX_DECIMALS,
   PERCENTAGE_CHANGE_MIN_DECIMALS,
-  USD_VALUE_MAX_DECIMALS,
-  USD_VALUE_MIN_DECIMALS,
 } from '../../constants/routing';
 import { getContainer } from '../../utils/common';
 import { numberToString } from '../../utils/numbers';
@@ -41,11 +39,7 @@ export function HighValueLossWarningModal(props: Props) {
   const highValueLossData = [
     {
       title: i18n.t('Swapping'),
-      value: numberToString(
-        warning.inputUsdValue,
-        USD_VALUE_MIN_DECIMALS,
-        USD_VALUE_MAX_DECIMALS
-      ),
+      value: numberToString(warning.inputUsdValue),
     },
     {
       title: i18n.t('Gas cost'),
@@ -57,11 +51,7 @@ export function HighValueLossWarningModal(props: Props) {
     },
     {
       title: i18n.t('Receiving'),
-      value: numberToString(
-        warning.outputUsdValue,
-        USD_VALUE_MIN_DECIMALS,
-        USD_VALUE_MAX_DECIMALS
-      ),
+      value: numberToString(warning.outputUsdValue),
     },
     {
       title: i18n.t('Price impact'),

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteErrorsModalItem.tsx
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteErrorsModalItem.tsx
@@ -1,24 +1,40 @@
 import type { ModalContentData } from './QuoteWarningsAndErrors.types';
 
-import { Typography } from '@rango-dev/ui';
+import { InfoIcon, Tooltip, Typography } from '@rango-dev/ui';
 import React from 'react';
 
-import { Item } from './QuoteWarningsAndErrors.styles';
+import { getContainer } from '../../utils/common';
+
+import {
+  Item,
+  ValueContent,
+  ValueTypography,
+} from './QuoteWarningsAndErrors.styles';
+
+const VALUE_LENGTH_THRESHOLD = 35;
 
 export function QuoteErrorsModalItem(props: ModalContentData) {
   const { title, value, valueColor } = props;
+  const container = getContainer();
 
   return (
     <Item>
       <Typography size="medium" variant="label" className="_title">
         {title}
       </Typography>
-      <Typography
-        size="large"
-        variant="label"
-        color={valueColor || 'foreground'}>
-        {`${valueColor ? '%' : '$'}${value}`}
-      </Typography>
+      <ValueContent>
+        <ValueTypography
+          size="large"
+          variant="label"
+          color={valueColor || 'foreground'}>
+          {`${valueColor ? '%' : '$'}${value}`}
+        </ValueTypography>
+        {value.length > VALUE_LENGTH_THRESHOLD && (
+          <Tooltip content={value} container={container}>
+            <InfoIcon size={12} color="gray" />
+          </Tooltip>
+        )}
+      </ValueContent>
     </Item>
   );
 }

--- a/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.styles.ts
+++ b/widget/embedded/src/components/QuoteWarningsAndErrors/QuoteWarningsAndErrors.styles.ts
@@ -1,4 +1,4 @@
-import { Button, darkTheme, styled } from '@rango-dev/ui';
+import { Button, darkTheme, styled, Typography } from '@rango-dev/ui';
 
 export const Alerts = styled('div', {
   width: '100%',
@@ -25,6 +25,20 @@ export const Item = styled('div', {
     },
     color: '$$color',
   },
+});
+
+export const ValueContent = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '$2',
+});
+
+export const ValueTypography = styled(Typography, {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  maxWidth: '250px',
 });
 
 export const Action = styled('div', {

--- a/widget/embedded/src/components/SwapDetails/SwapDetails.styles.ts
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.styles.ts
@@ -109,6 +109,7 @@ export const ErrorMessages = styled('div', {
   flexDirection: 'column',
   gap: '$5',
 });
+
 export const MessageText = styled(Typography, {
   wordBreak: 'break-word',
 });

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsCompleteModal.tsx
@@ -20,7 +20,7 @@ import { useUiStore } from '../../store/ui';
 import { getContainer } from '../../utils/common';
 import { WatermarkedModal } from '../common/WatermarkedModal';
 
-import { ProfileBanner } from './SwapDetailsModal.styles';
+import { ProfileBanner, wordWrap } from './SwapDetailsModal.styles';
 
 export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
   const {
@@ -68,6 +68,7 @@ export function SwapDetailsCompleteModal(props: CompleteModalPropTypes) {
           />
           <Divider size={12} />
           <Typography
+            className={wordWrap()}
             variant="body"
             size="medium"
             color="neutral700"

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.styles.ts
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.styles.ts
@@ -1,16 +1,8 @@
-import { darkTheme, styled } from '@rango-dev/ui';
+import { css, darkTheme, styled } from '@rango-dev/ui';
 
-export const WalletContainer = styled('div', {
-  display: 'flex',
-  justifyContent: 'center',
-});
-
-export const TooltipErrorContent = styled('div', {
-  maxWidth: 280,
-  '& ._typography': {
-    wordWrap: 'break-word',
-    display: 'block',
-  },
+export const wordWrap = css({
+  wordWrap: 'break-word',
+  display: 'block',
 });
 
 export const ProfileBanner = styled('img', {

--- a/widget/embedded/src/containers/QuoteInfo/QuoteInfo.styles.ts
+++ b/widget/embedded/src/containers/QuoteInfo/QuoteInfo.styles.ts
@@ -8,6 +8,9 @@ export const QuoteContainer = styled('div', {
 });
 export const FooterStepAlarm = styled('div', {
   paddingBottom: '$15',
+  '& .from-amount-text': {
+    wordBreak: 'break-word',
+  },
   variants: {
     dense: {
       true: {

--- a/widget/ui/src/components/Alert/Alert.styles.ts
+++ b/widget/ui/src/components/Alert/Alert.styles.ts
@@ -95,6 +95,9 @@ export const Main = styled('div', {
   display: 'flex',
   alignItems: 'center',
   alignSelf: 'stretch',
+  whiteSpace: 'normal',
+  wordBreak: 'break-all',
+
   variants: {
     variant: {
       regular: {

--- a/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.TokenSection.tsx
+++ b/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.TokenSection.tsx
@@ -1,16 +1,20 @@
 import type { TokenSectionPropTypes } from './FullExpandedQuote.types.js';
 
 import React from 'react';
+import { InfoIcon } from 'src/icons/index.js';
 
 import { ChainToken } from '../ChainToken/index.js';
+import { textTruncate } from '../TokenAmount/TokenAmount.styles.js';
 import { NumericTooltip } from '../Tooltip/index.js';
 import { Typography } from '../Typography/index.js';
 
 import {
+  AmountText,
   TokenInfo,
-  tokenLabelStyles,
   TokenSectionContainer,
 } from './FullExpandedQuote.styles.js';
+
+const MAX_AMOUNT_LENGTH_FOR_INFO_ICON = 6;
 
 export function TokenSection(props: TokenSectionPropTypes) {
   const {
@@ -23,6 +27,7 @@ export function TokenSection(props: TokenSectionPropTypes) {
     isInternalSwap,
     size = 'xmedium',
   } = props;
+
   return (
     <TokenSectionContainer style={style} isInternalSwap={isInternalSwap}>
       <ChainToken size={size} chainImage={chainImage} tokenImage={tokenImage} />
@@ -32,14 +37,22 @@ export function TokenSection(props: TokenSectionPropTypes) {
           container={tooltipProps?.container}
           side="bottom"
           open={tooltipProps?.open}>
-          <Typography
+          <AmountText
             size="xsmall"
             variant="body"
-            className={isInternalSwap ? tokenLabelStyles() : ''}>
+            className={`${textTruncate()} ${
+              isInternalSwap ? 'internal_swap_amount_typography' : ''
+            }`}>
             {amount}
-          </Typography>
+          </AmountText>
+          {amount && amount.length > MAX_AMOUNT_LENGTH_FOR_INFO_ICON && (
+            <InfoIcon color="gray" size={12} />
+          )}
         </NumericTooltip>
-        <Typography size="xsmall" variant="body" className={tokenLabelStyles()}>
+        <Typography
+          size="xsmall"
+          variant="body"
+          className="token_label_typography">
           {name}
         </Typography>
       </TokenInfo>

--- a/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.styles.ts
+++ b/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.styles.ts
@@ -1,7 +1,6 @@
 import { css, darkTheme, styled } from '../../theme.js';
 import { PriceImpact } from '../PriceImpact/index.js';
-
-export const tokenLabelStyles = css({});
+import { Typography } from '../Typography/Typography.js';
 
 export const FlexCenter = styled('div', {
   display: 'flex',
@@ -135,7 +134,7 @@ export const TokenInfo = styled(FlexCenter, {
   bottom: 0,
   left: 0,
   right: 0,
-  [`& .${tokenLabelStyles}`]: {
+  '& .internal_swap_amount_typography, & .token_label_typography': {
     color: '$neutral700',
     [`.${darkTheme} &`]: {
       color: '$neutral900',
@@ -226,6 +225,7 @@ export const VerticalLine = styled('div', {
 export const StyledPriceImpact = styled(PriceImpact, {
   justifyContent: 'center',
   gap: '$4',
+  maxWidth: 150,
 });
 
 export const lastStepStyle = css({
@@ -304,4 +304,12 @@ export const TooltipFooter = styled(FlexCenter, {
 
 export const Icon = styled('div', {
   paddingBottom: '$20',
+});
+
+export const OutputPriceValue = styled(Typography, {
+  maxWidth: '65px',
+});
+
+export const AmountText = styled(Typography, {
+  maxWidth: '34px',
 });

--- a/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.tsx
+++ b/widget/ui/src/components/FullExpandedQuote/FullExpandedQuote.tsx
@@ -4,11 +4,12 @@ import type { Tag } from 'rango-types/lib/api/main';
 import { i18n } from '@lingui/core';
 import React, { useState } from 'react';
 
-import { ErrorIcon, WarningIcon } from '../../icons/index.js';
+import { ErrorIcon, InfoIcon, WarningIcon } from '../../icons/index.js';
 import { ChainToken } from '../ChainToken/index.js';
 import { Image } from '../common/index.js';
 import { Divider } from '../Divider/index.js';
 import { QuoteTag } from '../QuoteTag/index.js';
+import { textTruncate } from '../TokenAmount/TokenAmount.styles.js';
 import { NumericTooltip, Tooltip } from '../Tooltip/index.js';
 import { Typography } from '../Typography/index.js';
 
@@ -28,6 +29,7 @@ import {
 import {
   IconHighlight,
   lastStepStyle,
+  OutputPriceValue,
   OutputSection,
   RouteContainer,
   RouteHeader,
@@ -46,6 +48,7 @@ import {
 import { TokenSection } from './FullExpandedQuote.TokenSection.js';
 import { TooltipContent } from './FullExpandedQuote.Tooltip.js';
 
+const MAX_OUTPUT_AMOUNT_LENGTH_FOR_INFO_ICON = 7;
 export function FullExpandedQuote(props: PropTypes) {
   const {
     loading,
@@ -244,9 +247,16 @@ export function FullExpandedQuote(props: PropTypes) {
                           open={
                             !props.outputPrice.realValue ? false : undefined
                           }>
-                          <Typography size="xmedium" variant="title">
+                          <OutputPriceValue
+                            className={textTruncate()}
+                            size="xmedium"
+                            variant="title">
                             {props.outputPrice.value}
-                          </Typography>
+                          </OutputPriceValue>
+                          {props.outputPrice.value.length >
+                            MAX_OUTPUT_AMOUNT_LENGTH_FOR_INFO_ICON && (
+                            <InfoIcon color="gray" size={12} />
+                          )}
                           <Divider size={4} direction="horizontal" />
                           <Typography size="xmedium" variant="title">
                             {step.to.token.displayName}

--- a/widget/ui/src/components/PriceImpact/PriceImpact.styles.ts
+++ b/widget/ui/src/components/PriceImpact/PriceImpact.styles.ts
@@ -5,13 +5,18 @@ export const Container = styled('div', {
   display: 'flex',
   justifyContent: 'end',
   alignItems: 'center',
+  overflow: 'hidden',
+  minWidth: 0,
 });
 
 export const ValueTypography = styled('div', {
   display: 'flex',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
+  '& .output-usd-value': {
+    flex: '1 1 auto',
+    minWidth: 0,
+    flexShrink: 1,
+    maxWidth: '100%',
+  },
   '& ._typography': {
     $$color: '$colors$neutral600',
     [`.${darkTheme} &`]: {

--- a/widget/ui/src/components/PriceImpact/PriceImpact.tsx
+++ b/widget/ui/src/components/PriceImpact/PriceImpact.tsx
@@ -1,8 +1,11 @@
 import type { PriceImpactPropTypes } from './PriceImpact.types.js';
 
-import React from 'react';
+import React, { useRef } from 'react';
+import { useIsTruncated } from 'src/hooks/useIsTruncated.js';
+import { InfoIcon } from 'src/icons/index.js';
 
 import { Divider, NumericTooltip, Typography } from '../index.js';
+import { textTruncate } from '../TokenAmount/TokenAmount.styles.js';
 
 import { Container, ValueTypography } from './PriceImpact.styles.js';
 
@@ -21,25 +24,32 @@ export function PriceImpact(props: PriceImpactPropTypes) {
 
   const hasWarning = !outputUsdValue || warningLevel === 'low';
   const hasError = warningLevel === 'high';
-
+  const realOutputUsdValueRef = useRef<HTMLSpanElement | null>(null);
+  const isRealOutputUsdValueTruncated = useIsTruncated(
+    realOutputUsdValue || '',
+    realOutputUsdValueRef
+  );
   return (
     <Container {...rest}>
       {outputUsdValue && (
-        <NumericTooltip
-          content={realOutputUsdValue}
-          container={tooltipProps?.container}
-          open={
-            !realOutputUsdValue || realOutputUsdValue === '0'
-              ? false
-              : undefined
-          }
-          side={tooltipProps?.side}>
-          <ValueTypography>
-            <Typography size={size} variant="body" color={outputColor}>
-              {outputUsdValue === '0' ? '0.00' : `~$${outputUsdValue}`}
-            </Typography>
-          </ValueTypography>
-        </NumericTooltip>
+        <ValueTypography className={textTruncate()}>
+          <Typography
+            className={`${textTruncate()} output-usd-value`}
+            size={size}
+            ref={realOutputUsdValueRef}
+            variant="body"
+            color={outputColor}>
+            {realOutputUsdValue === '0' ? '0.00' : `~$${realOutputUsdValue}`}
+          </Typography>
+          {isRealOutputUsdValueTruncated && (
+            <NumericTooltip
+              content={realOutputUsdValue}
+              container={tooltipProps?.container}
+              side={tooltipProps?.side}>
+              <InfoIcon size={12} color="gray" />
+            </NumericTooltip>
+          )}
+        </ValueTypography>
       )}
       {((outputUsdValue && percentageChange) || !outputUsdValue) && (
         <ValueTypography hasError={hasError} hasWarning={hasWarning}>

--- a/widget/ui/src/components/PriceImpact/PriceImpact.types.ts
+++ b/widget/ui/src/components/PriceImpact/PriceImpact.types.ts
@@ -11,6 +11,8 @@ export type PriceImpactPropTypes = {
   error?: string;
   percentageChange?: string | null;
   warningLevel?: PriceImpactWarningLevel;
+  style?: React.CSSProperties;
+  className?: string;
   tooltipProps?: {
     container?: TooltipPropTypes['container'];
     side?: TooltipPropTypes['side'];

--- a/widget/ui/src/components/StepDetails/StepDetails.styles.ts
+++ b/widget/ui/src/components/StepDetails/StepDetails.styles.ts
@@ -1,6 +1,7 @@
 import { css } from '@stitches/react';
 
 import { darkTheme, styled } from '../../theme.js';
+import { Typography } from '../Typography/Typography.js';
 
 export const Container = styled('div', {
   width: '100%',
@@ -125,6 +126,20 @@ export const StepSeparator = styled('div', {
       error: { borderColor: '$error500' },
     },
   },
+});
+
+export const TokenNameText = styled(Typography, {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  maxWidth: '38px',
+});
+
+export const ValueTypography = styled(Typography, {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  maxWidth: '60px',
 });
 
 export const tokensContainerStyles = css({

--- a/widget/ui/src/components/StepDetails/StepDetails.tsx
+++ b/widget/ui/src/components/StepDetails/StepDetails.tsx
@@ -4,7 +4,7 @@ import { i18n } from '@lingui/core';
 import React, { forwardRef, Fragment, memo, useEffect, useRef } from 'react';
 
 import { ChainToken } from '../../components/ChainToken/index.js';
-import { NextIcon } from '../../icons/index.js';
+import { InfoIcon, NextIcon } from '../../icons/index.js';
 import { Image } from '../common/index.js';
 import { Divider } from '../Divider/index.js';
 import { NumericTooltip } from '../Tooltip/index.js';
@@ -20,11 +20,14 @@ import {
   swapperItemStyles,
   SwapperSeparator,
   swappersStyles,
+  TokenNameText,
   tokensContainerStyles,
   tokensStyles,
+  ValueTypography,
 } from './StepDetails.styles.js';
 
 const HIGHT_OF_STICKY_HEADER = 45;
+const VALUE_LENGTH_THRESHOLD = 9;
 
 const StepDetailsComponent = forwardRef<HTMLDivElement, StepDetailsProps>(
   (props, parentRef) => {
@@ -149,11 +152,25 @@ const StepDetailsComponent = forwardRef<HTMLDivElement, StepDetailsProps>(
                 content={step.from.price.realValue}
                 container={tooltipContainer}>
                 <Divider direction="horizontal" size={4} />
-                <Typography
+                <ValueTypography
                   size="small"
                   color="$neutral700"
-                  variant="body">{`${step.from.price.value} ${step.from.token.displayName}`}</Typography>
+                  variant="body">{`${step.from.price.realValue}`}</ValueTypography>
+
+                {step.from.price.realValue &&
+                  step.from.price.realValue.length > VALUE_LENGTH_THRESHOLD && (
+                    <>
+                      <Divider direction="horizontal" size={2} />
+                      <InfoIcon size={12} color="gray" />
+                    </>
+                  )}
+                <Divider direction="horizontal" size={2} />
+
+                <TokenNameText size="small" color="$neutral700" variant="body">
+                  {step.from.token.displayName}
+                </TokenNameText>
               </NumericTooltip>
+
               <Divider direction="horizontal" size={4} />
 
               <NextIcon color="gray" />
@@ -168,11 +185,19 @@ const StepDetailsComponent = forwardRef<HTMLDivElement, StepDetailsProps>(
                 container={tooltipContainer}>
                 <Divider direction="horizontal" size={4} />
 
-                <Typography size="small" color="$neutral700" variant="body">{`${
-                  isCompleted ? '' : '~'
-                }${step.to.price.value} ${
-                  step.to.token.displayName
-                }`}</Typography>
+                <ValueTypography
+                  size="small"
+                  color="$neutral700"
+                  variant="body">{`${isCompleted ? '' : '~'}${
+                  step.to.price.value
+                }`}</ValueTypography>
+                <Divider direction="horizontal" size={2} />
+                {step.to.price.value.length + (isCompleted ? 0 : 1) >
+                  VALUE_LENGTH_THRESHOLD && <InfoIcon size={12} color="gray" />}
+                <Divider direction="horizontal" size={2} />
+                <TokenNameText size="small" color="$neutral700" variant="body">
+                  {step.to.token.displayName}
+                </TokenNameText>
               </NumericTooltip>
             </div>
             <Alerts pb={hasSeparator && type === 'quote-details'}>

--- a/widget/ui/src/components/SwapListItem/SwapToken.styles.ts
+++ b/widget/ui/src/components/SwapListItem/SwapToken.styles.ts
@@ -1,4 +1,5 @@
 import { styled } from '../../theme.js';
+import { Typography } from '../Typography/Typography.js';
 
 export const TokenContainer = styled('div', {
   display: 'flex',
@@ -61,9 +62,9 @@ export const LayoutLoading = styled('div', {
 });
 
 export const IconLoading = styled('div', {
-  display: 'flex',
   width: '$24',
   height: '$24',
+  display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
 });
@@ -73,4 +74,18 @@ export const LoadingContainer = styled('div', {
   padding: 0,
   alignItems: 'center',
   gap: 25,
+});
+
+export const TokenNameText = styled(Typography, {
+  maxWidth: '97px',
+});
+
+export const AmountText = styled(Typography, {
+  maxWidth: '$48',
+});
+
+export const FlexCenteredContainer = styled('div', {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
 });

--- a/widget/ui/src/components/SwapListItem/SwapToken.tsx
+++ b/widget/ui/src/components/SwapListItem/SwapToken.tsx
@@ -3,14 +3,17 @@ import type { PropTypes } from './SwapToken.types.js';
 import { i18n } from '@lingui/core';
 import React from 'react';
 
-import { NextIcon } from '../../icons/index.js';
+import { InfoIcon, NextIcon } from '../../icons/index.js';
 import { ChainToken } from '../ChainToken/index.js';
 import { Divider } from '../Divider/index.js';
 import { Skeleton } from '../Skeleton/index.js';
-import { NumericTooltip } from '../Tooltip/index.js';
+import { textTruncate } from '../TokenAmount/TokenAmount.styles.js';
+import { NumericTooltip, Tooltip } from '../Tooltip/index.js';
 import { Typography } from '../Typography/index.js';
 
 import {
+  AmountText,
+  FlexCenteredContainer,
   Icon,
   IconLoading,
   Images,
@@ -18,8 +21,12 @@ import {
   LayoutLoading,
   TokenContainer,
   TokenInfo,
+  TokenNameText,
   TopSection,
 } from './SwapToken.styles.js';
+
+const TOKEN_NAME_TOOLTIP_THRESHOLD = 10;
+const TOKEN_AMOUNT_TOOLTIP_THRESHOLD = 6;
 
 export function SwapToken(props: PropTypes) {
   if ('isLoading' in props) {
@@ -65,7 +72,6 @@ export function SwapToken(props: PropTypes) {
       },
       to: {
         token: toToken,
-        amount: toAmount,
         blockchain: toBlockchain,
         realAmount: toRealAmount,
       },
@@ -99,15 +105,35 @@ export function SwapToken(props: PropTypes) {
       {status === 'running' ? (
         <Layout direction="column">
           <TopSection>
-            <Typography size="medium" variant="title">
+            <TokenNameText
+              className={textTruncate()}
+              size="medium"
+              variant="title">
               {fromToken.displayName}
-            </Typography>
+            </TokenNameText>
+            {fromToken.displayName.length > TOKEN_NAME_TOOLTIP_THRESHOLD && (
+              <Tooltip
+                content={fromToken.displayName}
+                container={tooltipContainer}>
+                <InfoIcon size={12} color="gray" />
+              </Tooltip>
+            )}
             <Icon>
               <NextIcon size={24} color="black" />
             </Icon>
-            <Typography size="medium" variant="title">
+            <TokenNameText
+              className={textTruncate()}
+              size="medium"
+              variant="title">
               {toToken.displayName}
-            </Typography>
+            </TokenNameText>
+            {toToken.displayName.length > TOKEN_NAME_TOOLTIP_THRESHOLD && (
+              <Tooltip
+                content={toToken.displayName}
+                container={tooltipContainer}>
+                <InfoIcon size={12} color="gray" />
+              </Tooltip>
+            )}
           </TopSection>
           <Typography size="small" variant="body" color="neutral700">
             {currentStep?.fromBlockchain === currentStep?.toBlockchain
@@ -118,31 +144,77 @@ export function SwapToken(props: PropTypes) {
       ) : (
         <Layout direction="row">
           <TokenInfo>
-            <Typography size="medium" variant="title">
-              {fromToken.displayName}
-            </Typography>
+            <FlexCenteredContainer>
+              <TokenNameText
+                className={textTruncate()}
+                size="medium"
+                variant="title">
+                {fromToken.displayName}
+              </TokenNameText>
+              {fromToken.displayName.length > TOKEN_NAME_TOOLTIP_THRESHOLD && (
+                <Tooltip
+                  content={fromToken.displayName}
+                  container={tooltipContainer}>
+                  <InfoIcon size={12} color="gray" />
+                </Tooltip>
+              )}
+            </FlexCenteredContainer>
+
             {!!fromAmount && (
-              <NumericTooltip
-                content={fromRealAmount}
-                container={tooltipContainer}>
-                <Typography size="small" variant="body" color="neutral700">
-                  {fromAmount}
-                </Typography>
-              </NumericTooltip>
+              <FlexCenteredContainer>
+                <AmountText
+                  className={textTruncate()}
+                  size="small"
+                  variant="body"
+                  color="neutral700">
+                  {fromRealAmount}
+                </AmountText>
+
+                {fromRealAmount.length > TOKEN_AMOUNT_TOOLTIP_THRESHOLD && (
+                  <NumericTooltip
+                    content={fromRealAmount}
+                    container={tooltipContainer}>
+                    <InfoIcon size={12} color="gray" />
+                  </NumericTooltip>
+                )}
+              </FlexCenteredContainer>
             )}
           </TokenInfo>
           <Icon>
             <NextIcon size={24} color="black" />
           </Icon>
           <TokenInfo>
-            <Typography size="medium" variant="title">
-              {toToken.displayName}
-            </Typography>
-            <NumericTooltip content={toRealAmount} container={tooltipContainer}>
-              <Typography size="small" variant="body" color="neutral700">
-                {toAmount}
-              </Typography>
-            </NumericTooltip>
+            <FlexCenteredContainer>
+              <TokenNameText
+                className={textTruncate()}
+                size="medium"
+                variant="title">
+                {toToken.displayName}
+              </TokenNameText>
+              {toToken.displayName.length > TOKEN_NAME_TOOLTIP_THRESHOLD && (
+                <Tooltip
+                  content={toToken.displayName}
+                  container={tooltipContainer}>
+                  <InfoIcon size={12} color="gray" />
+                </Tooltip>
+              )}
+            </FlexCenteredContainer>
+            <FlexCenteredContainer>
+              <AmountText
+                className={textTruncate()}
+                size="small"
+                variant="body"
+                color="neutral700">
+                {toRealAmount}
+              </AmountText>
+              {toRealAmount.length > TOKEN_AMOUNT_TOOLTIP_THRESHOLD && (
+                <NumericTooltip
+                  content={toRealAmount}
+                  container={tooltipContainer}>
+                  <InfoIcon size={12} color="gray" />
+                </NumericTooltip>
+              )}
+            </FlexCenteredContainer>
           </TokenInfo>
         </Layout>
       )}

--- a/widget/ui/src/components/Toast/Toast.styles.ts
+++ b/widget/ui/src/components/Toast/Toast.styles.ts
@@ -333,6 +333,8 @@ export const AlertFlexContainer = styled('div', {
 });
 
 export const StyledTypography = styled(Typography, {
+  overflowWrap: 'break-word',
+  wordBreak: 'break-word',
   variants: {
     hasColor: {
       false: {

--- a/widget/ui/src/components/TokenAmount/TokenAmount.styles.ts
+++ b/widget/ui/src/components/TokenAmount/TokenAmount.styles.ts
@@ -1,8 +1,10 @@
 import { css, styled } from '../../theme.js';
+import { Typography } from '../Typography/Typography.js';
 
 export const Container = styled('div', {
   display: 'flex',
   justifyContent: 'space-between',
+  gap: '$8',
   variants: {
     direction: {
       vertical: {
@@ -17,17 +19,73 @@ export const Container = styled('div', {
   },
 });
 
-export const tokenAmountStyles = css({
+export const centeredFlexBox = css({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
 });
 
+export const TokenAmountWrapper = styled('div', {
+  flex: '1 1 0',
+  minWidth: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-start',
+  flexDirection: 'row',
+  variants: {
+    direction: {
+      vertical: {
+        maxWidth: 320,
+      },
+      horizontal: { maxWidth: 254 },
+    },
+  },
+});
+
 export const usdValueStyles = css({
   display: 'flex',
-  paddingTop: '$5',
+  paddingBottom: '$5',
+  minWidth: 0,
+  flex: '0 1 auto',
 });
 
 export const tooltipRootStyle = {
   width: 'fit-content',
 };
+
+export const TokenNameText = styled(Typography, {
+  maxWidth: '64px',
+});
+
+export const textTruncate = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+export const flexShrinkFix = css({
+  minWidth: 0,
+});
+
+export const usdValueText = css({
+  '& .output-usd-value': {
+    maxWidth: 77,
+  },
+  maxWidth: 88,
+});
+export const verticalUsdValueText = css({
+  '& .output-usd-value': {
+    maxWidth: 300,
+  },
+  maxWidth: 320,
+});
+
+export const flexShrink = css({
+  flexShrink: 1,
+});
+
+export const TokenInfoRow = styled('div', {
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+});

--- a/widget/ui/src/components/TokenAmount/TokenAmount.tsx
+++ b/widget/ui/src/components/TokenAmount/TokenAmount.tsx
@@ -1,28 +1,52 @@
 import type { PropTypes } from './TokenAmount.types.js';
 
-import React from 'react';
+import React, { useRef } from 'react';
+import { useIsTruncated } from 'src/hooks/useIsTruncated.js';
+import { InfoIcon } from 'src/icons/index.js';
 
 import { ChainToken } from '../ChainToken/index.js';
 import { Divider } from '../Divider/index.js';
 import { PriceImpact } from '../PriceImpact/index.js';
 import { ValueTypography } from '../PriceImpact/PriceImpact.styles.js';
-import { NumericTooltip } from '../Tooltip/index.js';
+import { NumericTooltip, Tooltip } from '../Tooltip/index.js';
 import { Typography } from '../Typography/index.js';
 
 import {
   Container,
-  tokenAmountStyles,
+  flexShrink,
+  flexShrinkFix,
+  textTruncate,
+  TokenAmountWrapper,
+  TokenInfoRow,
+  TokenNameText,
   tooltipRootStyle,
   usdValueStyles,
+  usdValueText,
+  verticalUsdValueText,
 } from './TokenAmount.styles.js';
 
 export function TokenAmount(props: PropTypes) {
+  const realValueRef = useRef<HTMLSpanElement | null>(null);
+  const isRealValueTruncated = useIsTruncated(
+    props.price?.realValue || '',
+    realValueRef
+  );
+  const realUSdValueRef = useRef<HTMLSpanElement | null>(null);
+  const isRealUsedValueTruncated = useIsTruncated(
+    props.price?.realUsdValue || '',
+    realUSdValueRef
+  );
+  const displayNameRef = useRef<HTMLSpanElement | null>(null);
+  const isDisplayNameTruncated = useIsTruncated(
+    props.token.displayName,
+    displayNameRef
+  );
   return (
     <Container
       direction={props.direction}
       centerAlign={props.centerAlign}
       id={props.id}>
-      <div className={tokenAmountStyles()}>
+      <TokenAmountWrapper direction={props.direction}>
         <ChainToken
           chainImage={props.chain.image}
           tokenImage={props.token.image}
@@ -30,50 +54,86 @@ export function TokenAmount(props: PropTypes) {
         />
 
         <Divider direction="horizontal" size={4} />
-        <div>
+        <div className={flexShrinkFix()}>
           {props.label && (
             <Typography size="xsmall" variant="body" color="$neutral700">
               {props.label}
             </Typography>
           )}
-          <div>
-            <NumericTooltip
-              styles={{ root: tooltipRootStyle }}
-              content={props.price.realValue}
-              open={!props.price.realValue ? false : undefined}
-              container={props.tooltipContainer}>
-              <Typography
-                size="medium"
-                variant="title"
-                style={{ fontWeight: 600 }}>
-                {props.price.value}
-              </Typography>
-              <Divider direction="horizontal" size={8} />
-              <Typography
-                size="medium"
-                variant="title"
-                style={{ fontWeight: 400 }}>
-                {props.token.displayName}
-              </Typography>
-            </NumericTooltip>
-          </div>
+          <TokenInfoRow className={flexShrinkFix()}>
+            <Typography
+              size="medium"
+              variant="title"
+              ref={realValueRef}
+              className={`${textTruncate()} ${flexShrinkFix()}`}
+              style={{ fontWeight: 600 }}>
+              {props.price.realValue}
+            </Typography>
+            {props.price.realValue && isRealValueTruncated && (
+              <>
+                <Divider direction="horizontal" size={2} />
+
+                <NumericTooltip
+                  styles={{ root: tooltipRootStyle }}
+                  content={props.price.realValue}
+                  open={!props.price.realValue ? false : undefined}
+                  container={props.tooltipContainer}>
+                  <InfoIcon size={12} color="gray" />
+                </NumericTooltip>
+              </>
+            )}
+            <Divider direction="horizontal" size={8} />
+            <TokenNameText
+              size="medium"
+              variant="title"
+              className={textTruncate()}
+              ref={displayNameRef}
+              style={{ fontWeight: 400 }}>
+              {props.token.displayName}
+            </TokenNameText>
+            {isDisplayNameTruncated && (
+              <>
+                <Divider direction="horizontal" size={2} />
+                <Tooltip
+                  content={props.token.displayName}
+                  container={props.tooltipContainer}>
+                  <InfoIcon size={12} color="gray" />
+                </Tooltip>
+              </>
+            )}
+          </TokenInfoRow>
         </div>
-      </div>
+      </TokenAmountWrapper>
       {props.price.usdValue && props.price.usdValue !== '0' && (
         <div className={usdValueStyles()}>
-          <NumericTooltip
-            content={props.price.realUsdValue}
-            container={props.tooltipContainer}>
-            {props.type === 'input' && (
-              <ValueTypography>
-                <Typography size="small" variant="body">
-                  {`~$${props.price.usdValue}`}
-                </Typography>
-              </ValueTypography>
-            )}
-          </NumericTooltip>
+          {props.type === 'input' && (
+            <ValueTypography className={usdValueText()}>
+              <Typography
+                ref={realUSdValueRef}
+                className={textTruncate()}
+                size="small"
+                variant="body">
+                {`~$${props.price.realUsdValue}`}
+              </Typography>
+              {isRealUsedValueTruncated && (
+                <NumericTooltip
+                  content={props.price.realUsdValue}
+                  container={props.tooltipContainer}>
+                  <InfoIcon size={12} color="gray" />
+                </NumericTooltip>
+              )}
+            </ValueTypography>
+          )}
           {props.type === 'output' && (
             <PriceImpact
+              className={`${
+                props.direction === 'horizontal'
+                  ? usdValueText()
+                  : verticalUsdValueText()
+              } ${flexShrinkFix()} ${flexShrink()}`}
+              style={{
+                ...(props.direction === 'horizontal' && { flexWrap: 'wrap' }),
+              }}
               size="small"
               tooltipProps={{ container: props.tooltipContainer, side: 'top' }}
               outputUsdValue={props.price.usdValue}

--- a/widget/ui/src/components/Typography/Typography.tsx
+++ b/widget/ui/src/components/Typography/Typography.tsx
@@ -5,26 +5,26 @@ import React from 'react';
 
 import { TypographyContainer } from './Typography.styles.js';
 
-export function Typography({
-  children,
-  id,
-  className,
-  color,
-  ...props
-}: PropsWithChildren<TypographyPropTypes>) {
+export const Typography = React.forwardRef<
+  HTMLSpanElement,
+  PropsWithChildren<TypographyPropTypes>
+>((props, ref) => {
+  const { children, id, className, color, ...rest } = props;
+
   const customCss = color
-    ? {
-        color: color.startsWith('$') ? color : `$${color}`,
-      }
-    : {
-        color: '$foreground',
-      };
+    ? { color: color.startsWith('$') ? color : `$${color}` }
+    : { color: '$foreground' };
+
   return (
     <TypographyContainer
+      id={id}
       className={`_typography _text ${className || ''}`}
       css={customCss}
-      {...props}>
+      ref={ref}
+      {...rest}>
       {children}
     </TypographyContainer>
   );
-}
+});
+
+Typography.displayName = 'Typography';

--- a/widget/ui/src/containers/SwapInput/SwapInput.styles.ts
+++ b/widget/ui/src/containers/SwapInput/SwapInput.styles.ts
@@ -107,7 +107,7 @@ export const balanceStyles = css({
 });
 
 export const amountStyles = css({
-  width: '45%',
+  width: '48%',
   maxWidth: '170px',
   display: 'flex',
   flexDirection: 'column',
@@ -126,4 +126,5 @@ export const UsdPrice = styled(Typography, {
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
+  maxWidth: 147,
 });

--- a/widget/ui/src/containers/SwapInput/SwapInput.tsx
+++ b/widget/ui/src/containers/SwapInput/SwapInput.tsx
@@ -23,8 +23,6 @@ import {
   MaxButton,
   textStyles,
   TokenSectionContainer,
-  UsdPrice,
-  ValueTypography,
 } from './SwapInput.styles.js';
 import { TokenSection } from './TokenSection.js';
 
@@ -39,13 +37,6 @@ export function SwapInput(props: SwapInputPropTypes) {
   const showBalanceSkeleton =
     'balance' in props && (props.loading || props.loadingBalance);
   const price = props.price;
-
-  const isUsdValueZeroOrFalsy =
-    !props.price.usdValue || props.price.usdValue === '0';
-
-  const displayUsdValue =
-    props.price.error ||
-    (isUsdValueZeroOrFalsy ? '0.00' : `~$${props.price.usdValue}`);
 
   return (
     <Container
@@ -144,32 +135,24 @@ export function SwapInput(props: SwapInputPropTypes) {
                   })}
                 />
               </NumericTooltip>
-              {'percentageChange' in props ? (
-                <PriceImpact
-                  size="medium"
-                  tooltipProps={{
-                    container: props.tooltipContainer,
-                    side: 'bottom',
-                  }}
-                  outputUsdValue={price.usdValue}
-                  realOutputUsdValue={price.realUsdValue}
-                  error={price.error}
-                  percentageChange={props.percentageChange}
-                  warningLevel={props.warningLevel}
-                />
-              ) : (
-                <NumericTooltip
-                  content={price.realUsdValue}
-                  container={props.tooltipContainer}
-                  open={isUsdValueZeroOrFalsy ? false : undefined}
-                  side="bottom">
-                  <ValueTypography hasWarning={!!price.error}>
-                    <UsdPrice variant="body" size="medium">
-                      {displayUsdValue}
-                    </UsdPrice>
-                  </ValueTypography>
-                </NumericTooltip>
-              )}
+              <PriceImpact
+                size="medium"
+                tooltipProps={{
+                  container: props.tooltipContainer,
+                  side: 'bottom',
+                }}
+                outputUsdValue={price.usdValue}
+                realOutputUsdValue={price.realUsdValue}
+                percentageChange={
+                  'percentageChange' in props
+                    ? props.percentageChange
+                    : undefined
+                }
+                warningLevel={
+                  'percentageChange' in props ? props.warningLevel : undefined
+                }
+                error={price.error}
+              />
             </>
           )}
         </div>

--- a/widget/ui/src/containers/SwapInput/TokenSection.styles.ts
+++ b/widget/ui/src/containers/SwapInput/TokenSection.styles.ts
@@ -114,3 +114,10 @@ export const SymbolTooltipContent = styled(Typography, {
   maxWidth: 217,
   lineBreak: 'anywhere',
 });
+
+export const BlockChainTypography = styled(Typography, {
+  maxWidth: 96,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});

--- a/widget/ui/src/hooks/index.ts
+++ b/widget/ui/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useCopyToClipboard } from './useCopyToClipboard.js';
+export { useIsTruncated } from './useIsTruncated.js';

--- a/widget/ui/src/hooks/useIsTruncated.tsx
+++ b/widget/ui/src/hooks/useIsTruncated.tsx
@@ -1,0 +1,27 @@
+import { type RefObject, useEffect, useState } from 'react';
+
+/*
+ * This hook checks whether the text (or content) inside a React element fits within its width.
+ * In other words, it determines if the content is truncated or fully visible.
+ */
+
+export function useIsTruncated(
+  content: string,
+  ref: RefObject<HTMLElement>
+): boolean {
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+    if (element.scrollWidth > element.clientWidth) {
+      setIsTruncated(true);
+    } else {
+      setIsTruncated(false);
+    }
+  }, [content, ref.current]);
+
+  return isTruncated;
+}


### PR DESCRIPTION
# Summary

Implement a unified truncation strategy for long cryptocurrency names, wallet addresses, and numeric values to ensure proper display across all wallet interface components on mobile viewports.

Fixes # (issue)

- [x] Truncation implemented for token names and amounts in the swap widget
- [x] Route selection component now gracefully handles long token pair names
- [x] Modal dialogs (e.g., token selection, confirmations) display truncated content correctly
- [x] Confirm Swap and Swap Details pages support truncation for long wallet addresses and transaction IDs
- [x] History page displays truncated token names and amounts in transaction lists
- [x] Input fields properly format and truncate large numeric values for better readability

# Checklist:

- [x] I have performed a self-review of my code
- [x] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
