### PR TITLE
chore: add classname to derivation path modal elements

### DIFF
--- a/widget/embedded/src/components/WalletStatefulConnect/DerivationPath.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/DerivationPath.tsx
@@ -82,7 +82,6 @@ export function DerivationPath(props: PropTypes) {
 
   return (
     <>
-      <Divider size={20} />
       <MessageBox
         type="info"
         title={i18n.t('Select Derivation Path')}
@@ -95,8 +94,12 @@ export function DerivationPath(props: PropTypes) {
         icon={<Image src={image} size={45} />}
       />
 
-      <InputsContainer>
-        <InputLabel variant="body" size="xsmall" color="$neutral600">
+      <InputsContainer className="_derivation_path_inputs_container">
+        <InputLabel
+          variant="body"
+          size="xsmall"
+          color="$neutral600"
+          className="_derivation_path_input_label">
           {i18n.t('Choose Derivation Path Template')}
         </InputLabel>
         <Select
@@ -111,7 +114,11 @@ export function DerivationPath(props: PropTypes) {
           styles={{ trigger: derivationPathInputStyles }}
         />
         <Divider size={20} />
-        <InputLabel variant="body" size="xsmall" color="$neutral600">
+        <InputLabel
+          variant="body"
+          size="xsmall"
+          color="$neutral600"
+          className="_derivation_path_input_label">
           {isCustomOptionSelected
             ? i18n.t('Enter Path')
             : i18n.t('Enter Index')}

--- a/widget/ui/src/components/MessageBox/DefaultMessageBox.tsx
+++ b/widget/ui/src/components/MessageBox/DefaultMessageBox.tsx
@@ -14,7 +14,7 @@ export function MessageBox(props: PropsWithChildren<PropTypes>) {
 
   return (
     <Container id={id}>
-      <IconHighlight type={type}>
+      <IconHighlight type={type} className="_message_box_icon_container">
         {icon || <StatusIcon type={type} />}
       </IconHighlight>
       <Divider size={4} />


### PR DESCRIPTION
# Summary

Added `className` to derivation path modal elements to enable styling them from outside of the widget.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
