### PR TITLE
chore: simplify the widget height calculation

### DIFF
--- a/widget/app/src/App.tsx
+++ b/widget/app/src/App.tsx
@@ -50,7 +50,14 @@ export function App() {
 
   return (
     <Routes>
-      <Route path="/*" element={<Widget config={configRef.current} />} />
+      <Route
+        path="/*"
+        element={
+          <div style={{ height: '100vh' }}>
+            <Widget config={configRef.current} />
+          </div>
+        }
+      />
     </Routes>
   );
 }

--- a/widget/embedded/src/components/Layout/Layout.styles.ts
+++ b/widget/embedded/src/components/Layout/Layout.styles.ts
@@ -25,7 +25,7 @@ export const Container = styled('div', {
       fixed: {
         minHeight: WIDGET_MIN_HEIGHT,
         maxHeight: WIDGET_MAX_HEIGHT,
-        height: WIDGET_MAX_HEIGHT,
+        height: '100%',
       },
     },
     showBanner: {

--- a/widget/embedded/src/components/Layout/Layout.tsx
+++ b/widget/embedded/src/components/Layout/Layout.tsx
@@ -4,13 +4,12 @@ import type { PropsWithChildren } from 'react';
 
 import { useManager } from '@rango-dev/queue-manager-react';
 import { BottomLogo, Divider, Header } from '@rango-dev/ui';
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { WIDGET_UI_ID } from '../../constants';
 import { useIframe } from '../../hooks/useIframe';
 import { isAppLoadedIntoIframe } from '../../hooks/useIframe/useIframe.helpers';
 import { useNavigateBack } from '../../hooks/useNavigateBack';
-import useScreenDetect from '../../hooks/useScreenDetect';
 import { useTheme } from '../../hooks/useTheme';
 import { useAppStore } from '../../store/AppStore';
 import { tabManager, useUiStore } from '../../store/ui';
@@ -22,10 +21,6 @@ import { ActivateTabModal } from '../common/ActivateTabModal';
 import { BackButton, CancelButton, WalletButton } from '../HeaderButtons';
 import { RefreshModal } from '../RefreshModal';
 
-import {
-  COMPACT_TOKEN_SELECTOR_THRESHOLD,
-  WIDGET_MAX_HEIGHT,
-} from './Layout.constants';
 import { onScrollContentAttachStatusToContainer } from './Layout.helpers';
 import {
   BannerContainer,
@@ -47,7 +42,7 @@ function Layout(props: PropsWithChildren<PropTypes>) {
   const {
     config: { features, theme },
   } = useAppStore();
-  const { watermark, setShowCompactTokenSelector } = useUiStore();
+  const { watermark } = useUiStore();
 
   const hasWatermark = watermark === 'FULL';
   const { activeTheme } = useTheme(theme || {});
@@ -67,7 +62,6 @@ function Layout(props: PropsWithChildren<PropTypes>) {
   } = useUiStore();
   const navigateBack = useNavigateBack();
   const { manager } = useManager();
-  const { isTablet, isMobile } = useScreenDetect();
   const pendingSwaps: PendingSwap[] = getPendingSwaps(manager).map(
     ({ swap }) => swap
   );
@@ -132,38 +126,6 @@ function Layout(props: PropsWithChildren<PropTypes>) {
   useEffect(() => {
     setOpenRefreshModal(fetchStatus === 'failed');
   }, [fetchStatus]);
-
-  useLayoutEffect(() => {
-    const isFixedHeight =
-      height === 'auto' || !containerRef.current || isAppLoadedIntoIframe();
-    const isSmallScreen = isMobile || isTablet;
-
-    const handler = () => {
-      if (isFixedHeight) {
-        return;
-      }
-
-      if (isSmallScreen) {
-        containerRef.current.style.height = `${
-          window.innerHeight - containerRef.current.offsetTop
-        }px`;
-      } else {
-        containerRef.current.style.height = `${WIDGET_MAX_HEIGHT}px`;
-      }
-
-      setShowCompactTokenSelector(
-        parseFloat(containerRef.current.style.height) <
-          COMPACT_TOKEN_SELECTOR_THRESHOLD
-      );
-    };
-
-    handler();
-
-    window.addEventListener('resize', handler);
-
-    return () => window.removeEventListener('resize', handler);
-  }, [height, isMobile, isTablet]);
-
   return (
     <Container
       height={height}

--- a/widget/embedded/src/containers/App/App.styles.ts
+++ b/widget/embedded/src/containers/App/App.styles.ts
@@ -2,6 +2,7 @@ import { styled } from '@rango-dev/ui';
 
 export const MainContainer = styled('div', {
   fontFamily: '$widget',
+  height: '100%',
   boxSizing: 'border-box',
   textAlign: 'left',
   '& *, *::before, *::after': {


### PR DESCRIPTION
# Summary

The dynamic height feature of the widget hasn't worked reliably across all applications. This pull request aims to fix that: 
https://github.com/rango-exchange/rango-client/pull/1210

I discussed the current solution with @nikaaru , and he pointed out that it adds unnecessary complexity. We've now replaced it with a simpler approach in this PR.

Interestingly, we had initially used a similar method during early development, but it caused various issues and introduced implicit dependencies on the host app. This PR revisits that approach for further testing.

It should be tested in different environments, including apps with nested layouts and the iframe version of the widget.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
