### PR TITLE
fix: fix trust wallet provider sign message error

### DIFF
--- a/wallets/provider-trustwallet/package.json
+++ b/wallets/provider-trustwallet/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-evm": "^0.36.1-next.0",
     "@rango-dev/wallets-shared": "^0.45.1-next.2",
+    "bs58": "^5.0.0",
     "rango-types": "^0.1.88"
   },
   "publishConfig": {

--- a/wallets/provider-trustwallet/src/legacy/signer.ts
+++ b/wallets/provider-trustwallet/src/legacy/signer.ts
@@ -13,10 +13,10 @@ export default async function getSigners(
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
-  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
+  const { CustomSolanaSigner } = await import('./signers/solanaSigner.js');
 
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
-  signers.registerSigner(TxType.SOLANA, new DefaultSolanaSigner(solProvider));
+  signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
 
   return signers;
 }

--- a/wallets/provider-trustwallet/src/legacy/signers/solanaSigner.ts
+++ b/wallets/provider-trustwallet/src/legacy/signers/solanaSigner.ts
@@ -1,0 +1,9 @@
+import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
+import base58 from 'bs58';
+
+export class CustomSolanaSigner extends DefaultSolanaSigner {
+  async signMessage(msg: string): Promise<string> {
+    const signature = (await this.provider.signMessage(msg))?.signature;
+    return base58.encode(signature);
+  }
+}


### PR DESCRIPTION
# Summary

Currently, attempting to sign a message using Solana account on Trust Wallet results in an error indicating that the `request` method is not available on the provider. This PR introduces a custom message signing implementation specifically for Solana transactions when using the Trust Wallet provider, effectively bypassing the error and ensuring compatibility.


# How did you test this change?

Tested by signing a message using Solana account on trust wallet in the profile page of Rango app.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
