### PR TITLE
chore: add 2 color to rango dark colors

### DIFF
--- a/widget/ui/src/theme.ts
+++ b/widget/ui/src/theme.ts
@@ -233,6 +233,8 @@ export const rangoDarkColors = {
   neutral300: '#0F142E',
   neutral400: '#111733',
   neutral500: '#161C38',
+  neutral600: '#929292',
+  neutral700: '#C0C0C0',
   neutral800: '#B8B8B8',
   neutral900: '#E9E9E9',
   background: '#070917',


### PR DESCRIPTION
# Summary

There were no defined values for `neutral600` and `neutral700` in `rangoDarkColors`, and the generated fallback colors did not provide sufficient contrast within Rango's dark theme.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
