### PR TITLE
fix: update Rango website link to point to landing page instead of widget

### DIFF
--- a/widget/playground/src/constants/urls.ts
+++ b/widget/playground/src/constants/urls.ts
@@ -1,2 +1,2 @@
 export const RANGO_DOCS_URL = 'https://docs.rango.exchange/';
-export const RANGO_WEBSITE_URL = 'https://widget.rango.exchange/';
+export const RANGO_WEBSITE_URL = 'https://rango.exchange/';


### PR DESCRIPTION

# Summary

In Playground, the Rango website link currently points to the widget instead of the landing page. It should redirect to the landing page.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
