### PR TITLE
fix: handle long names and numbers issues

### DIFF
--- a/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.tsx
+++ b/widget/embedded/src/components/CustomTokenModal/CustomTokenModal.tsx
@@ -54,7 +54,17 @@ export function CustomTokenModal(props: PropTypes) {
             {token.symbol}
           </TokenSymbolText>
           {token.symbol.length > MAX_SYMBOL_LENGTH_THRESHOLD && (
-            <Tooltip content={token.symbol} container={getContainer()}>
+            <Tooltip
+              styles={{
+                content: {
+                  maxWidth: 250,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                },
+              }}
+              content={token.symbol}
+              container={getContainer()}>
               <InfoIcon size={12} color="gray" />
             </Tooltip>
           )}

--- a/widget/embedded/src/components/Quote/Quote.styles.ts
+++ b/widget/embedded/src/components/Quote/Quote.styles.ts
@@ -345,7 +345,6 @@ export const TokenNameText = styled(Typography, {
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  maxWidth: '$30',
 });
 
 export const AmountText = styled(Typography, {
@@ -354,6 +353,9 @@ export const AmountText = styled(Typography, {
   whiteSpace: 'nowrap',
   minWidth: 0,
   flex: '0 1 auto',
+  '&.input-amount-text': {
+    flexShrink: 3,
+  },
 });
 
 export const MoreStep = styled('div', {
@@ -397,5 +399,4 @@ export const UsdValueText = styled(Typography, {
   whiteSpace: 'nowrap',
   flex: '0 1 auto',
   minWidth: 0,
-  flexShrink: 3,
 });

--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -435,7 +435,11 @@ export function Quote(props: QuoteProps) {
         </div>
         {type === 'basic' && (
           <BasicInfoOutput>
-            <AmountText ref={inputValueRef} size="small" variant="body">
+            <AmountText
+              className="input-amount-text"
+              ref={inputValueRef}
+              size="small"
+              variant="body">
               {input.value}
             </AmountText>
             {isInputValueTruncated && (

--- a/widget/embedded/src/constants/routing.ts
+++ b/widget/embedded/src/constants/routing.ts
@@ -15,3 +15,5 @@ export const PERCENTAGE_CHANGE_MAX_DECIMALS = 2;
 
 export const BALANCE_MIN_DECIMALS = 8;
 export const BALANCE_MAX_DECIMALS = 8;
+
+export const USD_VALUE_DEFAULT_DECIMALS = 12;

--- a/widget/embedded/src/containers/Inputs/Inputs.tsx
+++ b/widget/embedded/src/containers/Inputs/Inputs.tsx
@@ -13,8 +13,7 @@ import {
   PERCENTAGE_CHANGE_MIN_DECIMALS,
   TOKEN_AMOUNT_MAX_DECIMALS,
   TOKEN_AMOUNT_MIN_DECIMALS,
-  USD_VALUE_MAX_DECIMALS,
-  USD_VALUE_MIN_DECIMALS,
+  USD_VALUE_DEFAULT_DECIMALS,
 } from '../../constants/routing';
 import { useSwapMode } from '../../hooks/useSwapMode';
 import { useAppStore } from '../../store/AppStore';
@@ -101,8 +100,8 @@ export function Inputs(props: PropTypes) {
               ? undefined
               : numberToString(
                   inputUsdValue,
-                  USD_VALUE_MIN_DECIMALS,
-                  USD_VALUE_MAX_DECIMALS
+                  USD_VALUE_DEFAULT_DECIMALS,
+                  USD_VALUE_DEFAULT_DECIMALS
                 ),
             realUsdValue: priceImpactInputCanNotBeComputed
               ? undefined
@@ -164,8 +163,8 @@ export function Inputs(props: PropTypes) {
             ? undefined
             : numberToString(
                 outputUsdValue,
-                USD_VALUE_MIN_DECIMALS,
-                USD_VALUE_MAX_DECIMALS
+                USD_VALUE_DEFAULT_DECIMALS,
+                USD_VALUE_DEFAULT_DECIMALS
               ),
           realValue: outputAmount?.toString(),
           realUsdValue: priceImpactOutputCanNotBeComputed

--- a/widget/ui/src/components/PriceImpact/PriceImpact.styles.ts
+++ b/widget/ui/src/components/PriceImpact/PriceImpact.styles.ts
@@ -7,6 +7,7 @@ export const Container = styled('div', {
   alignItems: 'center',
   overflow: 'hidden',
   minWidth: 0,
+  gap: 4,
 });
 
 export const ValueTypography = styled('div', {
@@ -16,6 +17,10 @@ export const ValueTypography = styled('div', {
     minWidth: 0,
     flexShrink: 1,
     maxWidth: '100%',
+  },
+  '& .percentage-value': {
+    flex: '1 1 0',
+    minWidth: 0,
   },
   '& ._typography': {
     $$color: '$colors$neutral600',

--- a/widget/ui/src/components/PriceImpact/PriceImpact.tsx
+++ b/widget/ui/src/components/PriceImpact/PriceImpact.tsx
@@ -4,7 +4,7 @@ import React, { useRef } from 'react';
 import { useIsTruncated } from 'src/hooks/useIsTruncated.js';
 import { InfoIcon } from 'src/icons/index.js';
 
-import { Divider, NumericTooltip, Typography } from '../index.js';
+import { NumericTooltip, Typography } from '../index.js';
 import { textTruncate } from '../TokenAmount/TokenAmount.styles.js';
 
 import { Container, ValueTypography } from './PriceImpact.styles.js';
@@ -19,6 +19,7 @@ export function PriceImpact(props: PriceImpactPropTypes) {
     warningLevel,
     error,
     tooltipProps,
+    style,
     ...rest
   } = props;
 
@@ -29,8 +30,22 @@ export function PriceImpact(props: PriceImpactPropTypes) {
     realOutputUsdValue || '',
     realOutputUsdValueRef
   );
+
+  const percentageValueRef = useRef<HTMLSpanElement | null>(null);
+  const isPercentageValueTruncated = useIsTruncated(
+    `(-${percentageChange}%)`,
+    percentageValueRef
+  );
+
   return (
-    <Container {...rest}>
+    <Container
+      {...rest}
+      style={{
+        ...style,
+        ...(isPercentageValueTruncated && {
+          flexWrap: 'wrap',
+        }),
+      }}>
       {outputUsdValue && (
         <ValueTypography className={textTruncate()}>
           <Typography
@@ -53,8 +68,11 @@ export function PriceImpact(props: PriceImpactPropTypes) {
       )}
       {((outputUsdValue && percentageChange) || !outputUsdValue) && (
         <ValueTypography hasError={hasError} hasWarning={hasWarning}>
-          <Divider direction="horizontal" size={4} />
-          <Typography size={size} variant="body">
+          <Typography
+            ref={percentageValueRef}
+            className="percentage-value"
+            size={size}
+            variant="body">
             {outputUsdValue &&
               percentageChange &&
               `(${

--- a/widget/ui/src/components/TokenAmount/TokenAmount.styles.ts
+++ b/widget/ui/src/components/TokenAmount/TokenAmount.styles.ts
@@ -1,9 +1,10 @@
 import { css, styled } from '../../theme.js';
-import { Typography } from '../Typography/Typography.js';
+import { ValueTypography } from '../PriceImpact/PriceImpact.styles.js';
 
 export const Container = styled('div', {
   display: 'flex',
   justifyContent: 'space-between',
+  overflow: 'hidden',
   gap: '$8',
   variants: {
     direction: {
@@ -26,7 +27,7 @@ export const centeredFlexBox = css({
 });
 
 export const TokenAmountWrapper = styled('div', {
-  flex: '1 1 0',
+  flex: '1 1 auto',
   minWidth: 0,
   display: 'flex',
   alignItems: 'center',
@@ -47,20 +48,48 @@ export const usdValueStyles = css({
   paddingBottom: '$5',
   minWidth: 0,
   flex: '0 1 auto',
+  [`& ${ValueTypography}`]: {
+    minWidth: 0,
+  },
 });
 
 export const tooltipRootStyle = {
   width: 'fit-content',
 };
 
-export const TokenNameText = styled(Typography, {
-  maxWidth: '64px',
+export const RealAmountWrapper = styled('div', {
+  display: 'flex',
+  gap: 2,
+  minWidth: 0,
+  alignItems: 'center',
+  flex: '1 1 0%',
+  '& svg': {
+    flex: '0 0 auto',
+  },
+});
+
+export const TokenNameWrapper = styled('div', {
+  maxWidth: '78px',
+  display: 'flex',
+  gap: 2,
+  minWidth: 0,
+  flex: '0 1 auto',
+  alignItems: 'center',
+  '& svg': {
+    flex: '0 0 auto',
+  },
+  '& .token-name-text': {
+    maxWidth: '64px',
+  },
 });
 
 export const textTruncate = css({
   overflow: 'hidden',
   textOverflow: 'ellipsis',
+  maxWidth: '100%',
+  display: 'block',
   whiteSpace: 'nowrap',
+  minWidth: 0,
 });
 
 export const flexShrinkFix = css({
@@ -68,10 +97,13 @@ export const flexShrinkFix = css({
 });
 
 export const usdValueText = css({
-  '& .output-usd-value': {
-    maxWidth: 77,
-  },
   maxWidth: 88,
+});
+
+export const horizontalUsdValueText = css({
+  '& .output-usd-value': {
+    maxWidth: 88,
+  },
 });
 export const verticalUsdValueText = css({
   '& .output-usd-value': {
@@ -88,4 +120,6 @@ export const TokenInfoRow = styled('div', {
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
+  flex: 1,
+  gap: 8,
 });

--- a/widget/ui/src/components/TokenAmount/TokenAmount.tsx
+++ b/widget/ui/src/components/TokenAmount/TokenAmount.tsx
@@ -15,10 +15,12 @@ import {
   Container,
   flexShrink,
   flexShrinkFix,
+  horizontalUsdValueText,
+  RealAmountWrapper,
   textTruncate,
   TokenAmountWrapper,
   TokenInfoRow,
-  TokenNameText,
+  TokenNameWrapper,
   tooltipRootStyle,
   usdValueStyles,
   usdValueText,
@@ -61,18 +63,16 @@ export function TokenAmount(props: PropTypes) {
             </Typography>
           )}
           <TokenInfoRow className={flexShrinkFix()}>
-            <Typography
-              size="medium"
-              variant="title"
-              ref={realValueRef}
-              className={`${textTruncate()} ${flexShrinkFix()}`}
-              style={{ fontWeight: 600 }}>
-              {props.price.realValue}
-            </Typography>
-            {props.price.realValue && isRealValueTruncated && (
-              <>
-                <Divider direction="horizontal" size={2} />
-
+            <RealAmountWrapper>
+              <Typography
+                size="medium"
+                variant="title"
+                ref={realValueRef}
+                className={`${textTruncate()} ${flexShrinkFix()}`}
+                style={{ fontWeight: 600 }}>
+                {props.price.realValue}
+              </Typography>
+              {props.price.realValue && isRealValueTruncated && (
                 <NumericTooltip
                   styles={{ root: tooltipRootStyle }}
                   content={props.price.realValue}
@@ -80,27 +80,33 @@ export function TokenAmount(props: PropTypes) {
                   container={props.tooltipContainer}>
                   <InfoIcon size={12} color="gray" />
                 </NumericTooltip>
-              </>
-            )}
-            <Divider direction="horizontal" size={8} />
-            <TokenNameText
-              size="medium"
-              variant="title"
-              className={textTruncate()}
-              ref={displayNameRef}
-              style={{ fontWeight: 400 }}>
-              {props.token.displayName}
-            </TokenNameText>
-            {isDisplayNameTruncated && (
-              <>
-                <Divider direction="horizontal" size={2} />
+              )}
+            </RealAmountWrapper>
+            <TokenNameWrapper>
+              <Typography
+                size="medium"
+                variant="title"
+                className={`${textTruncate()} token-name-text`}
+                ref={displayNameRef}
+                style={{ fontWeight: 400 }}>
+                {props.token.displayName}
+              </Typography>
+              {isDisplayNameTruncated && (
                 <Tooltip
                   content={props.token.displayName}
-                  container={props.tooltipContainer}>
+                  container={props.tooltipContainer}
+                  styles={{
+                    content: {
+                      maxWidth: 250,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    },
+                  }}>
                   <InfoIcon size={12} color="gray" />
                 </Tooltip>
-              </>
-            )}
+              )}
+            </TokenNameWrapper>
           </TokenInfoRow>
         </div>
       </TokenAmountWrapper>
@@ -127,13 +133,10 @@ export function TokenAmount(props: PropTypes) {
           {props.type === 'output' && (
             <PriceImpact
               className={`${
-                props.direction === 'horizontal'
-                  ? usdValueText()
-                  : verticalUsdValueText()
+                props.direction === 'vertical'
+                  ? verticalUsdValueText()
+                  : horizontalUsdValueText()
               } ${flexShrinkFix()} ${flexShrink()}`}
-              style={{
-                ...(props.direction === 'horizontal' && { flexWrap: 'wrap' }),
-              }}
               size="small"
               tooltipProps={{ container: props.tooltipContainer, side: 'top' }}
               outputUsdValue={props.price.usdValue}

--- a/widget/ui/src/containers/SwapInput/SwapInput.styles.ts
+++ b/widget/ui/src/containers/SwapInput/SwapInput.styles.ts
@@ -128,3 +128,12 @@ export const UsdPrice = styled(Typography, {
   textOverflow: 'ellipsis',
   maxWidth: 147,
 });
+
+export const textTruncate = css({
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  maxWidth: '100%',
+  display: 'block',
+  whiteSpace: 'nowrap',
+  minWidth: 0,
+});

--- a/widget/ui/src/containers/SwapInput/TokenSection.tsx
+++ b/widget/ui/src/containers/SwapInput/TokenSection.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
 } from '../../components/index.js';
 
+import { textTruncate } from './SwapInput.styles.js';
 import {
   chainNameStyles,
   Container,
@@ -112,7 +113,7 @@ export function TokenSection(props: TokenSectionProps) {
               <Typography
                 variant="body"
                 size="medium"
-                className={chainNameStyles()}>
+                className={`${chainNameStyles()} ${textTruncate()}`}>
                 {getBodyContent()}
               </Typography>
             </>

--- a/widget/ui/src/hooks/useIsTruncated.tsx
+++ b/widget/ui/src/hooks/useIsTruncated.tsx
@@ -21,7 +21,7 @@ export function useIsTruncated(
     } else {
       setIsTruncated(false);
     }
-  }, [content, ref.current]);
+  }, [content]);
 
   return isTruncated;
 }


### PR DESCRIPTION
# Summary

 **Issues Found**

**- Incorrect USD Value Display**

The displayed USD value for a transaction is sometimes incorrect.

**Steps to Reproduce:**
- Create a transaction from WKC.BSC to SMR.SHimmer.
- Enter an input amount between 1 and 5 → the USD value shown will be wrong.
- Enter an amount greater than 5 → the USD value will be correct.

**- Missing Number in Parentheses**

In some cases, the number inside the parentheses does not appear in the preview environment (while it is visible in production).

**- Layout Issue with Long Chain Names and Dollar Amounts**

When both the chain name and the USD value are long, the box height breaks and the layout looks misaligned.
According to the design, long chain names should be truncated with an ellipsis (...).

**- General UI Misalignment in Routes List**

The list of routes shows inconsistent alignment and spacing, creating visual clutter.

**- Truncation Not Applied in Tooltips**

Truncation rules are not being applied to tooltip content.


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
