### PR TITLE
fix: restrict refuel quotes to single step routes

### DIFF
--- a/widget/embedded/src/hooks/useSwapInput.ts
+++ b/widget/embedded/src/hooks/useSwapInput.ts
@@ -22,6 +22,7 @@ import {
   throwErrorIfResponseIsNotValid,
 } from './useConfirmSwap/useConfirmSwap.helpers';
 import { useFetchAllQuotes } from './useFetchAllQuotes';
+import { useSwapMode } from './useSwapMode';
 
 const DEBOUNCE_DELAY = 600;
 
@@ -78,6 +79,7 @@ export function useSwapInput({
   const disabledLiquiditySources = useAppStore().getDisabledLiquiditySources();
   const excludeLiquiditySources = useAppStore().excludeLiquiditySources();
   const { findToken } = useAppStore();
+  const { swapMode } = useSwapMode();
 
   const [loading, setLoading] = useState(true);
   const prevInputAmount = useRef(inputAmount);
@@ -139,6 +141,10 @@ export function useSwapInput({
 
       if (routing?.maxLength) {
         requestBody.maxLength = routing.maxLength;
+      }
+
+      if (swapMode === 'refuel') {
+        requestBody.maxLength = 1;
       }
 
       fetchQuote(requestBody)


### PR DESCRIPTION
# Summary

Restricted refuel quotes to single step routes

# How did you test this change?

Tested be fetching quotes in swap and refuel mode and checking payload of requests.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
