### PR TITLE
feat: add status to textField

### DIFF
--- a/widget/embedded/src/components/Slippage/Slippage.styles.ts
+++ b/widget/embedded/src/components/Slippage/Slippage.styles.ts
@@ -32,26 +32,3 @@ export const SlippageChip = styled(Chip, {
   width: '61px',
   flexShrink: 0,
 });
-
-export const SlippageTextFieldContainer = styled('div', {
-  outlineWidth: 1,
-  outlineStyle: 'solid',
-  borderRadius: '$xs',
-  flex: 1,
-  variants: {
-    status: {
-      safe: {
-        outlineColor: '$secondary500',
-      },
-      error: {
-        outlineColor: '$error500',
-      },
-      warning: {
-        outlineColor: '$warning500',
-      },
-      empty: {
-        outlineWidth: 0,
-      },
-    },
-  },
-});

--- a/widget/embedded/src/components/Slippage/Slippage.tsx
+++ b/widget/embedded/src/components/Slippage/Slippage.tsx
@@ -21,7 +21,6 @@ import {
   Head,
   SlippageChip,
   SlippageChipsContainer,
-  SlippageTextFieldContainer,
 } from './Slippage.styles';
 import { SlippageTooltipContent } from './SlippageTooltipContent';
 
@@ -92,32 +91,31 @@ export function Slippage() {
             />
           );
         })}
-        <SlippageTextFieldContainer
+
+        <TextField
+          type="number"
+          min="0.01"
+          max="30"
+          step="0.01"
           status={
-            slippageValidation?.type || (customSlippage ? 'safe' : 'empty')
-          }>
-          <TextField
-            type="number"
-            min="0.01"
-            max="30"
-            step="0.01"
-            id="widget-slippage-chip-text-input"
-            onInput={onInput}
-            fullWidth
-            variant="contained"
-            value={customSlippage === null ? '' : customSlippage}
-            color="dark"
-            onChange={onSlippageValueChange}
-            suffix={
-              customSlippage && (
-                <Typography variant="body" size="small">
-                  %
-                </Typography>
-              )
-            }
-            placeholder={i18n.t('Custom')}
-          />
-        </SlippageTextFieldContainer>
+            slippageValidation?.type || (customSlippage ? 'success' : 'default')
+          }
+          id="widget-slippage-chip-text-input"
+          onInput={onInput}
+          fullWidth
+          variant="contained"
+          value={customSlippage === null ? '' : customSlippage}
+          color="dark"
+          onChange={onSlippageValueChange}
+          suffix={
+            customSlippage && (
+              <Typography variant="body" size="small">
+                %
+              </Typography>
+            )
+          }
+          placeholder={i18n.t('Custom')}
+        />
       </SlippageChipsContainer>
 
       {slippageValidation && (

--- a/widget/ui/src/components/TextField/TextField.styles.ts
+++ b/widget/ui/src/components/TextField/TextField.styles.ts
@@ -5,6 +5,8 @@ export const InputContainer = styled('div', {
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
+  borderWidth: 1,
+  borderStyle: 'solid',
   variants: {
     fullWidth: {
       true: {
@@ -57,6 +59,20 @@ export const InputContainer = styled('div', {
     disabled: {
       true: {},
       false: {},
+    },
+    status: {
+      default: {
+        borderColor: 'transparent',
+      },
+      error: {
+        borderColor: '$error500',
+      },
+      warning: {
+        borderColor: '$warning500',
+      },
+      success: {
+        borderColor: '$secondary500',
+      },
     },
   },
 

--- a/widget/ui/src/components/TextField/TextField.tsx
+++ b/widget/ui/src/components/TextField/TextField.tsx
@@ -21,6 +21,7 @@ function TextFieldComponent(
     variant,
     fullWidth,
     labelProps,
+    status = 'default',
     ...inputAttributes
   } = props;
 
@@ -63,6 +64,7 @@ function TextFieldComponent(
         variant={variant}
         size={size}
         css={style}
+        status={status}
         className="_text-field">
         {prefix || null}
         <Input

--- a/widget/ui/src/components/TextField/TextField.types.tsx
+++ b/widget/ui/src/components/TextField/TextField.types.tsx
@@ -5,6 +5,7 @@ import type * as Stitches from '@stitches/react';
 type BaseProps = Stitches.VariantProps<typeof InputContainer>;
 type BaseSizes = Exclude<BaseProps['size'], object>;
 type BaseVariants = Exclude<BaseProps['variant'], object>;
+type BaseStatus = Exclude<BaseProps['status'], object>;
 
 export type Ref =
   | ((instance: HTMLInputElement | null) => void)
@@ -22,4 +23,5 @@ export type TextFieldPropTypes = {
   fullWidth?: boolean;
   labelProps?: TypographyPropTypes;
   style?: Stitches.CSS;
+  status?: BaseStatus;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'prefix' | 'size'>;


### PR DESCRIPTION
# Summary

Add support for a status prop in the text field that changes the border color based on the validation state (default, error, warning, success).

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
