### PR TITLE
fix: handle dynamic import error

### DIFF
--- a/wallets/provider-bitget/src/signer.ts
+++ b/wallets/provider-bitget/src/signer.ts
@@ -3,9 +3,9 @@ import type { SignerFactory } from 'rango-types';
 
 import { DefaultTronSigner } from '@rango-dev/signer-tron';
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -15,7 +15,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const tronProvider = getNetworkInstance(provider, Networks.TRON);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-brave/src/signer.ts
+++ b/wallets/provider-brave/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -16,7 +16,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-clover/src/signer.ts
+++ b/wallets/provider-clover/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -16,7 +16,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-coin98/src/signer.ts
+++ b/wallets/provider-coin98/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -16,7 +16,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-coinbase/src/signer.ts
+++ b/wallets/provider-coinbase/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -16,7 +16,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-cosmostation/src/signer.ts
+++ b/wallets/provider-cosmostation/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -14,10 +14,10 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const cosmosProvider = getNetworkInstance(provider, Networks.COSMOS);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
-  const { DefaultCosmosSigner } = await retryLazyImport(
+  const { DefaultCosmosSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-cosmos')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-default/src/signer.ts
+++ b/wallets/provider-default/src/signer.ts
@@ -1,14 +1,14 @@
 import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/evm';
 import type { SignerFactory } from 'rango-types';
 
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: ProviderAPI
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(provider));

--- a/wallets/provider-enkrypt/src/signer.ts
+++ b/wallets/provider-enkrypt/src/signer.ts
@@ -1,14 +1,14 @@
 import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/evm';
 import type { SignerFactory } from 'rango-types';
 
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: ProviderAPI
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(provider));

--- a/wallets/provider-exodus/src/signer.ts
+++ b/wallets/provider-exodus/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -16,7 +16,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-frontier/src/signer.ts
+++ b/wallets/provider-frontier/src/signer.ts
@@ -3,9 +3,9 @@ import type { SignerFactory } from 'rango-types';
 
 import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -15,7 +15,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-halo/src/signer.ts
+++ b/wallets/provider-halo/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -13,7 +13,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-keplr/src/signer.ts
+++ b/wallets/provider-keplr/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -13,7 +13,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const cosmosProvider = getNetworkInstance(provider, Networks.COSMOS);
   const signers = new DefaultSignerFactory();
-  const { DefaultCosmosSigner } = await retryLazyImport(
+  const { DefaultCosmosSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-cosmos')
   );
   signers.registerSigner(

--- a/wallets/provider-leap-cosmos/src/signer.ts
+++ b/wallets/provider-leap-cosmos/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -13,7 +13,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const cosmosProvider = getNetworkInstance(provider, Networks.COSMOS);
   const signers = new DefaultSignerFactory();
-  const { DefaultCosmosSigner } = await retryLazyImport(
+  const { DefaultCosmosSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-cosmos')
   );
   signers.registerSigner(

--- a/wallets/provider-ledger/src/helpers.ts
+++ b/wallets/provider-ledger/src/helpers.ts
@@ -2,10 +2,10 @@ import type Transport from '@ledgerhq/hw-transport';
 
 import { getAltStatusMessage } from '@ledgerhq/errors';
 import {
+  dynamicImportWithRefinedError,
   ETHEREUM_CHAIN_ID,
   Networks,
   type ProviderConnectResult,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import bs58 from 'bs58';
 
@@ -62,7 +62,9 @@ export async function getEthereumAccounts(): Promise<ProviderConnectResult> {
     const derivationPath = getDerivationPath();
 
     const eth = new (
-      await retryLazyImport(async () => await import('@ledgerhq/hw-app-eth'))
+      await dynamicImportWithRefinedError(
+        async () => await import('@ledgerhq/hw-app-eth')
+      )
     ).default(transport);
 
     const accounts: string[] = [];
@@ -88,7 +90,9 @@ export async function getSolanaAccounts(): Promise<ProviderConnectResult> {
     const derivationPath = getDerivationPath();
 
     const solana = new (
-      await retryLazyImport(async () => await import('@ledgerhq/hw-app-solana'))
+      await dynamicImportWithRefinedError(
+        async () => await import('@ledgerhq/hw-app-solana')
+      )
     ).default(transport);
 
     const accounts: string[] = [];

--- a/wallets/provider-ledger/src/signer.ts
+++ b/wallets/provider-ledger/src/signer.ts
@@ -1,14 +1,14 @@
 import type { SignerFactory } from 'rango-types';
 
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { EthereumSigner } = await retryLazyImport(
+  const { EthereumSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/ethereum.js')
   );
-  const { SolanaSigner } = await retryLazyImport(
+  const { SolanaSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/solana.js')
   );
   signers.registerSigner(TxType.EVM, new EthereumSigner());

--- a/wallets/provider-math-wallet/src/signer.ts
+++ b/wallets/provider-math-wallet/src/signer.ts
@@ -3,9 +3,9 @@ import type { SignerFactory } from 'rango-types';
 
 import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -17,10 +17,10 @@ export default async function getSigners(
   const cosmosProvider = getNetworkInstance(provider, Networks.COSMOS);
 
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
-  const { MathWalletCosmosSigner } = await retryLazyImport(
+  const { MathWalletCosmosSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/cosmosSigner.js')
   );
 

--- a/wallets/provider-metamask/src/signer.ts
+++ b/wallets/provider-metamask/src/signer.ts
@@ -1,14 +1,14 @@
 import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/evm';
 import type { SignerFactory } from 'rango-types';
 
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: ProviderAPI
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(provider));

--- a/wallets/provider-okx/src/signer.ts
+++ b/wallets/provider-okx/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -16,7 +16,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-phantom/src/signer.ts
+++ b/wallets/provider-phantom/src/signer.ts
@@ -3,7 +3,10 @@ import type { SignerFactory } from 'rango-types';
 
 import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
 import { getInstance as getSuiInstance } from '@rango-dev/wallets-core/namespaces/sui';
-import { getNetworkInstance, retryLazyImport } from '@rango-dev/wallets-shared';
+import {
+  dynamicImportWithRefinedError,
+  getNetworkInstance,
+} from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { WALLET_NAME_IN_WALLET_STANDARD } from './constants.js';
@@ -17,16 +20,16 @@ export default async function getSigners(
 
   const suiProvider = getSuiInstance(WALLET_NAME_IN_WALLET_STANDARD);
 
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
-  const { DefaultSolanaSigner } = await retryLazyImport(
+  const { DefaultSolanaSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-solana')
   );
-  const { BTCSigner } = await retryLazyImport(
+  const { BTCSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/utxoSigner.js')
   );
-  const { DefaultSuiSigner } = await retryLazyImport(
+  const { DefaultSuiSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-sui')
   );
   const signers = new DefaultSignerFactory();

--- a/wallets/provider-rabby/src/signer.ts
+++ b/wallets/provider-rabby/src/signer.ts
@@ -2,7 +2,10 @@ import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
 import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
-import { getNetworkInstance, retryLazyImport } from '@rango-dev/wallets-shared';
+import {
+  dynamicImportWithRefinedError,
+  getNetworkInstance,
+} from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -10,7 +13,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const evmProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(evmProvider));

--- a/wallets/provider-safe/src/signer.ts
+++ b/wallets/provider-safe/src/signer.ts
@@ -1,14 +1,14 @@
 import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/evm';
 import type { SignerFactory } from 'rango-types';
 
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: ProviderAPI
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { CustomEvmSigner } = await retryLazyImport(
+  const { CustomEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/evm.js')
   );
   signers.registerSigner(TxType.EVM, new CustomEvmSigner(provider));

--- a/wallets/provider-safepal/src/signer.ts
+++ b/wallets/provider-safepal/src/signer.ts
@@ -3,9 +3,9 @@ import type { SignerFactory } from 'rango-types';
 
 import { DefaultSolanaSigner } from '@rango-dev/signer-solana';
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -15,7 +15,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-slush/src/signer.ts
+++ b/wallets/provider-slush/src/signer.ts
@@ -1,7 +1,7 @@
 import type { SignerFactory } from 'rango-types';
 
 import { getInstanceOrThrow } from '@rango-dev/wallets-core/namespaces/sui';
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { WALLET_NAME_IN_WALLET_STANDARD } from './constants.js';
@@ -9,7 +9,7 @@ import { WALLET_NAME_IN_WALLET_STANDARD } from './constants.js';
 export default async function getSigners(): Promise<SignerFactory> {
   const suiWalletProvider = getInstanceOrThrow(WALLET_NAME_IN_WALLET_STANDARD);
 
-  const { DefaultSuiSigner } = await retryLazyImport(
+  const { DefaultSuiSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-sui')
   );
   const signers = new DefaultSignerFactory();

--- a/wallets/provider-station/src/signer.ts
+++ b/wallets/provider-station/src/signer.ts
@@ -1,13 +1,13 @@
 import type { SignerFactory } from 'rango-types';
 
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: unknown
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { DefaultTerraSigner } = await retryLazyImport(
+  const { DefaultTerraSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-terra')
   );
   signers.registerSigner(TxType.COSMOS, new DefaultTerraSigner(provider));

--- a/wallets/provider-taho/src/signer.ts
+++ b/wallets/provider-taho/src/signer.ts
@@ -1,14 +1,14 @@
 import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/evm';
 import type { SignerFactory } from 'rango-types';
 
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: ProviderAPI
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(provider));

--- a/wallets/provider-tokenpocket/src/signer.ts
+++ b/wallets/provider-tokenpocket/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -13,7 +13,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-tomo/src/signer.ts
+++ b/wallets/provider-tomo/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -13,7 +13,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-tonconnect/src/helpers.ts
+++ b/wallets/provider-tonconnect/src/helpers.ts
@@ -1,16 +1,18 @@
 import type { TonConnectUI } from '@tonconnect/ui';
 
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 
 export async function getTonConnectUIModule() {
-  const tonConnectUI = await retryLazyImport(
+  const tonConnectUI = await dynamicImportWithRefinedError(
     async () => await import('@tonconnect/ui')
   );
   return tonConnectUI;
 }
 
 export async function getTonCoreModule() {
-  const tonCore = await retryLazyImport(async () => await import('@ton/core'));
+  const tonCore = await dynamicImportWithRefinedError(
+    async () => await import('@ton/core')
+  );
   return tonCore;
 }
 

--- a/wallets/provider-tonconnect/src/signer.ts
+++ b/wallets/provider-tonconnect/src/signer.ts
@@ -1,14 +1,14 @@
 import type { TonConnectUI } from '@tonconnect/ui';
 import type { SignerFactory } from 'rango-types';
 
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: TonConnectUI
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { CustomTonSigner } = await retryLazyImport(
+  const { CustomTonSigner } = await dynamicImportWithRefinedError(
     async () => await import('./ton-signer.js')
   );
   signers.registerSigner(TxType.TON, new CustomTonSigner(provider));

--- a/wallets/provider-trezor/src/helpers.ts
+++ b/wallets/provider-trezor/src/helpers.ts
@@ -1,10 +1,10 @@
 import type { TrezorConnect } from '@trezor/connect-web';
 
 import {
+  dynamicImportWithRefinedError,
   ETHEREUM_CHAIN_ID,
   Networks,
   type ProviderConnectResult,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 
 import { getDerivationPath } from './state.js';
@@ -15,7 +15,7 @@ export const trezorErrorMessages: { [statusCode: string]: string } = {
 
 // `@trezor/connect-web` is commonjs, when we are importing it dynamically, it has some differences in different tooling. for example vite (you can check widget-examples), goes throw error. this is a workaround for solving this interop issue.
 export async function getTrezorModule() {
-  const mod = await retryLazyImport(
+  const mod = await dynamicImportWithRefinedError(
     async () => await import('@trezor/connect-web')
   );
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/wallets/provider-trezor/src/signer.ts
+++ b/wallets/provider-trezor/src/signer.ts
@@ -1,11 +1,11 @@
 import type { SignerFactory } from 'rango-types';
 
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { EthereumSigner } = await retryLazyImport(
+  const { EthereumSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/ethereum.js')
   );
   signers.registerSigner(TxType.EVM, new EthereumSigner());

--- a/wallets/provider-trustwallet/src/signer.ts
+++ b/wallets/provider-trustwallet/src/signer.ts
@@ -2,7 +2,10 @@ import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
 import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
-import { getNetworkInstance, retryLazyImport } from '@rango-dev/wallets-shared';
+import {
+  dynamicImportWithRefinedError,
+  getNetworkInstance,
+} from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -12,10 +15,10 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
 
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
-  const { CustomSolanaSigner } = await retryLazyImport(
+  const { CustomSolanaSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/solanaSigner.js')
   );
 

--- a/wallets/provider-unisat/src/signer.ts
+++ b/wallets/provider-unisat/src/signer.ts
@@ -2,14 +2,17 @@ import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
 import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
-import { getNetworkInstance, retryLazyImport } from '@rango-dev/wallets-shared';
+import {
+  dynamicImportWithRefinedError,
+  getNetworkInstance,
+} from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
   const bitcoinInstance = getNetworkInstance(provider, Networks.BTC);
-  const { BTCSigner } = await retryLazyImport(
+  const { BTCSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/utxoSigner.js')
   );
   const signers = new DefaultSignerFactory();

--- a/wallets/provider-walletconnect-2/src/signer.ts
+++ b/wallets/provider-walletconnect-2/src/signer.ts
@@ -1,7 +1,7 @@
 import type { WCInstance } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
-import { retryLazyImport } from '@rango-dev/wallets-shared';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -13,13 +13,19 @@ export default async function getSigners(
 
   const signers = new DefaultSignerFactory();
   const EVMSigner = (
-    await retryLazyImport(async () => await import('./signers/evm.js'))
+    await dynamicImportWithRefinedError(
+      async () => await import('./signers/evm.js')
+    )
   ).default;
   const COSMOSSigner = (
-    await retryLazyImport(async () => await import('./signers/cosmos.js'))
+    await dynamicImportWithRefinedError(
+      async () => await import('./signers/cosmos.js')
+    )
   ).default;
   const SOLANASigner = (
-    await retryLazyImport(async () => await import('./signers/solana.js'))
+    await dynamicImportWithRefinedError(
+      async () => await import('./signers/solana.js')
+    )
   ).default;
 
   signers.registerSigner(

--- a/wallets/provider-xdefi/src/cosmos-signer.ts
+++ b/wallets/provider-xdefi/src/cosmos-signer.ts
@@ -2,9 +2,9 @@ import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/cosmos';
 import type { CosmosTransaction, GenericSigner } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { SignerError, SignerErrorCode } from 'rango-types';
 
@@ -36,7 +36,7 @@ export class CustomCosmosSigner implements GenericSigner<CosmosTransaction> {
     }
   }
   async signAndSendTx(tx: CosmosTransaction): Promise<{ hash: string }> {
-    const { executeCosmosTransaction } = await retryLazyImport(
+    const { executeCosmosTransaction } = await dynamicImportWithRefinedError(
       async () => await import('@rango-dev/signer-cosmos')
     );
 

--- a/wallets/provider-xdefi/src/signer.ts
+++ b/wallets/provider-xdefi/src/signer.ts
@@ -2,9 +2,9 @@ import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  dynamicImportWithRefinedError,
   getNetworkInstance,
   Networks,
-  retryLazyImport,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -19,7 +19,7 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
 
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await retryLazyImport(
+  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
 

--- a/wallets/shared/src/helpers.ts
+++ b/wallets/shared/src/helpers.ts
@@ -213,31 +213,22 @@ export function detectMobileScreens(): boolean {
 }
 
 /**
- * Retry a dynamic import multiple times with optional delay.
+ * Dynamically import a module and refine the error.
  *
  * @param importer - lazy import callback.
- * @param retries - Number of retry attempts (default: 3).
- * @param delayMs - Delay between retries in milliseconds (default: 500ms).
  * @returns A promise resolving to the imported module.
  */
-export async function retryLazyImport<T>(
-  importer: () => Promise<T>,
-  retries: number = 3,
-  delayMs: number = 500
+export async function dynamicImportWithRefinedError<T>(
+  importer: () => Promise<T>
 ): Promise<T> {
-  let attempt = 0;
-  while (attempt < retries) {
-    try {
-      return await importer();
-    } catch (error) {
-      attempt++;
-      if (attempt >= retries) {
-        throw error;
+  try {
+    return await importer();
+  } catch (error) {
+    throw new Error(
+      'A network error occurred while processing your request. Please check your internet connection or refresh the page and try again.',
+      {
+        cause: error,
       }
-      await new Promise((res) => setTimeout(res, delayMs));
-    }
+    );
   }
-
-  // Should never reach here
-  throw new Error('Unexpected error in retryLazyImport');
 }


### PR DESCRIPTION
# Summary

Dynamic import error on `getSigners` method in `queue-manager` was not handled properly. With these changes, the correct error message will be displayed on fail to fetch dynamically imported modules and transaction will fail.

Also retry mechanism for dynamic imports was not working properly so it is removed in this PR.

## Places to check
- wallets/shared/src/helpers.ts
removed retry mechanism and added an error refinement
- queue-manager/rango-preset/src/helpers.ts
wrapped `await getSigners(sourceWallet.walletType);` in try/catch to handle dynamic import errors related to signers
- all signer.ts files
replaced `retryLazyImport` with `dynamicImportWithRefinedError`


# How did you test this change?

Tested by throttling network to offline before attempting to download the bundle related to sign transaction and observing that transaction fails and proper error message gets displayed.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
