### PR TITLE
fix: convert trust-wallet in-app browser chainId to hex string

### DIFF
--- a/wallets/core/src/namespaces/evm/actions.ts
+++ b/wallets/core/src/namespaces/evm/actions.ts
@@ -118,7 +118,7 @@ export function changeAccountSubscriber(
       const evmInstance = instance();
 
       if (eventCallback && evmInstance) {
-        evmInstance.removeListener('accountsChanged', eventCallback);
+        evmInstance.removeListener?.('accountsChanged', eventCallback);
       }
 
       return err;


### PR DESCRIPTION
# Summary
This PR addresses an issue with Trust Wallet's in-app browser, which returns the `chainId` as a number instead of a hexadecimal string. This was causing an error in the `accountId.format` function, which expects the `chainId` in hex format.

To fix this, I've added a conditional check to convert `chainId` to a hex string when it's returned as a number. This ensures compatibility with Trust Wallet without affecting other providers.


Fixes # (issue)
* Normalize `chainId` to hex string if it’s returned as a number.

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
