### PR TITLE
fix: fix translating swap tabs in history page

### DIFF
--- a/widget/embedded/src/pages/HistoryPage.tsx
+++ b/widget/embedded/src/pages/HistoryPage.tsx
@@ -57,33 +57,6 @@ const Description = styled('div', {
   },
 });
 
-const transactionStatusFilters = [
-  {
-    id: TransactionStatus.SUCCESS,
-    title: i18n.t('Complete'),
-  },
-  {
-    id: TransactionStatus.RUNNING,
-    title: i18n.t('Running'),
-  },
-  { id: TransactionStatus.FAILED, title: i18n.t('Failed') },
-];
-
-const SWAP_MODE_TAB_ITEMS = [
-  {
-    id: 'all',
-    title: i18n.t('All'),
-  },
-  {
-    id: 'swap',
-    title: i18n.t('Swap'),
-  },
-  {
-    id: 'refuel',
-    title: i18n.t('Refuel'),
-  },
-];
-
 const isStepContainsText = (steps: PendingSwapStep[], value: string) => {
   if (!steps?.length) {
     return false;
@@ -113,6 +86,33 @@ export function HistoryPage() {
     setSearchedFor(value);
   };
   const { isMultiMode } = useSwapMode();
+
+  const transactionStatusFilters = [
+    {
+      id: TransactionStatus.SUCCESS,
+      title: i18n.t('Complete'),
+    },
+    {
+      id: TransactionStatus.RUNNING,
+      title: i18n.t('Running'),
+    },
+    { id: TransactionStatus.FAILED, title: i18n.t('Failed') },
+  ];
+
+  const swapModeTabItems = [
+    {
+      id: 'all',
+      title: i18n.t('All'),
+    },
+    {
+      id: 'swap',
+      title: i18n.t('Swap'),
+    },
+    {
+      id: 'refuel',
+      title: i18n.t('Refuel'),
+    },
+  ];
 
   const filteredList = useMemo(() => {
     if (!searchedFor && !filterBy && swapModeActiveTab === 'all') {
@@ -216,7 +216,7 @@ export function HistoryPage() {
         {isMultiMode && !loading && (
           <>
             <Tabs
-              items={SWAP_MODE_TAB_ITEMS}
+              items={swapModeTabItems}
               onChange={(item) => setSwapModeActiveTab(item.id as SwapModeTab)}
               value={swapModeActiveTab}
               type="secondary"


### PR DESCRIPTION
# Summary

Fixed translating swap tab items in history page.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
