### PR TITLE
fix: ensure input remains fully clickable by adjusting wrapper padding

### DIFF
--- a/widget/embedded/src/components/SearchInput/SearchInput.tsx
+++ b/widget/embedded/src/components/SearchInput/SearchInput.tsx
@@ -47,7 +47,6 @@ export function SearchInput(props: PropTypes) {
       color={color}
       variant={variant}
       style={{
-        padding: 10,
         borderRadius: 25,
         alignItems: 'center',
         ...style,

--- a/widget/ui/src/components/TextField/TextField.styles.ts
+++ b/widget/ui/src/components/TextField/TextField.styles.ts
@@ -17,14 +17,24 @@ export const InputContainer = styled('div', {
       },
     },
     size: {
-      small: {
-        padding: '$5 $15',
-      },
+      small: {},
       large: {
-        padding: '$10',
         borderRadius: '$xl',
       },
     },
+    suffix: {
+      true: {},
+      false: {
+        padding: 0,
+      },
+    },
+    prefix: {
+      true: {},
+      false: {
+        padding: 0,
+      },
+    },
+
     variant: {
       contained: {
         $$color: '$colors$neutral100',
@@ -78,6 +88,34 @@ export const InputContainer = styled('div', {
 
   compoundVariants: [
     {
+      size: 'small',
+      suffix: true,
+      css: {
+        paddingRight: '$15',
+      },
+    },
+    {
+      size: 'small',
+      prefix: true,
+      css: {
+        paddingLeft: '$15',
+      },
+    },
+    {
+      size: 'large',
+      suffix: true,
+      css: {
+        paddingRight: '$10',
+      },
+    },
+    {
+      size: 'large',
+      prefix: true,
+      css: {
+        paddingLeft: '$10',
+      },
+    },
+    {
       variant: 'contained',
       disabled: true,
       css: {
@@ -109,10 +147,37 @@ export const Input = styled('input', {
   fontFamily: 'inherit',
   maxWidth: '100%',
   variants: {
-    suffix: {
-      true: { marginRight: '$10' },
+    prefix: {
+      true: {
+        paddingLeft: '$0',
+      },
+      false: {},
+    },
+    size: {
+      small: {
+        padding: '$6 $15 $6 $0',
+      },
+      large: {
+        padding: '$10 $10 $10 $0',
+      },
     },
   },
+  compoundVariants: [
+    {
+      size: 'small',
+      prefix: false,
+      css: {
+        paddingLeft: '$15',
+      },
+    },
+    {
+      size: 'large',
+      prefix: false,
+      css: {
+        paddingLeft: '$10',
+      },
+    },
+  ],
   backgroundColor: 'transparent',
   '-webkit-appearance': 'none',
   margin: 0,

--- a/widget/ui/src/components/TextField/TextField.tsx
+++ b/widget/ui/src/components/TextField/TextField.tsx
@@ -1,7 +1,7 @@
 import type { Ref, TextFieldPropTypes } from './TextField.types.js';
 import type { PropsWithChildren } from 'react';
 
-import React from 'react';
+import React, { useRef } from 'react';
 
 import { Divider } from '../Divider/index.js';
 import { Typography } from '../Typography/index.js';
@@ -12,6 +12,8 @@ function TextFieldComponent(
   props: PropsWithChildren<TextFieldPropTypes>,
   ref?: Ref
 ) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const {
     label,
     prefix,
@@ -44,6 +46,14 @@ function TextFieldComponent(
     }
   };
 
+  const handleClick = () => {
+    if (ref && 'current' in ref && ref.current) {
+      ref.current.focus();
+    } else if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  };
+
   return (
     <>
       {label && (
@@ -65,18 +75,22 @@ function TextFieldComponent(
         size={size}
         css={style}
         status={status}
+        suffix={!!suffix}
+        prefix={!!prefix}
+        onClick={handleClick}
         className="_text-field">
-        {prefix || null}
+        {prefix}
         <Input
           autoComplete="off"
           {...inputAttributes}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
           spellCheck={false}
-          suffix={!!suffix}
-          ref={ref}
+          prefix={!!prefix}
+          size={size}
+          ref={ref || inputRef}
         />
-        {suffix || null}
+        {suffix}
       </InputContainer>
     </>
   );


### PR DESCRIPTION
# Summary

The input was wrapped in a div with padding, which caused the clickable area to be misaligned or broken. This PR refactors the layout to preserve the padding effect without interfering with the input's usability.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
