### PR TITLE
Feat/rf 2516 implement gas station

### DIFF
--- a/widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx
+++ b/widget/embedded/src/components/BlockchainsSection/BlockchainsSection.tsx
@@ -37,8 +37,8 @@ export function BlockchainsSection(props: PropTypes) {
   });
 
   const { fetchStatus } = useAppStore();
-  const resetToBlockchain = useQuoteStore.use.resetToBlockchain();
-  const resetFromBlockchain = useQuoteStore.use.resetFromBlockchain();
+  const resetToBlockchain = useQuoteStore().use.resetToBlockchain();
+  const resetFromBlockchain = useQuoteStore().use.resetFromBlockchain();
   const hasMoreItemsInList = blockchainsList.more.length > 0;
   /**
    * When only one item is left on list, we will not show the `More` button and will show the item itself instead.

--- a/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
@@ -51,7 +51,7 @@ export function ConfirmWalletsModal(props: PropTypes) {
     setQuoteWalletConfirmed: setQuoteWalletConfirmed,
     customDestination,
     setCustomDestination,
-  } = useQuoteStore();
+  } = useQuoteStore()();
   const { config, connectedWallets, setWalletsAsSelected } = useAppStore();
 
   const [showMoreWalletFor, setShowMoreWalletFor] = useState('');

--- a/widget/embedded/src/components/CustomDestination/CustomDestination.tsx
+++ b/widget/embedded/src/components/CustomDestination/CustomDestination.tsx
@@ -32,7 +32,7 @@ import {
 export function CustomDestination(props: PropTypes) {
   const { blockchain, handleOpenChange, open } = props;
 
-  const { customDestination, setCustomDestination } = useQuoteStore();
+  const { customDestination, setCustomDestination } = useQuoteStore()();
   const { config } = useAppStore();
   const blockchains = useAppStore().blockchains();
   const blockchainName = getBlockchainDisplayNameFor(

--- a/widget/embedded/src/components/Quotes/Quotes.tsx
+++ b/widget/embedded/src/components/Quotes/Quotes.tsx
@@ -37,7 +37,7 @@ export function Quotes(props: PropTypes) {
     toToken,
     sortStrategy,
     error,
-  } = useQuoteStore();
+  } = useQuoteStore()();
   const { slippage, customSlippage } = useAppStore();
   const { findToken } = useAppStore();
   const container = propContainer || getContainer();

--- a/widget/embedded/src/components/Quotes/SelectStrategy.tsx
+++ b/widget/embedded/src/components/Quotes/SelectStrategy.tsx
@@ -9,7 +9,7 @@ import { useQuoteStore } from '../../store/quote';
 import { SelectContainer } from './Quotes.styles';
 
 export function SelectStrategy(props: { container: HTMLElement }) {
-  const { updateQuotePartialState, sortStrategy } = useQuoteStore();
+  const { updateQuotePartialState, sortStrategy } = useQuoteStore()();
 
   const ROUTE_STRATEGY: { value: PreferenceType; label: string }[] = [
     {

--- a/widget/embedded/src/components/SameTokensWarning/SameTokensWarning.tsx
+++ b/widget/embedded/src/components/SameTokensWarning/SameTokensWarning.tsx
@@ -8,7 +8,7 @@ import { areTokensEqual } from '../../utils/wallets';
 import { Container } from './SameTokensWarning.styles';
 
 export function SameTokensWarning() {
-  const { fromToken, toToken } = useQuoteStore();
+  const { fromToken, toToken } = useQuoteStore()();
   const showWarningMessage =
     !!fromToken && !!toToken && areTokensEqual(fromToken, toToken);
 

--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -80,7 +80,7 @@ export function SwapDetails(props: SwapDetailsProps) {
   const blockchains = useAppStore().blockchains();
   const swappers = useAppStore().swappers();
   const { findToken } = useAppStore();
-  const retry = useQuoteStore.use.retry();
+  const retry = useQuoteStore().use.retry();
   const navigate = useNavigate();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/widget/embedded/src/components/SwitchFromAndTo/SwitchFromAndTo.tsx
+++ b/widget/embedded/src/components/SwitchFromAndTo/SwitchFromAndTo.tsx
@@ -10,7 +10,7 @@ import {
 } from './SwitchFromAndTo.styles';
 
 export function SwitchFromAndToButton() {
-  const switchFromAndTo = useQuoteStore.use.switchFromAndTo();
+  const switchFromAndTo = useQuoteStore().use.switchFromAndTo();
 
   return (
     <SwitchButtonContainer>

--- a/widget/embedded/src/components/SwitchFromAndTo/SwitchFromAndTo.tsx
+++ b/widget/embedded/src/components/SwitchFromAndTo/SwitchFromAndTo.tsx
@@ -1,6 +1,8 @@
 import { ReverseIcon } from '@rango-dev/ui';
 import React from 'react';
 
+import { useSwapMode } from '../../hooks/useSwapMode';
+import { useAppStore } from '../../store/AppStore';
 import { useQuoteStore } from '../../store/quote';
 
 import {
@@ -11,6 +13,9 @@ import {
 
 export function SwitchFromAndToButton() {
   const switchFromAndTo = useQuoteStore().use.switchFromAndTo();
+  const fromBlockchain = useQuoteStore().use.fromBlockchain();
+  const { findNativeToken } = useAppStore();
+  const swapMode = useSwapMode();
 
   return (
     <SwitchButtonContainer>
@@ -24,7 +29,12 @@ export function SwitchFromAndToButton() {
           setTimeout(() => {
             button.classList.remove('rotate');
           }, ROTATE_ANIMATION_DURATION);
-          switchFromAndTo();
+          switchFromAndTo({
+            toToken:
+              swapMode === 'refuel' && !!fromBlockchain
+                ? findNativeToken(fromBlockchain)
+                : undefined,
+          });
         }}>
         <ReverseIcon size={12} />
       </StyledButton>

--- a/widget/embedded/src/components/TokenList/TokenList.tsx
+++ b/widget/embedded/src/components/TokenList/TokenList.tsx
@@ -115,7 +115,7 @@ export function TokenList(props: PropTypes) {
   const blockchains = useAppStore().blockchains();
   const { getBalanceFor, fetchingWallets: loadingWallet } = useAppStore();
   const { isTokenPinned } = useAppStore();
-  const { setFromToken, setToToken } = useQuoteStore();
+  const { setFromToken, setToToken } = useQuoteStore()();
   const { t } = useTranslation();
   const navigateBack = useNavigateBack();
 

--- a/widget/embedded/src/containers/Inputs/Inputs.tsx
+++ b/widget/embedded/src/containers/Inputs/Inputs.tsx
@@ -16,6 +16,7 @@ import {
   USD_VALUE_MAX_DECIMALS,
   USD_VALUE_MIN_DECIMALS,
 } from '../../constants/routing';
+import { useSwapMode } from '../../hooks/useSwapMode';
 import { useAppStore } from '../../store/AppStore';
 import { useQuoteStore } from '../../store/quote';
 import { getContainer } from '../../utils/common';
@@ -41,6 +42,7 @@ export function Inputs(props: PropTypes) {
     outputUsdValue,
     selectedQuote,
   } = useQuoteStore()();
+  const swapMode = useSwapMode();
   const { connectedWallets, getBalanceFor } = useAppStore();
   const fromTokenBalance = fromToken ? getBalanceFor(fromToken) : null;
   const fromTokenFormattedBalance =
@@ -131,6 +133,7 @@ export function Inputs(props: PropTypes) {
         <SwitchFromAndToButton />
       </FromContainer>
       <SwapInput
+        selectionType={swapMode === 'swap' ? 'token' : 'chain'}
         sharpBottomStyle={!isExpandable && (!!selectedQuote || fetchingQuote)}
         label={i18n.t('To')}
         mode="To"

--- a/widget/embedded/src/containers/Inputs/Inputs.tsx
+++ b/widget/embedded/src/containers/Inputs/Inputs.tsx
@@ -40,7 +40,7 @@ export function Inputs(props: PropTypes) {
     outputAmount,
     outputUsdValue,
     selectedQuote,
-  } = useQuoteStore();
+  } = useQuoteStore()();
   const { connectedWallets, getBalanceFor } = useAppStore();
   const fromTokenBalance = fromToken ? getBalanceFor(fromToken) : null;
   const fromTokenFormattedBalance =

--- a/widget/embedded/src/containers/QuoteInfo/QuoteInfo.tsx
+++ b/widget/embedded/src/containers/QuoteInfo/QuoteInfo.tsx
@@ -28,7 +28,7 @@ export function QuoteInfo(props: PropTypes) {
     fullExpandedMode = false,
     container,
   } = props;
-  const { inputAmount, inputUsdValue } = useQuoteStore();
+  const { inputAmount, inputUsdValue } = useQuoteStore()();
 
   const outputAmount = !!quote?.outputAmount
     ? new BigNumber(quote?.outputAmount)

--- a/widget/embedded/src/containers/Refuel/Refuel.tsx
+++ b/widget/embedded/src/containers/Refuel/Refuel.tsx
@@ -1,4 +1,4 @@
-import type { WidgetProps } from './Widget.types';
+import type { RefuelProps } from './Refuel.types';
 import type { PropsWithChildren } from 'react';
 
 import React from 'react';
@@ -9,11 +9,11 @@ import { DEFAULT_CONFIG } from '../../store/slices/config';
 import { Main } from '../App';
 import { WidgetProvider } from '../WidgetProvider';
 
-export function Widget(props: PropsWithChildren<WidgetProps>) {
+export function Refuel(props: PropsWithChildren<RefuelProps>) {
   const isExternalWalletsEnabled = props.config?.externalWallets;
 
   return (
-    <SwapModeContext.Provider value="swap">
+    <SwapModeContext.Provider value="refuel">
       <AppRouter>
         {isExternalWalletsEnabled ? (
           <Main />

--- a/widget/embedded/src/containers/Refuel/Refuel.types.ts
+++ b/widget/embedded/src/containers/Refuel/Refuel.types.ts
@@ -1,0 +1,5 @@
+import type { WidgetConfig } from '../../types';
+
+export type RefuelProps = {
+  config?: WidgetConfig;
+};

--- a/widget/embedded/src/containers/Refuel/index.ts
+++ b/widget/embedded/src/containers/Refuel/index.ts
@@ -1,0 +1,1 @@
+export { Refuel } from './Refuel';

--- a/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
+++ b/widget/embedded/src/containers/WidgetInfo/WidgetInfo.tsx
@@ -20,7 +20,7 @@ export const WidgetInfoContext = createContext<
 export function WidgetInfo(props: React.PropsWithChildren) {
   const { manager } = useManager();
   const isActiveTab = useUiStore.use.isActiveTab();
-  const retrySwap = useQuoteStore.use.retry();
+  const retrySwap = useQuoteStore().use.retry();
   const {
     findToken,
     getBalances,
@@ -40,7 +40,7 @@ export function WidgetInfo(props: React.PropsWithChildren) {
   const clearNotifications = useNotificationStore().clearNotifications;
   const updateQuoteInputs = useUpdateQuoteInputs();
   const { fromBlockchain, toBlockchain, fromToken, toToken, inputAmount } =
-    useQuoteStore();
+    useQuoteStore()();
 
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   const value: WidgetInfoContextInterface = {

--- a/widget/embedded/src/hooks/useBootstrap/useBootstrap.ts
+++ b/widget/embedded/src/hooks/useBootstrap/useBootstrap.ts
@@ -10,7 +10,10 @@ import { WidgetContext } from '../../containers/Wallets';
 import { globalFont } from '../../globalStyles';
 import { useAppStore } from '../../store/AppStore';
 import { useNotificationStore } from '../../store/notification';
-import { unsubscribeQuoteStore } from '../../store/quote';
+import {
+  unsubscribeRefuelQuoteStore,
+  unsubscribeSwapQuoteStore,
+} from '../../store/quote';
 import { tabManager } from '../../store/ui';
 import { useFetchApiConfig } from '../useFetchApiConfig';
 import { useForceAutoConnect } from '../useForceAutoConnect';
@@ -34,7 +37,8 @@ export function useBootstrap() {
   const { fetchApiConfig } = useFetchApiConfig();
 
   // Unsubscribe QuoteStore listeners
-  useEffect(() => () => unsubscribeQuoteStore(), []);
+  useEffect(() => () => unsubscribeSwapQuoteStore(), []);
+  useEffect(() => () => unsubscribeRefuelQuoteStore(), []);
 
   // At the moment, we only detect the disconnection of EVM wallets.
   useQueueManager({

--- a/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.ts
+++ b/widget/embedded/src/hooks/useConfirmSwap/useConfirmSwap.ts
@@ -31,7 +31,7 @@ export function useConfirmSwap(): ConfirmSwap {
     selectedQuote: initialQuote,
     customDestination: customDestinationFromStore,
     resetAlerts,
-  } = useQuoteStore();
+  } = useQuoteStore()();
 
   const { slippage, customSlippage } = useAppStore();
   const disabledLiquiditySources = useAppStore().getDisabledLiquiditySources();

--- a/widget/embedded/src/hooks/useSwapInput.ts
+++ b/widget/embedded/src/hooks/useSwapInput.ts
@@ -65,7 +65,7 @@ export function useSwapInput({
     warning,
     setSelectedQuote,
     updateQuotePartialState,
-  } = useQuoteStore();
+  } = useQuoteStore()();
   const {
     slippage,
     customSlippage,

--- a/widget/embedded/src/hooks/useSwapMode.ts
+++ b/widget/embedded/src/hooks/useSwapMode.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react';
+
+type SwapModeContextType = 'swap' | 'refuel';
+
+export const SwapModeContext = createContext<SwapModeContextType>('swap');
+
+export function useSwapMode() {
+  const swapMode = useContext(SwapModeContext);
+
+  return swapMode;
+}

--- a/widget/embedded/src/hooks/useSyncStoresWithConfig.ts
+++ b/widget/embedded/src/hooks/useSyncStoresWithConfig.ts
@@ -21,7 +21,7 @@ export function useSyncStoresWithConfig() {
     toToken,
     fromBlockchain,
     toBlockchain,
-  } = useQuoteStore();
+  } = useQuoteStore()();
 
   const config = useAppStore().config;
   const fetchMetaStatus = useAppStore().fetchStatus;

--- a/widget/embedded/src/hooks/useSyncUrlAndStore/useSyncUrlAndStore.ts
+++ b/widget/embedded/src/hooks/useSyncUrlAndStore/useSyncUrlAndStore.ts
@@ -28,7 +28,7 @@ export function useSyncUrlAndStore() {
     setFromToken,
     setToToken,
     setInputAmount,
-  } = useQuoteStore();
+  } = useQuoteStore()();
   const fetchMetaStatus = useAppStore().fetchStatus;
   const blockchains = useAppStore().blockchains();
   const isInRouterContext = useInRouterContext();

--- a/widget/embedded/src/hooks/useUpdateQuoteInputs/useUpdateQuoteInputs.ts
+++ b/widget/embedded/src/hooks/useUpdateQuoteInputs/useUpdateQuoteInputs.ts
@@ -14,7 +14,7 @@ export function useUpdateQuoteInputs() {
     setToBlockchain,
     setToToken,
     setInputAmount,
-  } = useQuoteStore();
+  } = useQuoteStore()();
 
   const updateQuoteInputs: UpdateQuoteInputs = (params) => {
     const { fromBlockchain, fromToken, toBlockchain, toToken, requestAmount } =

--- a/widget/embedded/src/index.ts
+++ b/widget/embedded/src/index.ts
@@ -69,6 +69,7 @@ import {
 } from './components/WalletStatefulConnect';
 import { WIDGET_UI_ID as UI_ID } from './constants';
 import { SUPPORTED_FONTS } from './constants/fonts';
+import { Refuel } from './containers/Refuel';
 import { WidgetWallets } from './containers/Wallets';
 import { Widget } from './containers/Widget';
 import { useWidget } from './containers/WidgetInfo';
@@ -132,6 +133,7 @@ export type {
 };
 export {
   Widget,
+  Refuel,
   /**
    * @deprecated Use `WidgetProvider` instead. This component will be removed in future versions.
    */

--- a/widget/embedded/src/pages/ConfirmSwapPage.tsx
+++ b/widget/embedded/src/pages/ConfirmSwapPage.tsx
@@ -70,7 +70,7 @@ export function ConfirmSwapPage() {
     quoteWalletsConfirmed,
     customDestination,
     quoteWarningsConfirmed,
-  } = useQuoteStore();
+  } = useQuoteStore()();
   const navigate = useNavigate();
   const [dbErrorMessage, setDbErrorMessage] = useState<string>('');
 

--- a/widget/embedded/src/pages/CustomTokensPage.tsx
+++ b/widget/embedded/src/pages/CustomTokensPage.tsx
@@ -50,7 +50,7 @@ export function CustomTokensPage() {
   const [searchedFor, setSearchedFor] = useState<string>('');
   const { deleteCustomToken } = useAppStore();
   const customTokens = useAppStore().customTokens();
-  const { fromToken, toToken, setFromToken, setToToken } = useQuoteStore();
+  const { fromToken, toToken, setFromToken, setToToken } = useQuoteStore()();
   const { mode } = useTheme({});
   const navigate = useNavigate();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -150,6 +150,18 @@ export function Home() {
     setCustomSlippage(slippage);
   };
 
+  const handleInputTokenClick = (mode: 'from' | 'to') => {
+    if (mode === 'from') {
+      onHandleNavigation(navigationRoutes.fromSwap);
+    } else {
+      onHandleNavigation(
+        swapMode === 'swap'
+          ? navigationRoutes.toSwap
+          : navigationRoutes.toSwap + '/' + navigationRoutes.blockchains
+      );
+    }
+  };
+
   useEffect(() => {
     resetQuoteWallets();
     updateQuotePartialState('refetchQuote', true);
@@ -214,13 +226,7 @@ export function Home() {
             fetchingQuote={fetchingQuote}
             fetchMetaStatus={fetchMetaStatus}
             isExpandable={isExpandable}
-            onClickToken={(mode) => {
-              onHandleNavigation(
-                mode === 'from'
-                  ? navigationRoutes.fromSwap
-                  : navigationRoutes.toSwap
-              );
-            }}
+            onClickToken={handleInputTokenClick}
           />
           <Divider size="2" />
           {!isExpandable ? (

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -19,6 +19,7 @@ import { Inputs } from '../containers/Inputs';
 import { QuoteInfo } from '../containers/QuoteInfo';
 import useScreenDetect from '../hooks/useScreenDetect';
 import { useSwapInput } from '../hooks/useSwapInput';
+import { useSwapMode } from '../hooks/useSwapMode';
 import { useAppStore } from '../store/AppStore';
 import { useQuoteStore } from '../store/quote';
 import { useUiStore } from '../store/ui';
@@ -72,6 +73,7 @@ export function Home() {
   const { isActiveTab } = useUiStore();
   const [showQuoteWarningModal, setShowQuoteWarningModal] = useState(false);
   const currentSlippage = customSlippage !== null ? customSlippage : slippage;
+  const swapMode = useSwapMode();
 
   const slippageValidation = getSlippageValidation(currentSlippage);
 
@@ -192,7 +194,10 @@ export function Home() {
             onHandleNavigation(navigationRoutes.wallets);
           },
           hasBackButton: false,
-          title: config.title || i18n.t('Swap'),
+          title:
+            config.title || swapMode === 'swap'
+              ? i18n.t('Swap')
+              : i18n.t('Refuel'),
           suffix: (
             <HeaderButtons
               hidden={isExpandable ? ['refresh'] : undefined}

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -53,7 +53,7 @@ export function Home() {
     resetQuoteWallets,
     setQuoteWarningsConfirmed,
     updateQuotePartialState,
-  } = useQuoteStore();
+  } = useQuoteStore()();
 
   const [isVisibleExpanded, setIsVisibleExpanded] = useState<boolean>(false);
   const { isLargeScreen, isExtraLargeScreen } = useScreenDetect();

--- a/widget/embedded/src/pages/Routes.tsx
+++ b/widget/embedded/src/pages/Routes.tsx
@@ -21,7 +21,7 @@ export function RoutesPage() {
     setSelectedQuote,
     updateQuotePartialState,
     error: quoteError,
-  } = useQuoteStore();
+  } = useQuoteStore()();
 
   const { fetch: fetchQuote, loading: fetchingQuote } = useSwapInput({
     refetchQuote,

--- a/widget/embedded/src/pages/SelectBlockchainPage.tsx
+++ b/widget/embedded/src/pages/SelectBlockchainPage.tsx
@@ -24,8 +24,8 @@ export function SelectBlockchainPage(props: PropTypes) {
   const navigateBack = useNavigateBack();
   const [searchedFor, setSearchedFor] = useState<string>('');
   const [blockchainCategory, setBlockchainCategory] = useState<string>('ALL');
-  const setToBlockchain = useQuoteStore.use.setToBlockchain();
-  const setFromBlockchain = useQuoteStore.use.setFromBlockchain();
+  const setToBlockchain = useQuoteStore().use.setToBlockchain();
+  const setFromBlockchain = useQuoteStore().use.setFromBlockchain();
   const { fetchStatus } = useAppStore();
   const navigate = useNavigate();
 

--- a/widget/embedded/src/pages/SelectSwapItemPage/SelectSwapItemsPage.tsx
+++ b/widget/embedded/src/pages/SelectSwapItemPage/SelectSwapItemsPage.tsx
@@ -35,7 +35,7 @@ export function SelectSwapItemsPage(props: PropTypes) {
     setToToken,
     setFromBlockchain,
     setToBlockchain,
-  } = useQuoteStore();
+  } = useQuoteStore()();
   const { getBalanceFor } = useAppStore();
   const {
     fetch,

--- a/widget/embedded/src/store/quote.ts
+++ b/widget/embedded/src/store/quote.ts
@@ -6,12 +6,14 @@ import type {
   PreferenceType,
   Token,
 } from 'rango-sdk';
+import type { StateCreator } from 'zustand';
 
 import BigNumber from 'bignumber.js';
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 
 import { ZERO } from '../constants/numbers';
+import { useSwapMode } from '../hooks/useSwapMode';
 import { eventEmitter } from '../services/eventEmitter';
 import {
   type QuoteError,
@@ -103,276 +105,303 @@ export interface QuoteState {
   setQuoteWarningsConfirmed: (flag: boolean) => void;
 }
 
-export const useQuoteStore = createSelectors(
-  create<QuoteState>()(
-    subscribeWithSelector((set) => ({
-      fromBlockchain: null,
-      fromToken: null,
-      inputAmount: '',
-      outputAmount: null,
-      inputUsdValue: new BigNumber(0),
-      outputUsdValue: new BigNumber(0),
-      toBlockchain: null,
-      toToken: null,
-      refetchQuote: true,
-      sortStrategy: 'SMART',
-      selectedQuote: null,
-      quotes: null,
+const initializer: StateCreator<
+  QuoteState,
+  [['zustand/subscribeWithSelector', never]],
+  []
+> = (
+  set: (
+    partial:
+      | QuoteState
+      | Partial<QuoteState>
+      | ((state: QuoteState) => QuoteState | Partial<QuoteState>),
+    replace?: boolean | undefined
+  ) => void
+) => ({
+  fromBlockchain: null,
+  fromToken: null,
+  inputAmount: '',
+  outputAmount: null,
+  inputUsdValue: new BigNumber(0),
+  outputUsdValue: new BigNumber(0),
+  toBlockchain: null,
+  toToken: null,
+  refetchQuote: true,
+  sortStrategy: 'SMART',
+  selectedQuote: null,
+  quotes: null,
+  error: null,
+  warning: null,
+  quoteWalletsConfirmed: false,
+  selectedWallets: [],
+  customDestination: null,
+  quoteWarningsConfirmed: false,
+  updateQuotePartialState: (key, value) =>
+    set((state) => ({
+      ...state,
+      [key]: value,
+    })),
+  setSelectedQuote: (quote) =>
+    set((state) => {
+      let outputAmount: BigNumber | null = null;
+      let outputUsdValue: BigNumber = ZERO;
+
+      let inputUsdValue = state.inputUsdValue;
+      if (!isPositiveNumber(state.inputAmount)) {
+        return {};
+      }
+      if (!!quote) {
+        outputAmount = !!quote?.outputAmount
+          ? new BigNumber(quote?.outputAmount)
+          : null;
+        inputUsdValue = getUsdInputFrom(quote) ?? ZERO;
+        outputUsdValue = getUsdOutputFrom(quote) ?? ZERO;
+      }
+      return {
+        selectedQuote: quote,
+        ...(!!quote && {
+          outputAmount,
+          outputUsdValue,
+          inputUsdValue,
+        }),
+      };
+    }),
+  resetAlerts: () =>
+    set(() => ({
       error: null,
       warning: null,
+    })),
+  resetQuote: () =>
+    set(() => ({
+      selectedQuote: null,
+      outputAmount: null,
+      outputUsdValue: new BigNumber(0),
+      quotes: null,
+      refetchQuote: true,
+      error: null,
+      warning: null,
+    })),
+  setFromBlockchain: (chain) => {
+    set((state) => {
+      if (state.fromBlockchain?.name === chain?.name) {
+        return {};
+      }
+
+      return {
+        fromBlockchain: chain,
+        inputUsdValue: new BigNumber(0),
+        ...(state.fromToken && {
+          selectedQuote: null,
+          fromToken: null,
+          outputAmount: null,
+          outputUsdValue: new BigNumber(0),
+        }),
+      };
+    });
+  },
+  setFromToken: (params) => {
+    return set((state) => ({
+      fromToken: params.token,
+      ...(params.token && {
+        fromBlockchain:
+          params.meta.blockchains.find(
+            (blockchain) => blockchain.name === params.token.blockchain
+          ) ?? null,
+      }),
+      ...(!!state.inputAmount && {
+        inputUsdValue: getUsdValue(params.token, state.inputAmount),
+      }),
+    }));
+  },
+  setToBlockchain: (chain) => {
+    set((state) => {
+      if (state.toBlockchain?.name === chain?.name) {
+        return {};
+      }
+
+      return {
+        toBlockchain: chain,
+        ...(state.toToken && {
+          selectedQuote: null,
+          toToken: null,
+          outputAmount: null,
+          outputUsdValue: new BigNumber(0),
+        }),
+      };
+    });
+  },
+  setToToken: (params) => {
+    return set(() => ({
+      toToken: params.token,
+      ...(params.token && {
+        toBlockchain:
+          params.meta.blockchains.find(
+            (blockchain) => blockchain.name === params.token.blockchain
+          ) ?? null,
+      }),
+    }));
+  },
+  sanitizeInputAmount: (amount) => {
+    const sanitized = sanitizeInputAmount(amount);
+
+    set(() => ({
+      inputAmount: sanitized,
+    }));
+  },
+  setInputAmount: (amount) => {
+    let sanitized = amount;
+    if (!isZeroValue(amount)) {
+      // sanitize once a meaningful digit is entered (e.g. "00001" → "1")
+      sanitized = removeLeadingZeros(sanitized);
+      sanitized = ensureLeadingZeroForDecimal(sanitized);
+    }
+    set((state) => ({
+      inputAmount: sanitized,
+      ...(!sanitized && {
+        outputAmount: null,
+        outputUsdValue: new BigNumber(0),
+        selectedQuote: null,
+      }),
+      ...(!!state.fromToken && {
+        inputUsdValue: getUsdValue(state.fromToken, sanitized),
+      }),
+    }));
+  },
+  retry: (retryQuote) => {
+    const { fromBlockchain, fromToken, toBlockchain, toToken, inputAmount } =
+      retryQuote;
+
+    set({
+      fromBlockchain,
+      fromToken,
+      inputAmount,
+      outputAmount: null,
+      inputUsdValue: getUsdValue(fromToken ?? null, inputAmount),
+      outputUsdValue: new BigNumber(0),
+      toBlockchain,
+      toToken,
+      selectedQuote: null,
+    });
+  },
+  switchFromAndTo: () =>
+    set((state) => ({
+      fromBlockchain: state.toBlockchain,
+      fromToken: state.toToken,
+      toBlockchain: state.fromBlockchain,
+      toToken: state.fromToken,
+      inputAmount: state.outputAmount?.toString() || '',
+      inputUsdValue: state.toToken
+        ? getUsdValue(state.toToken, state.outputAmount?.toString() || '')
+        : new BigNumber(0),
+    })),
+  resetFromBlockchain: () =>
+    set(() => ({
+      fromToken: null,
+      fromBlockchain: null,
+      outputUsdValue: new BigNumber(0),
+      inputUsdValue: new BigNumber(0),
+      inputAmount: '',
+      outputAmount: null,
+      selectedQuote: null,
+    })),
+  resetToBlockchain: () =>
+    set(() => ({
+      toToken: null,
+      toBlockchain: null,
+      outputAmount: null,
+      outputUsdValue: new BigNumber(0),
+      selectedQuote: null,
+    })),
+  setQuoteWalletConfirmed: (flag) =>
+    set({
+      quoteWalletsConfirmed: flag,
+    }),
+  setSelectedWallets: (wallets) => set({ selectedWallets: wallets }),
+  setCustomDestination: (address) => set({ customDestination: address }),
+  resetQuoteWallets: () =>
+    set({
       quoteWalletsConfirmed: false,
       selectedWallets: [],
       customDestination: null,
-      quoteWarningsConfirmed: false,
-      updateQuotePartialState: (key, value) =>
-        set((state) => ({
-          ...state,
-          [key]: value,
-        })),
-      setSelectedQuote: (quote) =>
-        set((state) => {
-          let outputAmount: BigNumber | null = null;
-          let outputUsdValue: BigNumber = ZERO;
+    }),
+  setQuoteWarningsConfirmed: (flag) => set({ quoteWarningsConfirmed: flag }),
+});
 
-          let inputUsdValue = state.inputUsdValue;
-          if (!isPositiveNumber(state.inputAmount)) {
-            return {};
-          }
-          if (!!quote) {
-            outputAmount = !!quote?.outputAmount
-              ? new BigNumber(quote?.outputAmount)
-              : null;
-            inputUsdValue = getUsdInputFrom(quote) ?? ZERO;
-            outputUsdValue = getUsdOutputFrom(quote) ?? ZERO;
-          }
-          return {
-            selectedQuote: quote,
-            ...(!!quote && {
-              outputAmount,
-              outputUsdValue,
-              inputUsdValue,
-            }),
-          };
-        }),
-      resetAlerts: () =>
-        set(() => ({
-          error: null,
-          warning: null,
-        })),
-      resetQuote: () =>
-        set(() => ({
-          selectedQuote: null,
-          outputAmount: null,
-          outputUsdValue: new BigNumber(0),
-          quotes: null,
-          refetchQuote: true,
-          error: null,
-          warning: null,
-        })),
-      setFromBlockchain: (chain) => {
-        set((state) => {
-          if (state.fromBlockchain?.name === chain?.name) {
-            return {};
-          }
-
-          return {
-            fromBlockchain: chain,
-            inputUsdValue: new BigNumber(0),
-            ...(state.fromToken && {
-              selectedQuote: null,
-              fromToken: null,
-              outputAmount: null,
-              outputUsdValue: new BigNumber(0),
-            }),
-          };
-        });
-      },
-      setFromToken: (params) => {
-        return set((state) => ({
-          fromToken: params.token,
-          ...(params.token && {
-            fromBlockchain:
-              params.meta.blockchains.find(
-                (blockchain) => blockchain.name === params.token.blockchain
-              ) ?? null,
-          }),
-          ...(!!state.inputAmount && {
-            inputUsdValue: getUsdValue(params.token, state.inputAmount),
-          }),
-        }));
-      },
-      setToBlockchain: (chain) => {
-        set((state) => {
-          if (state.toBlockchain?.name === chain?.name) {
-            return {};
-          }
-
-          return {
-            toBlockchain: chain,
-            ...(state.toToken && {
-              selectedQuote: null,
-              toToken: null,
-              outputAmount: null,
-              outputUsdValue: new BigNumber(0),
-            }),
-          };
-        });
-      },
-      setToToken: (params) => {
-        return set(() => ({
-          toToken: params.token,
-          ...(params.token && {
-            toBlockchain:
-              params.meta.blockchains.find(
-                (blockchain) => blockchain.name === params.token.blockchain
-              ) ?? null,
-          }),
-        }));
-      },
-      sanitizeInputAmount: (amount) => {
-        const sanitized = sanitizeInputAmount(amount);
-
-        set(() => ({
-          inputAmount: sanitized,
-        }));
-      },
-      setInputAmount: (amount) => {
-        let sanitized = amount;
-        if (!isZeroValue(amount)) {
-          // sanitize once a meaningful digit is entered (e.g. "00001" → "1")
-          sanitized = removeLeadingZeros(sanitized);
-          sanitized = ensureLeadingZeroForDecimal(sanitized);
-        }
-        set((state) => ({
-          inputAmount: sanitized,
-          ...(!sanitized && {
-            outputAmount: null,
-            outputUsdValue: new BigNumber(0),
-            selectedQuote: null,
-          }),
-          ...(!!state.fromToken && {
-            inputUsdValue: getUsdValue(state.fromToken, sanitized),
-          }),
-        }));
-      },
-      retry: (retryQuote) => {
-        const {
-          fromBlockchain,
-          fromToken,
-          toBlockchain,
-          toToken,
-          inputAmount,
-        } = retryQuote;
-
-        set({
-          fromBlockchain,
-          fromToken,
-          inputAmount,
-          outputAmount: null,
-          inputUsdValue: getUsdValue(fromToken ?? null, inputAmount),
-          outputUsdValue: new BigNumber(0),
-          toBlockchain,
-          toToken,
-          selectedQuote: null,
-        });
-      },
-      switchFromAndTo: () =>
-        set((state) => ({
-          fromBlockchain: state.toBlockchain,
-          fromToken: state.toToken,
-          toBlockchain: state.fromBlockchain,
-          toToken: state.fromToken,
-          inputAmount: state.outputAmount?.toString() || '',
-          inputUsdValue: state.toToken
-            ? getUsdValue(state.toToken, state.outputAmount?.toString() || '')
-            : new BigNumber(0),
-        })),
-      resetFromBlockchain: () =>
-        set(() => ({
-          fromToken: null,
-          fromBlockchain: null,
-          outputUsdValue: new BigNumber(0),
-          inputUsdValue: new BigNumber(0),
-          inputAmount: '',
-          outputAmount: null,
-          selectedQuote: null,
-        })),
-      resetToBlockchain: () =>
-        set(() => ({
-          toToken: null,
-          toBlockchain: null,
-          outputAmount: null,
-          outputUsdValue: new BigNumber(0),
-          selectedQuote: null,
-        })),
-      setQuoteWalletConfirmed: (flag) =>
-        set({
-          quoteWalletsConfirmed: flag,
-        }),
-      setSelectedWallets: (wallets) => set({ selectedWallets: wallets }),
-      setCustomDestination: (address) => set({ customDestination: address }),
-      resetQuoteWallets: () =>
-        set({
-          quoteWalletsConfirmed: false,
-          selectedWallets: [],
-          customDestination: null,
-        }),
-      setQuoteWarningsConfirmed: (flag) =>
-        set({ quoteWarningsConfirmed: flag }),
-    }))
-  )
+const createSwapQuoteSelectors = create<QuoteState>()(
+  subscribeWithSelector(initializer)
+);
+const createRefuelQuoteSelectors = create<QuoteState>()(
+  subscribeWithSelector(initializer)
 );
 
-export const unsubscribeQuoteStore = useQuoteStore.subscribe(
-  (selectedState, previousSelectedState) => {
-    if (
-      selectedState.fromBlockchain !== previousSelectedState.fromBlockchain ||
-      selectedState.fromToken !== previousSelectedState.fromToken ||
-      selectedState.toBlockchain !== previousSelectedState.toBlockchain ||
-      selectedState.toToken !== previousSelectedState.toToken ||
-      selectedState.inputAmount !== previousSelectedState.inputAmount
-    ) {
-      // useEffect hook can not be used in Zustand subscribe
-      eventEmitter.emit(WidgetEvents.QuoteEvent, {
-        type: QuoteEventTypes.QUOTE_INPUT_UPDATE,
-        payload: {
-          fromBlockchain: selectedState.fromBlockchain?.name,
-          toBlockchain: selectedState.toBlockchain?.name,
-          fromToken: selectedState.fromToken
-            ? {
-                symbol: selectedState.fromToken.symbol,
-                name: selectedState.fromToken.name,
-                address: selectedState.fromToken.address,
-              }
-            : undefined,
-          toToken: selectedState.toToken
-            ? {
-                symbol: selectedState.toToken.symbol,
-                name: selectedState.toToken.name,
-                address: selectedState.toToken.address,
-              }
-            : undefined,
-          requestAmount: selectedState.inputAmount,
-        },
-      });
-    }
+export const useSwapQuoteStore = createSelectors(createSwapQuoteSelectors);
+export const useRefuelQuoteStore = createSelectors(createRefuelQuoteSelectors);
 
-    if (
-      selectedState.selectedQuote?.requestId !==
-      previousSelectedState.selectedQuote?.requestId
-    ) {
-      eventEmitter.emit(WidgetEvents.QuoteEvent, {
-        type: QuoteEventTypes.QUOTE_OUTPUT_UPDATE,
-        payload: selectedState.selectedQuote
+export function useQuoteStore() {
+  const swapMode = useSwapMode();
+  return createSelectors(
+    swapMode === 'refuel'
+      ? createRefuelQuoteSelectors
+      : createSwapQuoteSelectors
+  );
+}
+
+const subscribeCallback = (
+  selectedState: QuoteState,
+  previousSelectedState: QuoteState
+) => {
+  if (
+    selectedState.fromBlockchain !== previousSelectedState.fromBlockchain ||
+    selectedState.fromToken !== previousSelectedState.fromToken ||
+    selectedState.toBlockchain !== previousSelectedState.toBlockchain ||
+    selectedState.toToken !== previousSelectedState.toToken ||
+    selectedState.inputAmount !== previousSelectedState.inputAmount
+  ) {
+    // useEffect hook can not be used in Zustand subscribe
+    eventEmitter.emit(WidgetEvents.QuoteEvent, {
+      type: QuoteEventTypes.QUOTE_INPUT_UPDATE,
+      payload: {
+        fromBlockchain: selectedState.fromBlockchain?.name,
+        toBlockchain: selectedState.toBlockchain?.name,
+        fromToken: selectedState.fromToken
           ? {
-              requestAmount: selectedState.selectedQuote.requestAmount,
-              swaps: selectedState.selectedQuote.swaps,
-              outputAmount: selectedState.selectedQuote.outputAmount,
-              resultType: selectedState.selectedQuote.resultType,
-              tags: selectedState.selectedQuote.tags,
+              symbol: selectedState.fromToken.symbol,
+              name: selectedState.fromToken.name,
+              address: selectedState.fromToken.address,
             }
-          : null,
-      });
-    }
+          : undefined,
+        toToken: selectedState.toToken
+          ? {
+              symbol: selectedState.toToken.symbol,
+              name: selectedState.toToken.name,
+              address: selectedState.toToken.address,
+            }
+          : undefined,
+        requestAmount: selectedState.inputAmount,
+      },
+    });
   }
-);
+
+  if (
+    selectedState.selectedQuote?.requestId !==
+    previousSelectedState.selectedQuote?.requestId
+  ) {
+    eventEmitter.emit(WidgetEvents.QuoteEvent, {
+      type: QuoteEventTypes.QUOTE_OUTPUT_UPDATE,
+      payload: selectedState.selectedQuote
+        ? {
+            requestAmount: selectedState.selectedQuote.requestAmount,
+            swaps: selectedState.selectedQuote.swaps,
+            outputAmount: selectedState.selectedQuote.outputAmount,
+            resultType: selectedState.selectedQuote.resultType,
+            tags: selectedState.selectedQuote.tags,
+          }
+        : null,
+    });
+  }
+};
+
+export const unsubscribeSwapQuoteStore =
+  useSwapQuoteStore.subscribe(subscribeCallback);
+export const unsubscribeRefuelQuoteStore =
+  useRefuelQuoteStore.subscribe(subscribeCallback);

--- a/widget/embedded/src/store/quote.ts
+++ b/widget/embedded/src/store/quote.ts
@@ -97,7 +97,7 @@ export interface QuoteState {
   sanitizeInputAmount: (amount: string) => void;
   setSelectedQuote: (quote: SelectedQuote | null) => void;
   retry: (retryQuote: RetryQuote) => void;
-  switchFromAndTo: () => void;
+  switchFromAndTo: (options?: { toToken?: Token }) => void;
   setQuoteWalletConfirmed: (flag: boolean) => void;
   setSelectedWallets: (wallets: Wallet[]) => void;
   setCustomDestination: (address: string | null) => void;
@@ -283,12 +283,12 @@ const initializer: StateCreator<
       selectedQuote: null,
     });
   },
-  switchFromAndTo: () =>
+  switchFromAndTo: (options) =>
     set((state) => ({
       fromBlockchain: state.toBlockchain,
       fromToken: state.toToken,
       toBlockchain: state.fromBlockchain,
-      toToken: state.fromToken,
+      toToken: options?.toToken ?? state.fromToken,
       inputAmount: state.outputAmount?.toString() || '',
       inputUsdValue: state.toToken
         ? getUsdValue(state.toToken, state.outputAmount?.toString() || '')

--- a/widget/embedded/src/store/slices/data.ts
+++ b/widget/embedded/src/store/slices/data.ts
@@ -56,6 +56,7 @@ export interface DataSlice {
   swappers: () => SwapperMeta[];
   isTokenPinned: (token: Token, type: 'source' | 'destination') => boolean;
   findToken: FindToken;
+  findNativeToken: (blockchain: BlockchainMeta) => Token | undefined;
   fetch: () => Promise<void>;
 }
 
@@ -274,6 +275,14 @@ export const createDataSlice: StateCreator<
       );
     }
     return token;
+  },
+  findNativeToken: (blockchain: BlockchainMeta) => {
+    const feeAsset = blockchain.feeAssets[0];
+    return get().findToken({
+      blockchain: blockchain.name,
+      address: feeAsset.address,
+      symbol: feeAsset.symbol,
+    });
   },
   isTokenPinned: (token, type) => {
     const pinnedTokens =

--- a/widget/ui/src/components/Tabs/Tabs.styles.tsx
+++ b/widget/ui/src/components/Tabs/Tabs.styles.tsx
@@ -97,6 +97,7 @@ export const Tab = styled(Button, {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
+    gap: '$2',
   },
   variants: {
     borderRadius: {

--- a/widget/ui/src/components/Tabs/Tabs.tsx
+++ b/widget/ui/src/components/Tabs/Tabs.tsx
@@ -3,7 +3,6 @@ import type { TabsPropTypes } from './Tabs.types.js';
 import React, { useEffect, useRef, useState } from 'react';
 import { ChevronLeftIcon, ChevronRightIcon } from 'src/icons/index.js';
 
-import { Divider } from '../Divider/index.js';
 import { Tooltip } from '../Tooltip/index.js';
 
 import {
@@ -190,7 +189,7 @@ export function TabsComponent(props: TabsPropTypes) {
               content={item.tooltip}
               open={!item.tooltip ? false : undefined}>
               <Tab
-                className="_tab"
+                className={`_tab ${isActive ? '_active' : ''}`}
                 ref={index === currentIndex ? tabRef : null}
                 type={type}
                 fullWidth={scrollable ? false : true}
@@ -202,9 +201,6 @@ export function TabsComponent(props: TabsPropTypes) {
                 data-active={isActive}
                 variant="default">
                 {item.icon}
-                {!!item.icon && !!item.title && (
-                  <Divider direction="horizontal" size="2" />
-                )}
                 {item.title}
               </Tab>
             </Tooltip>

--- a/widget/ui/src/containers/SwapInput/SwapInput.tsx
+++ b/widget/ui/src/containers/SwapInput/SwapInput.tsx
@@ -88,6 +88,7 @@ export function SwapInput(props: SwapInputPropTypes) {
         <TokenSectionContainer>
           <TokenSection
             id={`${props.id}-token-selection-container`}
+            selectionType={props.selectionType}
             chain={props.chain.displayName}
             chianImageId={
               props.mode === 'To'

--- a/widget/ui/src/containers/SwapInput/SwapInput.types.ts
+++ b/widget/ui/src/containers/SwapInput/SwapInput.types.ts
@@ -25,6 +25,7 @@ export type BaseProps = {
   sharpBottomStyle?: boolean;
   onClickToken: () => void;
   tooltipContainer?: HTMLElement;
+  selectionType?: 'token' | 'chain';
 };
 
 type FromProps = {

--- a/widget/ui/src/containers/SwapInput/TokenSection.tsx
+++ b/widget/ui/src/containers/SwapInput/TokenSection.tsx
@@ -37,9 +37,21 @@ export function TokenSection(props: TokenSectionProps) {
     warning,
     tooltipContainer,
     id,
+    selectionType = 'token',
   } = props;
 
   const tokenSelected = !error && !loading && !!tokenSymbol;
+
+  const getBodyContent = () => {
+    if (error) {
+      return error;
+    } else if (!loading && !chain) {
+      return selectionType === 'token'
+        ? i18n.t('Select Chain')
+        : i18n.t('Select gas chain');
+    }
+    return chain;
+  };
 
   return (
     <Container
@@ -85,7 +97,9 @@ export function TokenSection(props: TokenSectionProps) {
                   </Tooltip>
                 ) : (
                   <Typography variant="title" size="medium">
-                    {i18n.t('Select Token')}
+                    {selectionType === 'token'
+                      ? i18n.t('Select Token')
+                      : i18n.t('Select Chain')}
                   </Typography>
                 )}
                 {warning && (
@@ -99,7 +113,7 @@ export function TokenSection(props: TokenSectionProps) {
                 variant="body"
                 size="medium"
                 className={chainNameStyles()}>
-                {error || (!loading && !chain) ? i18n.t('Select Chain') : chain}
+                {getBodyContent()}
               </Typography>
             </>
           )}

--- a/widget/ui/src/containers/SwapInput/TokenSection.types.ts
+++ b/widget/ui/src/containers/SwapInput/TokenSection.types.ts
@@ -10,4 +10,5 @@ export type TokenSectionProps = {
   loading?: boolean;
   warning?: boolean;
   tooltipContainer?: HTMLElement;
+  selectionType?: 'token' | 'chain';
 };


### PR DESCRIPTION
# Summary

Implemented Refuel container to be exposed from `@rango-dev/widget-embedded`. 

## Key Changes per each commit

### Export refuel container
- Exported a container named Refuel such as Widget
- Added a custom hook called `useSwapMode` to specify the current mode for widget

### Add quote slice for refuel 
- Updated `useQuoteStore` and added a clone for quote slice
- Updated all usges to be compatible with new changes

### Add refuel title for widget
- Title of widget is updated based on the value returned by `useSwapMode` hook

### Add blockchain selection selection input
- Added a prop named `selectionType` to `SwapInput` to specify type of entity which should be selected
- Added new changes to the inputs to handle blockchain selection
- Updated `SelectBlockchainChange` to update destination blockchain and token (which should be the native token of the selected blockchain) based on the selected blockchain
- Updated `SwitchFromAndTo` button in order to select the native token of the "from" blockchain as "to" token on switching From and to

### Updated Tabs component to be more customizable

# How did you test this change?

Tested by switching between "Swap" and "Refuel" modes and creating transaction in each mode.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
