### PR TITLE
fix: trust wallet disconnect problem in its in-app browser

### DIFF
--- a/wallets/core/src/namespaces/evm/actions.ts
+++ b/wallets/core/src/namespaces/evm/actions.ts
@@ -118,7 +118,7 @@ export function changeAccountSubscriber(
       const evmInstance = instance();
 
       if (eventCallback && evmInstance) {
-        evmInstance.removeListener('accountsChanged', eventCallback);
+        evmInstance.removeListener?.('accountsChanged', eventCallback);
       }
 
       return err;


### PR DESCRIPTION
# Summary

Trust Wallet's in-app browser doesn't provide a `removeListener` function on its injected instance, which caused disconnect functionality to fail. The code was attempting to remove listeners in the `after` hook, and when this threw an error, the disconnect process would halt and not continue to other namespaces.

This PR makes the `removeListener` calls optional to handle cases where the function is unavailable, ensuring the disconnect process continues across all namespaces even in Trust Wallet's environment while maintaining backward compatibility with other wallet providers.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
