### PR TITLE
fix: fix dynamic import issue in provider ledger

### DIFF
--- a/wallets/provider-ledger/package.json
+++ b/wallets/provider-ledger/package.json
@@ -28,6 +28,7 @@
     "@ledgerhq/types-cryptoassets": "^7.11.0",
     "@ledgerhq/types-devices": "^6.24.0",
     "@rango-dev/signer-solana": "^0.44.0",
+    "@rango-dev/wallets-core": "^0.49.1-next.2",
     "@rango-dev/wallets-shared": "^0.50.1-next.2",
     "@solana/web3.js": "^1.91.4",
     "@types/w3c-web-hid": "^1.0.2",

--- a/wallets/provider-ledger/src/signer.ts
+++ b/wallets/provider-ledger/src/signer.ts
@@ -1,16 +1,12 @@
 import type { SignerFactory } from 'rango-types';
 
-import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
+
+import { EthereumSigner } from './signers/ethereum';
+import { SolanaSigner } from './signers/solana';
 
 export default async function getSigners(): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { EthereumSigner } = await dynamicImportWithRefinedError(
-    async () => await import('./signers/ethereum.js')
-  );
-  const { SolanaSigner } = await dynamicImportWithRefinedError(
-    async () => await import('./signers/solana.js')
-  );
   signers.registerSigner(TxType.EVM, new EthereumSigner());
   signers.registerSigner(TxType.SOLANA, new SolanaSigner());
   return signers;

--- a/wallets/provider-ledger/src/signers/solana.ts
+++ b/wallets/provider-ledger/src/signers/solana.ts
@@ -2,8 +2,8 @@ import type { SolanaWeb3Signer } from '@rango-dev/signer-solana';
 import type { Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { GenericSigner, SolanaTransaction } from 'rango-types';
 
-import Solana from '@ledgerhq/hw-app-solana';
 import { generalSolanaTransactionExecutor } from '@rango-dev/signer-solana';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { PublicKey } from '@solana/web3.js';
 import { SignerError, SignerErrorCode } from 'rango-types';
 
@@ -24,8 +24,12 @@ export class SolanaSigner implements GenericSigner<SolanaTransaction> {
   async signMessage(msg: string): Promise<string> {
     try {
       const transport = await transportConnect();
-
-      const solana = new Solana(transport);
+      const LedgerAppSolana = (
+        await dynamicImportWithRefinedError(
+          async () => await import('@ledgerhq/hw-app-solana')
+        )
+      ).default;
+      const solana = new LedgerAppSolana(transport);
 
       const result = await solana.signOffchainMessage(
         getDerivationPath(),
@@ -43,7 +47,12 @@ export class SolanaSigner implements GenericSigner<SolanaTransaction> {
         solanaWeb3Transaction: Transaction | VersionedTransaction
       ) => {
         const transport = await transportConnect();
-        const solana = new Solana(transport);
+        const LedgerAppSolana = (
+          await dynamicImportWithRefinedError(
+            async () => await import('@ledgerhq/hw-app-solana')
+          )
+        ).default;
+        const solana = new LedgerAppSolana(transport);
 
         let signResult;
         if (isVersionedTransaction(solanaWeb3Transaction)) {

--- a/wallets/provider-ledger/src/utils.ts
+++ b/wallets/provider-ledger/src/utils.ts
@@ -65,13 +65,13 @@ export function standardizeAndThrowLedgerError(_: unknown, error: unknown) {
 export async function getEthereumAccounts(): Promise<ProviderConnectResult> {
   try {
     const transport = await transportConnect();
-    const derivationPath = getDerivationPath();
-
-    const eth = new (
+    const LedgerAppEth = (
       await dynamicImportWithRefinedError(
         async () => await import('@ledgerhq/hw-app-eth')
       )
-    ).default(transport);
+    ).default;
+    const eth = new LedgerAppEth(transport);
+    const derivationPath = getDerivationPath();
 
     const accounts: string[] = [];
 
@@ -93,13 +93,13 @@ export async function getEthereumAccounts(): Promise<ProviderConnectResult> {
 export async function getSolanaAccounts(): Promise<ProviderConnectResult> {
   try {
     const transport = await transportConnect();
-    const derivationPath = getDerivationPath();
-
-    const solana = new (
+    const LedgerAppSolana = (
       await dynamicImportWithRefinedError(
         async () => await import('@ledgerhq/hw-app-solana')
       )
-    ).default(transport);
+    ).default;
+    const solana = new LedgerAppSolana(transport);
+    const derivationPath = getDerivationPath();
 
     const accounts: string[] = [];
 
@@ -121,9 +121,13 @@ export async function getSolanaAccounts(): Promise<ProviderConnectResult> {
 let transportConnection: Transport | null = null;
 
 export async function transportConnect() {
-  transportConnection = await (
-    await import('@ledgerhq/hw-transport-webhid')
-  ).default.create();
+  const TransportWebHID = (
+    await dynamicImportWithRefinedError(
+      async () => await import('@ledgerhq/hw-transport-webhid')
+    )
+  ).default;
+
+  transportConnection = await TransportWebHID.create();
 
   return transportConnection;
 }


### PR DESCRIPTION
# Summary

There was an issue in dynamically importing signers in `provider-ledger`. The issue was related to that the paths `./signers/ethereum` and `./signers/solana` were being imported dynamically in the file `wallets/provider-ledger/src/signer.ts` . There was some problems with this approach which are explained below:
1. Most of the code being bundled in the chunks related to these paths was related to two packages '@ledgerhq/hw-app-solana' and '@ledgerhq/hw-app-eth' which were also being imported dynamically in `wallets/provider-ledger/src/utils.ts` and there is no need to create other chunks for `./signers/ethereum` and `./signers/solana` and we can only create new chunks for '@ledgerhq/hw-app-solana' and '@ledgerhq/hw-app-eth'.
2. Dynamically importing  `./signers/ethereum` and `./signers/solana` was making some issues because some other packages like `@rango-dev/wallets-shared` and `@rango-dev/wallets-core` were being used in these two files and was making bundlers to create a new chunk for these two packages to be shared between the chunks related to `./signers/ethereum` and `./signers/solana`. This was creating some issues like creating two different instances of classes like `ProviderBuilder` and `Provider` in the main chunk and the mentioned shared chunk which was creating some problems for checking the `instanceof` for objects which were created using these two classes.

In this PR, explained issues are fixed by removing dynamic imports for `./signers/ethereum` and `./signers/solana` in `wallets/provider-ledger/src/signer.ts` and only dynamically importing '@ledgerhq/hw-app-solana' and '@ledgerhq/hw-app-eth' everywhere they are used


# How did you test this change?

Tested by linking the build result of `@rango-dev/widget-embedded` and `@rango-dev/provider-ledger` in the vite example and rango dapp and observing that everything works properly.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
