### PR TITLE
feat: add single selection to detached modal

### DIFF
--- a/queue-manager/rango-preset/src/actions/executeTransaction.ts
+++ b/queue-manager/rango-preset/src/actions/executeTransaction.ts
@@ -17,6 +17,7 @@ import {
   isNetworkMatchedForTransaction,
   isRequiredWalletConnected,
   isWalletNull,
+  resetNetworkStatus,
   signTransaction,
   updateNetworkStatus,
 } from '../helpers';
@@ -103,12 +104,15 @@ export async function executeTransaction(
     requestBlock(blockedFor);
     return;
   }
-  // Update network to mark it as network changed successfully.
-  updateNetworkStatus(actions, {
-    message: '',
-    details: 'The network has been successfully changed.',
-    status: PendingSwapNetworkStatus.NetworkChanged,
-  });
+
+  if (currentStep.networkStatus === PendingSwapNetworkStatus.NetworkChanged) {
+    // Considering that network is matched now, if currently network status of the current step is equal to `NetworkChanged`, we need to update the network status to mark it as network changed successfully.
+    updateNetworkStatus(actions, {
+      message: '',
+      details: 'The network has been successfully changed.',
+      status: PendingSwapNetworkStatus.NetworkChanged,
+    });
+  }
 
   /*
    *For avoiding conflict by making too many requests to wallet, we need to make sure
@@ -125,6 +129,8 @@ export async function executeTransaction(
     requestBlock(blockedFor);
     return;
   }
+
+  resetNetworkStatus(actions);
 
   // All the conditions are met. We can safely send the tx to wallet for sign.
   await signTransaction(actions);

--- a/wallets/core/store/package.json
+++ b/wallets/core/store/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@rango-dev/wallets-core/store",
+  "type": "module",
+  "main": "../dist/hub/store/mod.js",
+  "module": "../dist/hub/store/mod.js",
+  "types": "../dist/hub/store/mod.d.ts",
+  "sideEffects": false
+}

--- a/widget/embedded/src/components/StatefulConnectModal/StatefulConnectModal.tsx
+++ b/widget/embedded/src/components/StatefulConnectModal/StatefulConnectModal.tsx
@@ -75,7 +75,7 @@ export function StatefulConnectModal(props: PropTypes) {
       );
     }
 
-    handleDerivationPath(derivationPath)
+    handleDerivationPath(props.wallet!, derivationPath)
       .then(afterConnected)
       .catch(catchErrorOnHandle);
   };
@@ -112,6 +112,13 @@ export function StatefulConnectModal(props: PropTypes) {
     } else if (resultIsDisconnected) {
       handleClosingModal();
     }
+  };
+
+  const handleNavigateToDerivationPath = (selectedNamespace: Namespace) => {
+    if (!props.wallet?.needsDerivationPath) {
+      return;
+    }
+    void handleNamespace(props.wallet, [selectedNamespace]);
   };
 
   useEffect(() => {
@@ -200,6 +207,7 @@ export function StatefulConnectModal(props: PropTypes) {
           }
           value={getState().namespace}
           selectedNamespaces={getState().selectedNamespaces}
+          navigateToDerivationPath={handleNavigateToDerivationPath}
         />
       )}
     </WatermarkedModal>

--- a/widget/embedded/src/components/WalletStatefulConnect/Detached.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Detached.tsx
@@ -1,7 +1,9 @@
 import type { PropTypes } from './Detached.types';
+import type { LegacyNamespaceMeta } from '@rango-dev/wallets-core/legacy';
+import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 
 import { i18n } from '@lingui/core';
-import { Button, Divider, Image, MessageBox } from '@rango-dev/ui';
+import { Alert, Button, Divider, Image, MessageBox } from '@rango-dev/ui';
 import { useWallets } from '@rango-dev/wallets-react';
 import React from 'react';
 
@@ -12,11 +14,127 @@ import { NamespaceDetachedItem } from './NamespaceDetachedItem';
 import { NamespaceList, StyledButton } from './Namespaces.styles';
 
 export function Detached(props: PropTypes) {
-  const { selectedNamespaces, value, onDisconnectWallet } = props;
+  const {
+    value,
+    selectedNamespaces,
+    onConfirm,
+    onDisconnectWallet,
+    navigateToDerivationPath,
+  } = props;
   const { targetWallet } = value;
 
-  const { state } = useWallets();
-  const walletState = state(targetWallet.type);
+  const { connect, disconnect, state } = useWallets();
+  const walletType = targetWallet.type;
+  const walletState = state(walletType);
+  const namespacesProperty = targetWallet.properties?.find(
+    (property) => property.name === 'namespaces'
+  );
+  const derivationPathProperty = targetWallet.properties?.find(
+    (property) => property.name === 'derivationPath'
+  );
+
+  const singleSelection = namespacesProperty?.value.selection === 'single';
+
+  const handleConnectNamespace = async (
+    namespace: Namespace,
+    options?: {
+      derivationPath?: string;
+      shouldAskForDerivationPath?: boolean;
+    }
+  ) => {
+    if (singleSelection) {
+      // For single-selection wallets, disconnect all namespaces before connecting a new namespace
+      await disconnect(walletType);
+    }
+    if (derivationPathProperty && options?.shouldAskForDerivationPath) {
+      navigateToDerivationPath(namespace);
+    } else {
+      await connect(walletType, [
+        {
+          namespace: namespace,
+          network: '',
+          derivationPath: options?.derivationPath ?? undefined,
+        },
+      ]);
+    }
+  };
+
+  const handleDisconnectNamespace = async (namespace: Namespace) => {
+    await disconnect(walletType, [namespace]);
+  };
+
+  const renderNamespaceListHeader = () => {
+    if (!!singleSelection) {
+      return (
+        <>
+          <Divider size={20} />
+          <Alert
+            id="widget-wallet-stateful-connect-alert"
+            variant="alarm"
+            type="info"
+            title={i18n.t(
+              'This wallet can only connect to one chain at a time.'
+            )}
+          />
+          <Divider size={30} />
+        </>
+      );
+    }
+    return (
+      <>
+        <Divider size={30} />
+        <NamespacesHeader>
+          <Button
+            id="widget-detached-disconnect-wallet-btn"
+            variant="ghost"
+            type="error"
+            size="xsmall"
+            disabled={walletState.connecting || !walletState.connected}
+            onClick={onDisconnectWallet}>
+            {i18n.t('Disconnect wallet')}
+          </Button>
+        </NamespacesHeader>
+        <Divider size={16} />
+      </>
+    );
+  };
+
+  const renderNamespaceItem = (namespace: LegacyNamespaceMeta) => {
+    if (namespace.unsupported) {
+      return <NamespaceUnsupportedItem namespace={namespace} />;
+    }
+
+    const selectedNamespace = selectedNamespaces?.find(
+      (selectedNamespaceItem) =>
+        selectedNamespaceItem.namespace === namespace.value
+    );
+
+    const namespaceState = walletState.namespaces?.get(namespace.value);
+
+    if (!namespaceState) {
+      throw new Error(`State for ${namespace.value} was not found!`);
+    }
+
+    const disabled = singleSelection && walletState.connecting; // If wallet is configured as single selection, button should be disabled while a namespace is already in connecting state
+
+    return (
+      <NamespaceDetachedItem
+        namespace={namespace}
+        initialConnect={!!selectedNamespace}
+        disabled={disabled}
+        state={namespaceState}
+        handleConnect={async (options) =>
+          handleConnectNamespace(namespace.value, {
+            derivationPath: selectedNamespace?.derivationPath,
+            shouldAskForDerivationPath: options?.shouldAskForDerivationPath,
+          })
+        }
+        handleDisconnect={async () =>
+          handleDisconnectNamespace(namespace.value)
+        }
+      />
+    );
+  };
 
   return (
     <>
@@ -30,30 +148,11 @@ export function Detached(props: PropTypes) {
         )}
         icon={<Image src={targetWallet.image} size={45} />}
       />
-      <Divider size={30} />
-      <NamespacesHeader>
-        <Button
-          id="widget-detached-disconnect-wallet-btn"
-          variant="ghost"
-          type="error"
-          size="xsmall"
-          disabled={walletState.connecting || !walletState.connected}
-          onClick={onDisconnectWallet}>
-          {i18n.t('Disconnect wallet')}
-        </Button>
-      </NamespacesHeader>
-      <NamespaceList id="widget-detached-namespace-list" as={'ul'}>
+      {renderNamespaceListHeader()}
+      <NamespaceList id="widget-detached-namespace-list">
         {targetWallet.needsNamespace?.data.map((namespace, index, array) => (
           <React.Fragment key={namespace.id}>
-            {namespace.unsupported ? (
-              <NamespaceUnsupportedItem namespace={namespace} />
-            ) : (
-              <NamespaceDetachedItem
-                walletType={targetWallet.type}
-                namespace={namespace}
-                initialConnect={selectedNamespaces?.includes(namespace.value)}
-              />
-            )}
+            {renderNamespaceItem(namespace)}
             {index !== array.length - 1 && <Divider size={10} />}
           </React.Fragment>
         ))}
@@ -62,7 +161,7 @@ export function Detached(props: PropTypes) {
       <StyledButton
         id="widget-name-space-confirm-btn"
         type="primary"
-        onClick={props.onConfirm}>
+        onClick={onConfirm}>
         {i18n.t('Done')}
       </StyledButton>
     </>

--- a/widget/embedded/src/components/WalletStatefulConnect/Detached.types.ts
+++ b/widget/embedded/src/components/WalletStatefulConnect/Detached.types.ts
@@ -5,5 +5,8 @@ export interface PropTypes {
   value: NeedsNamespacesState;
   onConfirm: () => void;
   onDisconnectWallet: () => void;
-  selectedNamespaces: Namespace[] | null;
+  selectedNamespaces:
+    | { namespace: Namespace; derivationPath?: string }[]
+    | null;
+  navigateToDerivationPath: (selectedNamespace: Namespace) => void;
 }

--- a/widget/embedded/src/components/WalletStatefulConnect/Namespaces.styles.ts
+++ b/widget/embedded/src/components/WalletStatefulConnect/Namespaces.styles.ts
@@ -2,7 +2,6 @@ import { Button, styled } from '@rango-dev/ui';
 
 export const NamespaceList = styled('ul', {
   padding: 0,
-  paddingTop: '$16',
   paddingBottom: '$20',
   margin: 0,
 });

--- a/widget/embedded/src/components/WalletStatefulConnect/Namespaces.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Namespaces.tsx
@@ -124,6 +124,7 @@ export function Namespaces(props: PropTypes) {
               'This wallet can only connect to one chain at a time. '
             )}
           />
+          <Divider size={30} />
         </>
       ) : (
         <>
@@ -139,6 +140,7 @@ export function Namespaces(props: PropTypes) {
               ? i18n.t('Deselect all')
               : i18n.t('Select all')}
           </Button>
+          <Divider size={10} />
         </>
       )}
       <NamespaceList>

--- a/widget/embedded/src/components/WalletStatefulConnect/Namespaces.types.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Namespaces.types.tsx
@@ -1,6 +1,7 @@
 import type { NeedsNamespacesState } from '../../hooks/useStatefulConnect';
 import type { LegacyNamespaceMeta } from '@rango-dev/wallets-core/legacy';
 import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { NamespaceData } from '@rango-dev/wallets-core/store';
 
 export interface PropTypes {
   onConfirm: (namespaces: Namespace[]) => void;
@@ -27,7 +28,12 @@ export type NamespaceItemPropTypes =
   | CheckboxNamespaceItemPropTypes;
 
 export type NamespaceDetachedItemPropTypes = {
-  walletType: string;
-  initialConnect?: boolean;
   namespace: LegacyNamespaceMeta;
+  state: NamespaceData;
+  initialConnect?: boolean;
+  disabled?: boolean;
+  handleConnect: (options?: {
+    shouldAskForDerivationPath?: boolean;
+  }) => Promise<void>;
+  handleDisconnect: () => Promise<void>;
 };

--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.state.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.state.ts
@@ -9,7 +9,9 @@ export interface State {
   status: 'init' | 'namespace' | 'derivationPath' | 'detached';
   namespace: NeedsNamespacesState | null;
   derivationPath: NeedsDerivationPathState | null;
-  selectedNamespaces: Namespace[] | null;
+  selectedNamespaces:
+    | { namespace: Namespace; derivationPath?: string }[]
+    | null;
 }
 
 export const initState: State = {

--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
@@ -26,8 +26,11 @@ interface UseStatefulConnect {
     wallet: WalletInfoWithExtra,
     selectedNamespaces: Namespace[]
   ) => Promise<Result>;
-  handleDerivationPath: (path: string) => Promise<Result>;
   handleDisconnect: (wallet: WalletInfoWithExtra) => Promise<Result>;
+  handleDerivationPath: (
+    wallet: ExtendedModalWalletInfo,
+    path: string
+  ) => Promise<Result>;
   getState(): State;
   resetState(section?: 'derivation'): void;
 }
@@ -231,14 +234,14 @@ export function useStatefulConnect(): UseStatefulConnect {
       type: 'detached',
       payload: {
         targetWallet: wallet,
-        selectedNamespaces:
-          namespaces?.map((namespace) => namespace.namespace) || null,
+        selectedNamespaces: namespaces ?? null,
       },
     });
     return { status: ResultStatus.Detached };
   };
 
   const handleDerivationPath = async (
+    wallet: ExtendedModalWalletInfo,
     derivationPath: string
   ): Promise<Result> => {
     if (!derivationPath) {
@@ -255,6 +258,22 @@ export function useStatefulConnect(): UseStatefulConnect {
     const type = connectState.derivationPath.providerType;
     const selectedNamespace = connectState.derivationPath.namespace;
     const namespaces = [{ namespace: selectedNamespace, derivationPath }];
+
+    const isHub = !!wallet.isHub;
+    const needsNamespace = isHub
+      ? wallet.properties?.find((item) => item.name === 'namespaces')?.value
+      : wallet.needsNamespace;
+    if (!!needsNamespace?.data && needsNamespace.data.length > 1) {
+      dispatch({
+        type: 'detached',
+        payload: {
+          targetWallet: wallet,
+          selectedNamespaces: namespaces ?? null,
+          derivationPath,
+        },
+      });
+      return { status: ResultStatus.Detached };
+    }
 
     return await runConnect(type, namespaces);
   };

--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.types.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.types.ts
@@ -14,7 +14,10 @@ export interface NeedsNamespacesState {
 
 export interface DetachedPayload {
   targetWallet: ExtendedModalWalletInfo;
-  selectedNamespaces: Namespace[] | null;
+  selectedNamespaces:
+    | { namespace: Namespace; derivationPath?: string }[]
+    | null;
+  derivationPath?: string;
 }
 
 export interface NeedsDerivationPathState {

--- a/widget/embedded/src/pages/WalletsPage.tsx
+++ b/widget/embedded/src/pages/WalletsPage.tsx
@@ -89,23 +89,23 @@ export function WalletsPage() {
         </Typography>
         <ListContainer>
           {filteredWallets.map((wallet, index) => {
-            const walletState = state(wallet.type);
-            const namespacesState = walletState.namespaces;
+            const namespacesState = state(wallet.type).namespaces;
             const key = `wallet-${index}-${wallet.type}`;
             const isWalletPartiallyConnected = checkIsWalletPartiallyConnected(
               wallet,
               namespacesState
             );
 
+            let walletState = wallet.state;
+            if (isWalletPartiallyConnected) {
+              // If the wallet is connected to only a subset of namespaces, and the user has the option to connect to additional ones, we label the wallet as `Partially Connected`
+              walletState = WalletState.PARTIALLY_CONNECTED;
+            }
             return (
               <Wallet
                 key={key}
                 {...wallet}
-                state={
-                  isWalletPartiallyConnected
-                    ? WalletState.PARTIALLY_CONNECTED
-                    : wallet.state
-                }
+                state={walletState}
                 hasDeepLink={checkHasDeepLink(wallet.type)}
                 link={getWalletLink(wallet.type)}
                 container={getContainer()}

--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -551,7 +551,11 @@ export function checkIsWalletPartiallyConnected(
     (namespace) => !namespace.unsupported
   );
 
-  return supportedNamespaces.some(
-    (namespace) => !namespacesState?.get(namespace.value)?.connected
+  // If the wallet is connected to only a subset of namespaces, and the user has the option to connect to additional ones, we label the wallet as `Partially Connected`
+  return (
+    wallet.needsNamespace.selection === 'multiple' &&
+    supportedNamespaces.some(
+      (namespace) => !namespacesState?.get(namespace.value)?.connected
+    )
   );
 }


### PR DESCRIPTION
# Summary

Added single selection to detached modal.

## Key changes
- State for wallet item in wallets page will be displayed as "Connected" instead of "Partially connected" when a wallet is partially connected and defined as single selection wallet
- Detached modal will be displayed for hub wallets after confirming derivation path modal
- If derivation path is needed for connecting a namespace, trying to connect to the namespace in detached modal will result in navigating to derivation path modal
- If wallet is defined as single selection wallet, trying to connect to a namespace in detached modal will result in disconnecting on other namespaces
- derivation path is added to hub wallet events

Fixes # 2239


# How did you test this change?

Tested by connecting and disconnecting on different namespaces of ledger wallet in detached modal.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
