### PR TITLE
fix: fix undefined wallet type for transfer transactions

### DIFF
--- a/queue-manager/rango-preset/src/shared.ts
+++ b/queue-manager/rango-preset/src/shared.ts
@@ -233,7 +233,13 @@ export const getCurrentWalletTypeAndAddress = (
     swap.wallets[step.tonTransaction?.blockChain || ''] ||
     swap.wallets[step.suiTransaction?.blockChain || ''] ||
     (step.transferTransaction?.fromWalletAddress
-      ? { address: step.transferTransaction?.fromWalletAddress }
+      ? {
+          address: step.transferTransaction.fromWalletAddress,
+          walletType: Object.values(swap.wallets).find(
+            (wallet) =>
+              wallet.address === step.transferTransaction?.fromWalletAddress
+          )?.walletType,
+        }
       : null) ||
     null;
   if (result == null) {


### PR DESCRIPTION
# Summary

According to that blockchain is not available in transfer transaction, it was resulting in that required wallet for the transfer transaction step not getting found and failing to find the correct wallet and signing transactions. It is fixed in this PR by checking for the source wallet address among the list of wallets in the swap.


# How did you test this change?

Tested by signing transfer transactions using Phantom wallet.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
