### PR TITLE
fix: fix issue with checking version of providers

### DIFF
--- a/widget/embedded/src/utils/providers.ts
+++ b/widget/embedded/src/utils/providers.ts
@@ -1,12 +1,8 @@
 import type { WidgetConfig } from '../types';
+import type { Provider, VersionedProviders } from '@rango-dev/wallets-core';
 import type { LegacyProviderInterface } from '@rango-dev/wallets-core/legacy';
 
-import {
-  defineVersions,
-  pickVersion,
-  Provider,
-  type VersionedProviders,
-} from '@rango-dev/wallets-core';
+import { defineVersions, pickVersion } from '@rango-dev/wallets-core';
 
 export interface ProvidersOptions {
   walletConnectProjectId?: WidgetConfig['walletConnectProjectId'];
@@ -15,6 +11,10 @@ export interface ProvidersOptions {
   >['walletConnectListedDesktopWalletLink'];
   trezorManifest: WidgetConfig['trezorManifest'];
   tonConnect: WidgetConfig['tonConnect'];
+}
+
+function isHubProvider(provider: BothProvidersInterface): provider is Provider {
+  return 'version' in provider && provider.version === '1.0';
 }
 
 /**
@@ -56,7 +56,7 @@ export function matchAndGenerateProviders({
            */
           const versionedProvider =
             pickProviderVersionWithFallbackToLegacy(provider);
-          if (versionedProvider instanceof Provider) {
+          if (isHubProvider(versionedProvider)) {
             return versionedProvider.id === requestedWallet;
           }
           return versionedProvider.config.type === requestedWallet;
@@ -77,7 +77,7 @@ export function matchAndGenerateProviders({
         }
       } else {
         // It's a custom provider so we directly push it to the list.
-        if (requestedWallet instanceof Provider) {
+        if (isHubProvider(requestedWallet)) {
           selectedProviders.push(
             defineVersions().version('1.0.0', requestedWallet).build()
           );
@@ -112,7 +112,7 @@ export function configWalletsToWalletName(
   const names = providers
     .map((provider) => pickProviderVersionWithFallbackToLegacy(provider))
     .map((provider) => {
-      if (provider instanceof Provider) {
+      if (isHubProvider(provider)) {
         return provider.id;
       }
       return provider.config.type;


### PR DESCRIPTION
# Summary

There was an issue in checking for version of providers which was causing a crash in every dapp or example which uses `widget-embedded` package after migrating ledger provider to hub. The issue was related to that, the version of provider was being checked by this expression:
```
versionedProvider instanceof Provider
```
Given that `provider-ledger` relies on code splitting, it seems that a different clone of `ProviderBuilder` class is being used in `provider-ledger` which is different from the one we are checking the ledger built provider instance with it. So it causes that the expression always turn to false and result in unwanted flows and crash in each app or example which integrated the widget. In this PR, checking for version of provider is changed to checking for `version` property of the provider object.


# How did you test this change?

Tested by linking the the build widget with new changes in vite example and dapp and observing that no crashes happen and connecting to wallets works properly.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
