### PR TITLE
fix: fix dynamic height feature

### DIFF
--- a/widget/embedded/src/components/Layout/Layout.tsx
+++ b/widget/embedded/src/components/Layout/Layout.tsx
@@ -145,7 +145,9 @@ function Layout(props: PropsWithChildren<PropTypes>) {
 
       if (isSmallScreen) {
         containerRef.current.style.height = `${
-          window.innerHeight - containerRef.current.offsetTop
+          window.innerHeight -
+          containerRef.current.getBoundingClientRect().top -
+          (__UNSTABLE_OR_INTERNAL__?.dynamicHeight?.offsetBottom ?? 0)
         }px`;
       } else {
         containerRef.current.style.height = `${WIDGET_MAX_HEIGHT}px`;
@@ -162,7 +164,12 @@ function Layout(props: PropsWithChildren<PropTypes>) {
     window.addEventListener('resize', handler);
 
     return () => window.removeEventListener('resize', handler);
-  }, [height, isMobile, isTablet]);
+  }, [
+    height,
+    isMobile,
+    isTablet,
+    __UNSTABLE_OR_INTERNAL__?.dynamicHeight?.offsetBottom,
+  ]);
 
   return (
     <Container

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -278,6 +278,7 @@ export type WidgetConfig = {
       element: ReactElement;
       routes?: string[];
     };
+    dynamicHeight?: { offsetBottom: number };
   };
   routing?: Routing;
 };


### PR DESCRIPTION
# Summary

Previously, the dynamic height calculation for the widget used the `offsetTop` relative to its parent element, rather than to the top of the viewport. This caused issues when the widget was nested within other elements, resulting in incorrect height calculations. This issue is now resolved in the new changes
Additionally, we’ve introduced a configuration option that allows widget users to specify a custom `offsetBottom` value when using dynamic height mode.

# How did you test this change?

You can test these changes by decreasing the browser window width and adjusting the viewport height. Additionally, you can add elements above the widget in the app to check the effect of the offset on the widget's height.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
