### PR TITLE
feat: make detached confirm text customizable

### DIFF
--- a/widget/embedded/src/components/WalletStatefulConnect/Detached.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Detached.tsx
@@ -25,6 +25,7 @@ export function Detached(props: PropTypes) {
     value,
     selectedNamespaces,
     onConfirm,
+    confirmText = i18n.t('Done'),
     onDisconnectWallet,
     navigateToDerivationPath,
   } = props;
@@ -173,7 +174,7 @@ export function Detached(props: PropTypes) {
         id="widget-name-space-confirm-btn"
         type="primary"
         onClick={onConfirm}>
-        {i18n.t('Done')}
+        {confirmText}
       </StyledButton>
     </>
   );

--- a/widget/embedded/src/components/WalletStatefulConnect/Detached.types.ts
+++ b/widget/embedded/src/components/WalletStatefulConnect/Detached.types.ts
@@ -4,6 +4,7 @@ import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 export interface PropTypes {
   value: NeedsNamespacesState;
   onConfirm: () => void;
+  confirmText?: string;
   onDisconnectWallet: () => void;
   selectedNamespaces:
     | { namespace: Namespace; derivationPath?: string }[]


### PR DESCRIPTION
# Summary

Added optional `confirmText` prop to `Detached` component enabling customizing the text of confirm button.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
