### PR TITLE
feat: implement changeAccountSubscriber builder

### DIFF
--- a/wallets/core/src/namespaces/common/hooks/changeAccountSubscriber.test.ts
+++ b/wallets/core/src/namespaces/common/hooks/changeAccountSubscriber.test.ts
@@ -1,0 +1,162 @@
+import { waitFor } from '@testing-library/dom';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { createStore, Namespace } from '../../../mod.js';
+
+import { ChangeAccountSubscriberBuilder } from './changeAccountSubscriber.js';
+
+interface TestNamespaceActions {
+  disconnect: () => void;
+}
+
+describe('check changeAccountSubscriber', () => {
+  const garbageProvider = { name: 'garbage provider' };
+
+  const garbageFormatter = async (
+    _instance: typeof garbageProvider,
+    accounts: string[]
+  ) => accounts.map((account) => `Formatted: ${account}`);
+
+  const garbageAddEventListener = (
+    _instance: typeof garbageProvider,
+    callback: (event: string[]) => void
+  ) => {
+    callback(['0']);
+  };
+
+  const garbageRemoveEventListener = (
+    _: typeof garbageProvider,
+    __: (event: string[]) => void
+  ) => {};
+
+  let builder: ChangeAccountSubscriberBuilder<string[], typeof garbageProvider>;
+
+  const setupNamespace = () => {
+    const actions = new Map();
+    const disconnectAction = vi.fn();
+    actions.set('disconnect', disconnectAction);
+
+    const store = createStore();
+    const ns = new Namespace<TestNamespaceActions>('evm', 'garbage provider', {
+      actions,
+      store,
+    });
+
+    const context = { action: ns.run.bind(ns), state: ns.state.bind(ns) };
+
+    return { ns, context, disconnectAction };
+  };
+
+  beforeEach(() => {
+    builder = new ChangeAccountSubscriberBuilder();
+  });
+
+  test('throws error if required operators are not set', () => {
+    expect(() => builder.build()).toThrow(
+      `Required "getInstance" operation has not been set for "changeAccountSubscriber"`
+    );
+
+    builder.getInstance(() => garbageProvider);
+    expect(() => builder.build()).toThrow(
+      `Required "format" operation has not been set for "changeAccountSubscriber"`
+    );
+
+    builder.format(garbageFormatter);
+    expect(() => builder.build()).toThrow(
+      `Required "addEventListener" operation has not been set for "changeAccountSubscriber"`
+    );
+
+    builder.addEventListener(garbageAddEventListener);
+    expect(() => builder.build()).toThrow(
+      `Required "removeEventListener" operation has not been set for "changeAccountSubscriber"`
+    );
+
+    builder.removeEventListener(garbageRemoveEventListener);
+
+    // should not throw now
+    builder.build();
+  });
+
+  test('calls addEventListener and formats accounts correctly', async () => {
+    const { context } = setupNamespace();
+    const spiedAddEventListener = vi.fn(garbageAddEventListener);
+
+    builder
+      .getInstance(() => garbageProvider)
+      .format(garbageFormatter)
+      .addEventListener(spiedAddEventListener)
+      .removeEventListener(garbageRemoveEventListener);
+
+    const [subscriber] = builder.build();
+
+    expect(spiedAddEventListener).toHaveBeenCalledTimes(0);
+    subscriber(context);
+    expect(spiedAddEventListener).toHaveBeenCalledTimes(1);
+
+    const [getState] = context.state();
+    await waitFor(() => {
+      expect(getState('accounts')?.[0]).toBe('Formatted: 0');
+    });
+  });
+
+  test('calls disconnect if event is not valid', () => {
+    const { context, disconnectAction } = setupNamespace();
+    const spiedAddEventListener = vi.fn(garbageAddEventListener);
+
+    builder
+      .getInstance(() => garbageProvider)
+      .format(garbageFormatter)
+      .addEventListener(spiedAddEventListener)
+      .validateEventPayload((event) => !event)
+      .removeEventListener(garbageRemoveEventListener);
+
+    const [subscriber] = builder.build();
+
+    expect(disconnectAction).toHaveBeenCalledTimes(0);
+    subscriber(context);
+    expect(disconnectAction).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls removeEventListener', () => {
+    const { context } = setupNamespace();
+    const spiedRemoveEventListener = vi.fn(garbageRemoveEventListener);
+
+    builder
+      .getInstance(() => garbageProvider)
+      .format(garbageFormatter)
+      .addEventListener(garbageAddEventListener)
+      .removeEventListener(spiedRemoveEventListener);
+
+    const [, clearSubscriber] = builder.build();
+
+    expect(spiedRemoveEventListener).toHaveBeenCalledTimes(0);
+    clearSubscriber(context);
+    expect(spiedRemoveEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  test('calls addEventListener returned function', () => {
+    const { context } = setupNamespace();
+    const unsubscribe = vi.fn();
+
+    const addEventListenerWithReturn = (
+      _: typeof garbageProvider,
+      __: (event: string[]) => void
+    ) => {
+      return unsubscribe;
+    };
+
+    builder
+      .getInstance(() => garbageProvider)
+      .format(garbageFormatter)
+      .addEventListener(addEventListenerWithReturn)
+      .removeEventListener(garbageRemoveEventListener);
+
+    const [subscriber, clearSubscriber] = builder.build();
+
+    subscriber(context);
+    expect(unsubscribe).toHaveBeenCalledTimes(0);
+
+    clearSubscriber(context);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/wallets/core/src/namespaces/common/hooks/changeAccountSubscriber.ts
+++ b/wallets/core/src/namespaces/common/hooks/changeAccountSubscriber.ts
@@ -1,0 +1,188 @@
+import type {
+  Actions,
+  SubscriberCleanUp,
+} from '../../../hub/namespaces/types.js';
+import type { Subscriber } from '../../../mod.js';
+import type { AutoImplementedActionsByRecommended } from '../types.js';
+
+export class ChangeAccountSubscriberBuilder<EventType, ProviderAPI> {
+  #getInstance: (() => ProviderAPI) | null = null;
+  #format:
+    | ((instance: ProviderAPI, event: EventType) => Promise<string[]>)
+    | null = null;
+  #validateEventPayload: ((event: EventType) => boolean) | null = null;
+
+  #addEventListener:
+    | ((
+        instance: ProviderAPI,
+        callback: (event: EventType) => void
+      ) => (() => void) | void)
+    | null = null;
+  #removeEventListener:
+    | ((instance: ProviderAPI, callback: (event: EventType) => void) => void)
+    | null = null;
+
+  /**
+   * Sets the function that provides the provider API instance.
+   *
+   * @param operator - Function that returns the provider API instance
+   * @returns The builder instance for method chaining
+   * @example
+   * ```typescript
+   * builder.getInstance(() => window.ethereum)
+   * ```
+   */
+  public getInstance(operator: () => ProviderAPI) {
+    this.#getInstance = operator;
+    return this;
+  }
+
+  /**
+   * Sets the formatter function that converts provider events to account strings.
+   *
+   * @param operator - Function that takes a provider instance and event, returns array of account strings
+   * @returns The builder instance for method chaining
+   * @example
+   * ```typescript
+   * builder.format(async (instance, event) => event.accounts || [])
+   * ```
+   */
+  public format(
+    operator: (instance: ProviderAPI, event: EventType) => Promise<string[]>
+  ) {
+    this.#format = operator;
+    return this;
+  }
+
+  /**
+   * Sets the event payload validation function (optional).
+   *
+   * @param operator - Function that validates if an event payload is valid
+   * @returns The builder instance for method chaining
+   * @example
+   * ```typescript
+   * builder.validateEventPayload(event => !!event)
+   * ```
+   */
+  public validateEventPayload(operator: (event: EventType) => boolean) {
+    this.#validateEventPayload = operator;
+    return this;
+  }
+
+  /**
+   * Sets the event listener attachment function.
+   *
+   * @param operator - Function that attaches an event listener and optionally returns a cleanup function
+   * @returns The builder instance for method chaining
+   * @example
+   * ```typescript
+   * builder.addEventListener((instance, callback) => {
+   *   return instance.on('accountsChanged', callback);
+   * })
+   * ```
+   */
+  public addEventListener(
+    operator: (
+      instance: ProviderAPI,
+      callback: (event: EventType) => void
+    ) => (() => void) | void
+  ) {
+    this.#addEventListener = operator;
+    return this;
+  }
+
+  /**
+   * Sets the event listener removal function.
+   *
+   * @param operator - Function that removes an event listener from the provider
+   * @returns The builder instance for method chaining
+   * @example
+   * ```typescript
+   * builder.removeEventListener((instance, callback) => instance.off('accountsChanged', callback))
+   * ```
+   */
+  public removeEventListener(
+    operator: (
+      instance: ProviderAPI,
+      callback: (event: EventType) => void
+    ) => void
+  ) {
+    this.#removeEventListener = operator;
+    return this;
+  }
+  public build<
+    ActionsType extends Actions<ActionsType> &
+      Actions<AutoImplementedActionsByRecommended>
+  >(): [Subscriber<ActionsType>, SubscriberCleanUp<ActionsType>] {
+    if (this.#getInstance === null) {
+      throw new Error(this.#getErrorMessage('getInstance'));
+    }
+    if (this.#format === null) {
+      throw new Error(this.#getErrorMessage('format'));
+    }
+    if (this.#addEventListener === null) {
+      throw new Error(this.#getErrorMessage('addEventListener'));
+    }
+    if (this.#removeEventListener === null) {
+      throw new Error(this.#getErrorMessage('removeEventListener'));
+    }
+
+    /**
+     * Capture current operator state at build time to ensure immutability.
+     *
+     * This creates a snapshot of all operators, preventing the built subscriber
+     * from being affected by subsequent changes to the builder instance.
+     * Each call to build() gets its own isolated set of operators, allowing
+     * the builder to be reused for creating multiple independent subscribers.
+     */
+    const getInstance = this.#getInstance;
+    const format = this.#format;
+    const addEventListener = this.#addEventListener;
+    const removeEventListener = this.#removeEventListener;
+    const validateEventPayload = this.#validateEventPayload;
+    let subscriber: (event: EventType) => void;
+    let unsubscribe: (() => void) | void;
+    return [
+      async (context) => {
+        const [, setState] = context.state();
+        const instance = getInstance();
+
+        if (!instance) {
+          throw new Error(
+            'Trying to subscribe to your wallet, but seems its instance is not available.'
+          );
+        }
+        subscriber = async (event) => {
+          if (!!validateEventPayload && !validateEventPayload(event)) {
+            context.action('disconnect');
+            return;
+          }
+          setState('accounts', await format(instance, event));
+        };
+        unsubscribe = addEventListener(instance, subscriber);
+      },
+      (_, err) => {
+        /**
+         * Call the cleanup function if addEventListener returned one.
+         * This handles providers that return an unsubscribe function from their event listeners.
+         */
+        if (unsubscribe && typeof unsubscribe === 'function') {
+          unsubscribe();
+        }
+        const instance = getInstance();
+
+        /**
+         * Always call removeEventListener as well to handle the on/off pattern.
+         * This ensures cleanup works regardless of which pattern the provider uses.
+         */
+        removeEventListener(instance, subscriber);
+
+        // subscriber can be passed to `or`, it will get the error and should rethrow error to pass the error to next `or` or throw error.
+        return err;
+      },
+    ];
+  }
+  #getErrorMessage(operatorName: string) {
+    return `Required "${operatorName}" operation has not been set for "changeAccountSubscriber"`;
+  }
+}

--- a/wallets/core/src/namespaces/evm/actions.ts
+++ b/wallets/core/src/namespaces/evm/actions.ts
@@ -1,26 +1,18 @@
-import type { EIP1193EventMap } from './eip1193.js';
 import type { ConnectOptions, EvmActions, ProviderAPI } from './types.js';
-import type { Context, Subscriber } from '../../hub/namespaces/mod.js';
-import type {
-  CanEagerConnect,
-  SubscriberCleanUp,
-} from '../../hub/namespaces/types.js';
-import type { CaipAccount } from '../../types/accounts.js';
+import type { Context } from '../../hub/namespaces/mod.js';
+import type { CanEagerConnect } from '../../hub/namespaces/types.js';
 import type { FunctionWithContext } from '../../types/actions.js';
-
-import { AccountId } from 'caip';
 
 import { recommended as commonRecommended } from '../common/actions.js';
 
-import { CAIP_NAMESPACE } from './constants.js';
 import {
   filterAndGetEvmBlockchainNames,
+  formatAccountsToCAIP,
   getAccounts,
   switchOrAddNetwork,
 } from './utils.js';
 
 export const recommended = [...commonRecommended];
-const CHAIN_ID_RADIX = 16;
 export function connect(
   instance: () => ProviderAPI,
   options?: ConnectOptions
@@ -50,127 +42,16 @@ export function connect(
 
     const result = await getAccounts(evmInstance);
 
-    /*
-     * Trust Wallet Compatibility Fix:
-     * Trust Wallet's in-app browser has been observed to return the `chainId` as a
-     * number (e.g., 1) rather than the standard hexadecimal string (e.g., "0x1").
-     * This code block standardizes the `chainId` to the required hex format to
-     * prevent downstream errors.
-     */
-    let chainId = result.chainId;
-    if (typeof chainId === 'number') {
-      chainId = `0x${Number(chainId).toString(CHAIN_ID_RADIX)}`;
-    }
-
-    const formatAccounts = result.accounts.map(
-      (account) =>
-        AccountId.format({
-          address: account,
-          chainId: {
-            namespace: CAIP_NAMESPACE,
-            reference: chainId,
-          },
-        }) as CaipAccount
+    const formattedAccounts = formatAccountsToCAIP(
+      result.accounts,
+      result.chainId
     );
 
     return {
-      accounts: formatAccounts,
-      network: chainId,
+      accounts: formattedAccounts,
+      network: result.chainId,
     };
   };
-}
-
-export function changeAccountSubscriber(
-  instance: () => ProviderAPI
-): [Subscriber<EvmActions>, SubscriberCleanUp<EvmActions>] {
-  let eventCallback: EIP1193EventMap['accountsChanged'];
-
-  // subscriber can be passed to `or`, it will get the error and should rethrow error to pass the error to next `or` or throw error.
-  return [
-    (context, err) => {
-      const evmInstance = instance();
-
-      if (!evmInstance) {
-        throw new Error(
-          'Trying to subscribe to your EVM wallet, but seems its instance is not available.'
-        );
-      }
-
-      const [, setState] = context.state();
-
-      eventCallback = async (accounts) => {
-        /*
-         * In Phantom, when user is switching to an account which is not connected to dApp yet, it returns a null.
-         * So null means we don't have access to account and we need to disconnect and let the user connect the account.
-         *
-         * This assumption may not work for other wallets, if that the case, we need to consider a new approach.
-         */
-        if (!accounts || accounts.length === 0) {
-          context.action('disconnect');
-          return;
-        }
-
-        const chainId = await evmInstance.request({ method: 'eth_chainId' });
-        const formatAccounts = accounts.map((account) =>
-          AccountId.format({
-            address: account,
-            chainId: {
-              namespace: CAIP_NAMESPACE,
-              reference: chainId,
-            },
-          })
-        );
-
-        setState('accounts', formatAccounts);
-      };
-      evmInstance.on('accountsChanged', eventCallback);
-
-      if (err instanceof Error) {
-        throw err;
-      }
-    },
-    (_, err) => {
-      const evmInstance = instance();
-
-      if (eventCallback && evmInstance) {
-        evmInstance.removeListener?.('accountsChanged', eventCallback);
-      }
-
-      return err;
-    },
-  ];
-}
-
-export function changeChainSubscriber(
-  instance: () => ProviderAPI
-): [Subscriber<EvmActions>, SubscriberCleanUp<EvmActions>] {
-  let eventCallback: EIP1193EventMap['chainChanged'];
-
-  return [
-    (context) => {
-      const evmInstance = instance();
-
-      if (!evmInstance) {
-        throw new Error(
-          'Trying to subscribe to your EVM wallet, but seems its instance is not available.'
-        );
-      }
-
-      const [, setState] = context.state();
-
-      eventCallback = async (chainId: string) => {
-        setState('network', chainId);
-      };
-      evmInstance.on('chainChanged', eventCallback);
-    },
-    () => {
-      const evmInstance = instance();
-
-      if (eventCallback && evmInstance) {
-        evmInstance.removeListener('chainChanged', eventCallback);
-      }
-    },
-  ];
 }
 
 export function canEagerConnect(

--- a/wallets/core/src/namespaces/evm/builders.ts
+++ b/wallets/core/src/namespaces/evm/builders.ts
@@ -1,12 +1,18 @@
-import type { EvmActions } from './types.js';
+import type { EvmActions, ProviderAPI } from './types.js';
+
+import { AccountId } from 'caip';
 
 import { ActionBuilder } from '../../mod.js';
+import { ChangeAccountSubscriberBuilder } from '../common/hooks/changeAccountSubscriber.js';
 import {
   connectAndUpdateStateForMultiNetworks,
   intoConnecting,
   intoConnectionFinished,
 } from '../common/mod.js';
 
+import { CAIP_NAMESPACE } from './constants.js';
+
+// Actions
 export const connect = () =>
   new ActionBuilder<EvmActions, 'connect'>('connect')
     .and(connectAndUpdateStateForMultiNetworks)
@@ -17,3 +23,35 @@ export const canEagerConnect = () =>
   new ActionBuilder<EvmActions, 'canEagerConnect'>('canEagerConnect');
 export const canSwitchNetwork = () =>
   new ActionBuilder<EvmActions, 'canSwitchNetwork'>('canSwitchNetwork');
+
+// Hooks
+export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
+  new ChangeAccountSubscriberBuilder<string[], ProviderAPI>()
+    .getInstance(getInstance)
+    .validateEventPayload(
+      (accounts) =>
+        /*
+         * In some wallets, when a user switches to an account not yet connected to the dApp, it returns null.
+         * A null value indicates no access to the account, requiring a disconnect and user reconnection.
+         * This behavior may vary across different wallets, and if so, a different approach may be needed.
+         */
+        accounts && accounts.length !== 0
+    )
+    .format(async (instance, accounts) => {
+      const chainId = await instance.request({ method: 'eth_chainId' });
+      return accounts.map((account) =>
+        AccountId.format({
+          address: account,
+          chainId: {
+            namespace: CAIP_NAMESPACE,
+            reference: chainId,
+          },
+        })
+      );
+    })
+    .addEventListener((instance, callback) => {
+      instance.on('accountsChanged', callback);
+    })
+    .removeEventListener((instance, callback) => {
+      instance.removeListener?.('accountsChanged', callback);
+    });

--- a/wallets/core/src/namespaces/evm/hooks.ts
+++ b/wallets/core/src/namespaces/evm/hooks.ts
@@ -1,0 +1,43 @@
+import type { EIP1193EventMap } from './eip1193.js';
+import type { EvmActions, ProviderAPI } from './types.js';
+import type { Subscriber, SubscriberCleanUp } from '../../mod.js';
+
+import { builders } from './mod.js';
+
+export function changeAccountSubscriber(
+  instance: () => ProviderAPI
+): [Subscriber<EvmActions>, SubscriberCleanUp<EvmActions>] {
+  return builders.changeAccountSubscriber(instance).build();
+}
+
+export function changeChainSubscriber(
+  instance: () => ProviderAPI
+): [Subscriber<EvmActions>, SubscriberCleanUp<EvmActions>] {
+  let eventCallback: EIP1193EventMap['chainChanged'];
+
+  return [
+    (context) => {
+      const evmInstance = instance();
+
+      if (!evmInstance) {
+        throw new Error(
+          'Trying to subscribe to your EVM wallet, but seems its instance is not available.'
+        );
+      }
+
+      const [, setState] = context.state();
+
+      eventCallback = async (chainId: string) => {
+        setState('network', chainId);
+      };
+      evmInstance.on('chainChanged', eventCallback);
+    },
+    () => {
+      const evmInstance = instance();
+
+      if (eventCallback && evmInstance) {
+        evmInstance.removeListener('chainChanged', eventCallback);
+      }
+    },
+  ];
+}

--- a/wallets/core/src/namespaces/evm/mod.ts
+++ b/wallets/core/src/namespaces/evm/mod.ts
@@ -1,4 +1,5 @@
 export * as actions from './actions.js';
+export * as hooks from './hooks.js';
 export * as after from './after.js';
 export * as and from './and.js';
 export * as before from './before.js';

--- a/wallets/core/src/namespaces/solana/actions.ts
+++ b/wallets/core/src/namespaces/solana/actions.ts
@@ -1,8 +1,7 @@
 import type { ProviderAPI, SolanaActions } from './types.js';
-import type { Context, Subscriber } from '../../hub/namespaces/mod.js';
-import type { SubscriberCleanUp } from '../../hub/namespaces/types.js';
+import type { Context } from '../../hub/namespaces/mod.js';
 import type { CaipAccount } from '../../types/accounts.js';
-import type { AnyFunction, FunctionWithContext } from '../../types/actions.js';
+import type { FunctionWithContext } from '../../types/actions.js';
 
 import { AccountId } from 'caip';
 
@@ -13,59 +12,6 @@ import { getAccounts } from './utils.js';
 
 export const recommended = [...commonRecommended];
 
-export function changeAccountSubscriber(
-  instance: () => ProviderAPI | undefined
-): [Subscriber<SolanaActions>, SubscriberCleanUp<SolanaActions>] {
-  let eventCallback: AnyFunction;
-
-  // subscriber can be passed to `or`, it will get the error and should rethrow error to pass the error to next `or` or throw error.
-  return [
-    (context, err) => {
-      const solanaInstance = instance();
-
-      if (!solanaInstance) {
-        throw new Error(
-          'Trying to subscribe to your Solana wallet, but seems its instance is not available.'
-        );
-      }
-
-      const [, setState] = context.state();
-
-      eventCallback = (publicKey) => {
-        /*
-         * In Phantom, when user is switching to an account which is not connected to dApp yet, it returns a null.
-         * So null means we don't have access to account and we 0 need to disconnect and let the user connect the account.
-         */
-        if (!publicKey) {
-          context.action('disconnect');
-          return;
-        }
-
-        setState('accounts', [
-          AccountId.format({
-            address: publicKey.toString(),
-            chainId: {
-              namespace: CAIP_NAMESPACE,
-              reference: CAIP_SOLANA_CHAIN_ID,
-            },
-          }),
-        ]);
-      };
-      solanaInstance.on('accountChanged', eventCallback);
-
-      return err;
-    },
-    (_context, err) => {
-      const solanaInstance = instance();
-
-      if (eventCallback && solanaInstance) {
-        solanaInstance.off('accountChanged', eventCallback);
-      }
-
-      return err;
-    },
-  ];
-}
 export function connect(
   instance: () => ProviderAPI
 ): FunctionWithContext<SolanaActions['connect'], Context> {

--- a/wallets/core/src/namespaces/solana/builders.ts
+++ b/wallets/core/src/namespaces/solana/builders.ts
@@ -1,14 +1,38 @@
-import type { SolanaActions } from './types.js';
+import type { ProviderAPI, SolanaActions } from './types.js';
 
 import { ActionBuilder } from '../../mod.js';
+import { ChangeAccountSubscriberBuilder } from '../common/hooks/changeAccountSubscriber.js';
 import {
   connectAndUpdateStateForSingleNetwork,
   intoConnecting,
   intoConnectionFinished,
 } from '../common/mod.js';
 
+import { formatAccountsToCAIP } from './utils.js';
+
+// Actions
 export const connect = () =>
   new ActionBuilder<SolanaActions, 'connect'>('connect')
     .and(connectAndUpdateStateForSingleNetwork)
     .before(intoConnecting)
     .after(intoConnectionFinished);
+
+// Hooks
+export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
+  new ChangeAccountSubscriberBuilder<string, ProviderAPI>()
+    .getInstance(getInstance)
+    .validateEventPayload(
+      (accounts) =>
+        /*
+         * In some wallets, when a user switches to an account not yet connected to the dApp, it returns null.
+         * A null value indicates no access to the account, requiring a disconnect and user reconnection.
+         */
+        !!accounts
+    )
+    .format(async (_, accounts) => formatAccountsToCAIP([accounts]))
+    .addEventListener((instance, callback) => {
+      instance.on('accountChanged', callback);
+    })
+    .removeEventListener((instance, callback) => {
+      instance.off('accountChanged', callback);
+    });

--- a/wallets/core/src/namespaces/solana/hooks.ts
+++ b/wallets/core/src/namespaces/solana/hooks.ts
@@ -1,0 +1,10 @@
+import type { ProviderAPI, SolanaActions } from './types.js';
+import type { Subscriber, SubscriberCleanUp } from '../../mod.js';
+
+import { builders } from './mod.js';
+
+export function changeAccountSubscriber(
+  instance: () => ProviderAPI
+): [Subscriber<SolanaActions>, SubscriberCleanUp<SolanaActions>] {
+  return builders.changeAccountSubscriber(instance).build();
+}

--- a/wallets/core/src/namespaces/solana/mod.ts
+++ b/wallets/core/src/namespaces/solana/mod.ts
@@ -1,4 +1,5 @@
 export * as actions from './actions.js';
+export * as hooks from './hooks.js';
 export * as after from './after.js';
 export * as and from './and.js';
 export * as before from './before.js';

--- a/wallets/core/src/namespaces/solana/utils.ts
+++ b/wallets/core/src/namespaces/solana/utils.ts
@@ -1,6 +1,11 @@
 import type { ProviderAPI } from './types.js';
+import type { CaipAccount } from '../../types/accounts.js';
+
+import { AccountId } from 'caip';
 
 import { LegacyNetworks } from '../../legacy/mod.js';
+
+import { CAIP_NAMESPACE, CAIP_SOLANA_CHAIN_ID } from './constants.js';
 
 export async function getAccounts(provider: ProviderAPI) {
   const solanaResponse = await provider.connect();
@@ -9,4 +14,17 @@ export async function getAccounts(provider: ProviderAPI) {
     accounts: [account],
     chainId: LegacyNetworks.SOLANA,
   };
+}
+
+export function formatAccountsToCAIP(accounts: string[]) {
+  return accounts.map(
+    (account) =>
+      AccountId.format({
+        address: account.toString(),
+        chainId: {
+          namespace: CAIP_NAMESPACE,
+          reference: CAIP_SOLANA_CHAIN_ID,
+        },
+      }) as CaipAccount
+  );
 }

--- a/wallets/core/src/namespaces/sui/actions.ts
+++ b/wallets/core/src/namespaces/sui/actions.ts
@@ -1,68 +1,8 @@
 import type { SuiActions } from './types.js';
-import type { Subscriber } from '../../hub/namespaces/mod.js';
-import type {
-  CanEagerConnect,
-  SubscriberCleanUp,
-} from '../../hub/namespaces/types.js';
-import type { StandardEventsChangeProperties } from '@mysten/wallet-standard';
+import type { CanEagerConnect } from '../../hub/namespaces/types.js';
 
-import { AccountId } from 'caip';
-
-import { CAIP_NAMESPACE, CAIP_SUI_CHAIN_ID } from './constants.js';
 import { getInstanceOrThrow } from './mod.js';
 
-interface ChangeAccountSubscriberParams {
-  name: string;
-}
-
-export function changeAccountSubscriber(
-  params: ChangeAccountSubscriberParams
-): [Subscriber<SuiActions>, SubscriberCleanUp<SuiActions>] {
-  let unsubscriber: () => void;
-
-  return [
-    (context, err) => {
-      const wallet = getInstanceOrThrow(params.name);
-
-      const [, setState] = context.state();
-      const eventCallback = (event: StandardEventsChangeProperties) => {
-        if (event.accounts) {
-          if (event.accounts.length === 0) {
-            context.action('disconnect');
-          } else {
-            setState(
-              'accounts',
-              event.accounts.map((account) => {
-                return AccountId.format({
-                  address: account.address,
-                  chainId: {
-                    namespace: CAIP_NAMESPACE,
-                    reference: CAIP_SUI_CHAIN_ID,
-                  },
-                });
-              })
-            );
-          }
-        }
-      };
-      unsubscriber = wallet.features['standard:events'].on(
-        'change',
-        eventCallback
-      );
-
-      if (err instanceof Error) {
-        throw err;
-      }
-    },
-    (_context, err) => {
-      if (unsubscriber) {
-        unsubscriber();
-      }
-
-      return err;
-    },
-  ];
-}
 interface CanEagerConnectParams {
   name: string;
 }

--- a/wallets/core/src/namespaces/sui/hooks.ts
+++ b/wallets/core/src/namespaces/sui/hooks.ts
@@ -1,0 +1,10 @@
+import type { ChangeAccountSubscriberParams, SuiActions } from './types.js';
+import type { Subscriber, SubscriberCleanUp } from '../../mod.js';
+
+import { builders } from './mod.js';
+
+export function changeAccountSubscriber(
+  params: ChangeAccountSubscriberParams
+): [Subscriber<SuiActions>, SubscriberCleanUp<SuiActions>] {
+  return builders.changeAccountSubscriber({ name: params.name }).build();
+}

--- a/wallets/core/src/namespaces/sui/mod.ts
+++ b/wallets/core/src/namespaces/sui/mod.ts
@@ -2,6 +2,7 @@ export type { ProviderAPI, SuiActions } from './types.js';
 
 export * as actions from './actions.js';
 export * as builders from './builders.js';
+export * as hooks from './hooks.js';
 export { getInstanceOrThrow, getInstance } from './utils.js';
 
 export { CAIP_NAMESPACE, CAIP_SUI_CHAIN_ID } from './constants.js';

--- a/wallets/core/src/namespaces/sui/types.ts
+++ b/wallets/core/src/namespaces/sui/types.ts
@@ -3,6 +3,12 @@ import type {
   AutoImplementedActionsByRecommended,
   CommonActions,
 } from '../common/types.js';
+import type {
+  StandardConnectFeature,
+  StandardEventsFeature,
+  SuiFeatures,
+  WalletWithFeatures,
+} from '@mysten/wallet-standard';
 
 export interface SuiActions
   extends AutoImplementedActionsByRecommended,
@@ -11,5 +17,10 @@ export interface SuiActions
   canEagerConnect: () => Promise<boolean>;
 }
 
-// eslint-disable-next-line
-export type ProviderAPI = Record<string, any>;
+export type ProviderAPI = WalletWithFeatures<
+  StandardConnectFeature & StandardEventsFeature & SuiFeatures
+>;
+
+export interface ChangeAccountSubscriberParams {
+  name: string;
+}

--- a/wallets/core/src/namespaces/sui/utils.ts
+++ b/wallets/core/src/namespaces/sui/utils.ts
@@ -6,6 +6,9 @@ import type {
 } from '@mysten/wallet-standard';
 
 import { getWallets, SUI_MAINNET_CHAIN } from '@mysten/wallet-standard';
+import { AccountId } from 'caip';
+
+import { CAIP_NAMESPACE, CAIP_SUI_CHAIN_ID } from './constants.js';
 
 // TODO: StandardFetures doesn't work, so we should add each feature separately
 type SuiWalletStandard = WalletWithFeatures<
@@ -39,4 +42,15 @@ export function getInstanceOrThrow(name: string): SuiWalletStandard {
   }
 
   return wallet;
+}
+export function formatAccountsToCAIP(accounts: readonly { address: string }[]) {
+  return accounts.map((account) => {
+    return AccountId.format({
+      address: account.address,
+      chainId: {
+        namespace: CAIP_NAMESPACE,
+        reference: CAIP_SUI_CHAIN_ID,
+      },
+    });
+  });
 }

--- a/wallets/provider-phantom/src/namespaces/evm.ts
+++ b/wallets/provider-phantom/src/namespaces/evm.ts
@@ -5,13 +5,17 @@ import {
   builders as commonBuilders,
   standardizeAndThrowError,
 } from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/evm';
+import {
+  actions,
+  builders,
+  hooks,
+} from '@rango-dev/wallets-core/namespaces/evm';
 
 import { WALLET_ID } from '../constants.js';
 import { evmPhantom } from '../utils.js';
 
 const [changeAccountSubscriber, changeAccountCleanup] =
-  actions.changeAccountSubscriber(evmPhantom);
+  hooks.changeAccountSubscriber(evmPhantom);
 
 /*
  * TODO: If user imported a private key for EVM, it hasn't solana.

--- a/wallets/provider-phantom/src/namespaces/solana.ts
+++ b/wallets/provider-phantom/src/namespaces/solana.ts
@@ -7,10 +7,10 @@ import {
   standardizeAndThrowError,
 } from '@rango-dev/wallets-core/namespaces/common';
 import {
-  actions,
   builders,
   CAIP_NAMESPACE,
   CAIP_SOLANA_CHAIN_ID,
+  hooks,
 } from '@rango-dev/wallets-core/namespaces/solana';
 import { CAIP } from '@rango-dev/wallets-core/utils';
 import { getSolanaAccounts } from '@rango-dev/wallets-shared';
@@ -19,7 +19,7 @@ import { WALLET_ID } from '../constants.js';
 import { solanaPhantom } from '../utils.js';
 
 const [changeAccountSubscriber, changeAccountCleanup] =
-  actions.changeAccountSubscriber(solanaPhantom);
+  hooks.changeAccountSubscriber(solanaPhantom);
 
 /*
  * TODO: If user imported a private key for EVM, it hasn't solana.

--- a/wallets/provider-phantom/src/namespaces/sui.ts
+++ b/wallets/provider-phantom/src/namespaces/sui.ts
@@ -6,14 +6,14 @@ import {
   builders as commonBuilders,
   standardizeAndThrowError,
 } from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/sui';
+import { builders, hooks } from '@rango-dev/wallets-core/namespaces/sui';
 
 import { WALLET_ID, WALLET_NAME_IN_WALLET_STANDARD } from '../constants.js';
 
 import { canEagerConnectAction as solanaCanEagerConnectAction } from './solana.js';
 
 const [changeAccountSubscriber, changeAccountCleanup] =
-  actions.changeAccountSubscriber({
+  hooks.changeAccountSubscriber({
     name: WALLET_NAME_IN_WALLET_STANDARD,
   });
 

--- a/wallets/provider-phantom/src/utils.ts
+++ b/wallets/provider-phantom/src/utils.ts
@@ -94,5 +94,5 @@ export function suiPhantom(): SuiProviderApi {
     );
   }
 
-  return suiInstance;
+  return suiInstance as SuiProviderApi;
 }

--- a/wallets/provider-rabby/src/namespaces/evm.ts
+++ b/wallets/provider-rabby/src/namespaces/evm.ts
@@ -5,13 +5,17 @@ import {
   builders as commonBuilders,
   standardizeAndThrowError,
 } from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/evm';
+import {
+  actions,
+  builders,
+  hooks,
+} from '@rango-dev/wallets-core/namespaces/evm';
 
 import { WALLET_ID } from '../constants.js';
 import { evmRabby, switchOrAddNetwork } from '../utils.js';
 
 const [changeAccountSubscriber, changeAccountCleanup] =
-  actions.changeAccountSubscriber(evmRabby);
+  hooks.changeAccountSubscriber(evmRabby);
 
 const connect = builders
   .connect()

--- a/wallets/provider-trustwallet/src/namespaces/evm.ts
+++ b/wallets/provider-trustwallet/src/namespaces/evm.ts
@@ -5,7 +5,11 @@ import {
   builders as commonBuilders,
   standardizeAndThrowError,
 } from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/evm';
+import {
+  actions,
+  builders,
+  hooks,
+} from '@rango-dev/wallets-core/namespaces/evm';
 
 import { WALLET_ID } from '../constants.js';
 import {
@@ -14,7 +18,7 @@ import {
 } from '../utils.js';
 
 const [changeAccountSubscriber, changeAccountCleanup] =
-  actions.changeAccountSubscriber(evmTrustWallet);
+  hooks.changeAccountSubscriber(evmTrustWallet);
 
 const connect = builders
   .connect()

--- a/wallets/provider-trustwallet/src/namespaces/solana.ts
+++ b/wallets/provider-trustwallet/src/namespaces/solana.ts
@@ -5,7 +5,11 @@ import {
   builders as commonBuilders,
   standardizeAndThrowError,
 } from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/solana';
+import {
+  actions,
+  builders,
+  hooks,
+} from '@rango-dev/wallets-core/namespaces/solana';
 
 import { WALLET_ID } from '../constants.js';
 import {
@@ -14,7 +18,7 @@ import {
 } from '../utils.js';
 
 const [changeAccountSubscriber, changeAccountCleanup] =
-  actions.changeAccountSubscriber(solanaTrustWallet);
+  hooks.changeAccountSubscriber(solanaTrustWallet);
 
 const connect = builders
   .connect()


### PR DESCRIPTION
# Summary


* Implemented **`changeAccountSubscriberBuilder`** in `common/hooks.ts` with support for namespace-specific defaults.
* Updated all providers in **Hub** to use this builder for consistency and easier customization.
* Moved **`changeAccountSubscriber`** and **`changeChainSubscriber`** from `actions` to `hooks`.
* Applied the new builder-based approach across all existing providers, ensuring no functional changes but improving maintainability.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
