### PR TITLE
feat: add select chain input for refuel tab

### DIFF
--- a/widget/embedded/src/containers/Inputs/Inputs.tsx
+++ b/widget/embedded/src/containers/Inputs/Inputs.tsx
@@ -16,6 +16,7 @@ import {
   USD_VALUE_MAX_DECIMALS,
   USD_VALUE_MIN_DECIMALS,
 } from '../../constants/routing';
+import { useSwapMode } from '../../hooks/useSwapMode';
 import { useAppStore } from '../../store/AppStore';
 import { useQuoteStore } from '../../store/quote';
 import { getContainer } from '../../utils/common';
@@ -41,6 +42,7 @@ export function Inputs(props: PropTypes) {
     outputUsdValue,
     selectedQuote,
   } = useQuoteStore()();
+  const swapMode = useSwapMode();
   const { connectedWallets, getBalanceFor } = useAppStore();
   const fromTokenBalance = fromToken ? getBalanceFor(fromToken) : null;
   const fromTokenFormattedBalance =
@@ -131,6 +133,7 @@ export function Inputs(props: PropTypes) {
         <SwitchFromAndToButton />
       </FromContainer>
       <SwapInput
+        selectionType={swapMode === 'swap' ? 'token' : 'chain'}
         sharpBottomStyle={!isExpandable && (!!selectedQuote || fetchingQuote)}
         label={i18n.t('To')}
         mode="To"

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -185,6 +185,18 @@ export function Home() {
     setCustomSlippage(slippage);
   };
 
+  const handleInputTokenClick = (mode: 'from' | 'to') => {
+    if (mode === 'from') {
+      onHandleNavigation(navigationRoutes.fromSwap);
+    } else {
+      onHandleNavigation(
+        swapMode === 'swap'
+          ? navigationRoutes.toSwap
+          : navigationRoutes.toSwap + '/' + navigationRoutes.blockchains
+      );
+    }
+  };
+
   useEffect(() => {
     resetQuoteWallets();
     updateQuotePartialState('refetchQuote', true);
@@ -276,13 +288,7 @@ export function Home() {
               fetchingQuote={fetchingQuote}
               fetchMetaStatus={fetchMetaStatus}
               isExpandable={isExpandable}
-              onClickToken={(mode) => {
-                onHandleNavigation(
-                  mode === 'from'
-                    ? navigationRoutes.fromSwap
-                    : navigationRoutes.toSwap
-                );
-              }}
+              onClickToken={handleInputTokenClick}
             />
             <Divider size="2" />
             {!isExpandable ? (

--- a/widget/embedded/src/store/slices/data.ts
+++ b/widget/embedded/src/store/slices/data.ts
@@ -56,6 +56,7 @@ export interface DataSlice {
   swappers: () => SwapperMeta[];
   isTokenPinned: (token: Token, type: 'source' | 'destination') => boolean;
   findToken: FindToken;
+  findNativeToken: (blockchain: BlockchainMeta) => Token | undefined;
   fetch: () => Promise<void>;
 }
 
@@ -274,6 +275,14 @@ export const createDataSlice: StateCreator<
       );
     }
     return token;
+  },
+  findNativeToken: (blockchain: BlockchainMeta) => {
+    const feeAsset = blockchain.feeAssets[0];
+    return get().findToken({
+      blockchain: blockchain.name,
+      address: feeAsset.address,
+      symbol: feeAsset.symbol,
+    });
   },
   isTokenPinned: (token, type) => {
     const pinnedTokens =

--- a/widget/ui/src/containers/SwapInput/SwapInput.tsx
+++ b/widget/ui/src/containers/SwapInput/SwapInput.tsx
@@ -88,6 +88,7 @@ export function SwapInput(props: SwapInputPropTypes) {
         <TokenSectionContainer>
           <TokenSection
             id={`${props.id}-token-selection-container`}
+            selectionType={props.selectionType}
             chain={props.chain.displayName}
             chianImageId={
               props.mode === 'To'

--- a/widget/ui/src/containers/SwapInput/SwapInput.types.ts
+++ b/widget/ui/src/containers/SwapInput/SwapInput.types.ts
@@ -25,6 +25,7 @@ export type BaseProps = {
   sharpBottomStyle?: boolean;
   onClickToken: () => void;
   tooltipContainer?: HTMLElement;
+  selectionType?: 'token' | 'chain';
 };
 
 type FromProps = {

--- a/widget/ui/src/containers/SwapInput/TokenSection.tsx
+++ b/widget/ui/src/containers/SwapInput/TokenSection.tsx
@@ -37,9 +37,21 @@ export function TokenSection(props: TokenSectionProps) {
     warning,
     tooltipContainer,
     id,
+    selectionType = 'token',
   } = props;
 
   const tokenSelected = !error && !loading && !!tokenSymbol;
+
+  const getBodyContent = () => {
+    if (error) {
+      return error;
+    } else if (!loading && !chain) {
+      return selectionType === 'token'
+        ? i18n.t('Select Chain')
+        : i18n.t('Where you need gas on');
+    }
+    return chain;
+  };
 
   return (
     <Container
@@ -85,7 +97,9 @@ export function TokenSection(props: TokenSectionProps) {
                   </Tooltip>
                 ) : (
                   <Typography variant="title" size="medium">
-                    {i18n.t('Select Token')}
+                    {selectionType === 'token'
+                      ? i18n.t('Select Token')
+                      : i18n.t('Select Chain')}
                   </Typography>
                 )}
                 {warning && (
@@ -99,7 +113,7 @@ export function TokenSection(props: TokenSectionProps) {
                 variant="body"
                 size="medium"
                 className={chainNameStyles()}>
-                {error || (!loading && !chain) ? i18n.t('Select Chain') : chain}
+                {getBodyContent()}
               </Typography>
             </>
           )}

--- a/widget/ui/src/containers/SwapInput/TokenSection.types.ts
+++ b/widget/ui/src/containers/SwapInput/TokenSection.types.ts
@@ -10,4 +10,5 @@ export type TokenSectionProps = {
   loading?: boolean;
   warning?: boolean;
   tooltipContainer?: HTMLElement;
+  selectionType?: 'token' | 'chain';
 };


### PR DESCRIPTION
# Summary

Added select destination chain input for refuel tab. Clicking on this input will navigate the user to select blockchain page and selecting a blockchain in that page will set the native token of the selected blockchain as the destination token.

Fixes # 2518


# How did you test this change?

Tested by selecting different blockchains as the destination in refuel tab.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
