### PR TITLE
ci: adding built widget examples

### DIFF
--- a/.github/actions/build-examples/action.yml
+++ b/.github/actions/build-examples/action.yml
@@ -1,0 +1,69 @@
+name: 'Build Examples'
+description: 'Links the current widget embedded package to example projects and builds them'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 🔨 Build Widget Package
+      run: yarn run build:widget
+      shell: bash
+
+    - name: 🔗 Link Core Packages
+      run: |
+        echo "::group::🔗 Creating symbolic links for widget and React dependencies"
+        yarn link --cwd widget/embedded
+        yarn link --cwd node_modules/react
+        yarn link --cwd node_modules/react-dom
+        echo "✅ Packages linked successfully"
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 📦 Setup Example Projects
+      run: |
+        echo "::group::🔍 Scanning and configuring example projects"
+        for dir in ./examples/*; do
+          if [ -f "$dir/package.json" ]; then
+            echo ""
+            echo "📂 Processing: $dir"
+            echo "  🔗 Linking @rango-dev/widget-embedded..."
+            yarn --cwd $dir link @rango-dev/widget-embedded
+            yarn --cwd $dir link react
+            yarn --cwd $dir link react-dom
+            echo "  📥 Installing dependencies..."
+            yarn --cwd $dir
+            echo "  ✅ Setup complete for $dir"
+          fi
+        done
+        echo ""
+        echo "🎉 All example projects configured successfully"
+        echo "::endgroup::"
+      shell: bash
+
+    - name: ⚙️ Configure Vite Build Settings
+      run: |
+        echo "::group::⚙️ Updating Vite configurations"
+        cp -rf scripts/build-examples/vite.config.ts examples/vite
+        cp -rf scripts/build-examples/vite.vue.config.ts examples/vue/vite.config.ts
+        echo "  📦 Adding vite-plugin-node-polyfills to Vite example..."
+        yarn --cwd examples/vite add -D vite-plugin-node-polyfills@0.17.0
+        echo "  📦 Adding vite-plugin-node-polyfills to Vue example..."
+        yarn --cwd examples/vue add -D vite-plugin-node-polyfills@0.17.0
+        echo "✅ Vite configurations updated"
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 🚀 Build All Examples
+      run: |
+        echo "::group::🚀 Building all example projects"
+        for dir in ./examples/*; do
+          if [ -f "$dir/package.json" ]; then
+            echo ""
+            echo "🏗️ Building: $dir"
+            yarn --cwd $dir build
+            echo "✅ Build complete: $dir"
+          fi
+        done
+        echo ""
+        echo "🎊 All examples built successfully!"
+        echo "::endgroup::"
+      shell: bash

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -129,3 +129,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPOSITORY: ${{ github.repository }}
+  build-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+      - name: Prepare
+        uses: ./.github/actions/prepare
+      - name: Build examples
+        uses: ./.github/actions/build-examples

--- a/scripts/build-examples/vite.config.ts
+++ b/scripts/build-examples/vite.config.ts
@@ -1,0 +1,80 @@
+/*
+ * This configuration is for vite example.
+ * When building these examples, we need to link our packages manually.
+ * This setup excludes those linked packages from Vite's pre-bundling process.
+ */
+import { defineConfig } from 'vite';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+import { lstatSync, readdirSync } from 'fs';
+const SCOPE = '@rango-dev';
+const CUSTOM_PKGS = ['rango-sdk'];
+
+const NODE_MODULES_PATH = `node_modules`;
+export default defineConfig(() => {
+  const excludedPackages = getSymlinkedPackages();
+
+  return {
+    build: {
+      commonjsOptions: {
+        transformMixedEsModules: true,
+      },
+    },
+    plugins: [
+      nodePolyfills({
+        globals: {
+          Buffer: true,
+          global: true,
+          process: true,
+        },
+      }),
+    ],
+    server: {
+      host: 'localhost',
+      port: 3000,
+    },
+    optimizeDeps: {
+      exclude: excludedPackages,
+      force: excludedPackages.length > 0 ? true : false,
+      esbuildOptions: {
+        define: {
+          global: 'globalThis',
+        },
+      },
+    },
+  };
+});
+
+function getSymlinkedPackages() {
+  const symlinkedPackages: string[] = [];
+
+  // Check custom packages
+  CUSTOM_PKGS.forEach((pkgName) => {
+    try {
+      const pkg = lstatSync(`${NODE_MODULES_PATH}/${pkgName}`);
+      if (pkg.isSymbolicLink()) {
+        symlinkedPackages.push(`${SCOPE}/${pkgName}`);
+      }
+    } catch {
+      // skip by ignoring errors.
+    }
+  });
+
+  // Check scoped packages
+  const scopedPackages = readdirSync(`${NODE_MODULES_PATH}/${SCOPE}`, {
+    withFileTypes: true,
+  });
+
+  scopedPackages.forEach((pkg) => {
+    if (pkg.isSymbolicLink()) {
+      symlinkedPackages.push(`${SCOPE}/${pkg.name}`);
+    }
+  });
+
+  if (symlinkedPackages.length > 0) {
+    console.log(
+      `${symlinkedPackages} linked package detected. we will exclude them.`
+    );
+  }
+
+  return symlinkedPackages;
+}

--- a/scripts/build-examples/vite.vue.config.ts
+++ b/scripts/build-examples/vite.vue.config.ts
@@ -1,0 +1,77 @@
+/*
+ * This configuration is for vue example that uses Vite.
+ * When building these examples, we need to link our packages manually.
+ * This setup excludes those linked packages from Vite's pre-bundling process.
+ */
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+import veauryVitePlugins from 'veaury/vite';
+import { defineConfig } from 'vite';
+import { lstatSync, readdirSync } from 'fs';
+const SCOPE = '@rango-dev';
+const CUSTOM_PKGS = ['rango-sdk'];
+
+const NODE_MODULES_PATH = `node_modules`;
+export default defineConfig(() => {
+  const excludedPackages = getSymlinkedPackages();
+
+  return {
+    plugins: [
+      veauryVitePlugins({
+        type: 'vue',
+      }),
+      nodePolyfills({
+        globals: {
+          Buffer: true,
+          global: true,
+          process: true,
+        },
+      }),
+    ],
+    esbuild: {
+      target: 'esnext',
+    },
+    optimizeDeps: {
+      exclude: excludedPackages,
+      force: excludedPackages.length > 0 ? true : false,
+      esbuildOptions: {
+        define: {
+          global: 'globalThis',
+        },
+      },
+    },
+  };
+});
+function getSymlinkedPackages() {
+  const symlinkedPackages: string[] = [];
+
+  // Check custom packages
+  CUSTOM_PKGS.forEach((pkgName) => {
+    try {
+      const pkg = lstatSync(`${NODE_MODULES_PATH}/${pkgName}`);
+      if (pkg.isSymbolicLink()) {
+        symlinkedPackages.push(`${SCOPE}/${pkgName}`);
+      }
+    } catch {
+      // skip by ignoring errors.
+    }
+  });
+
+  // Check scoped packages
+  const scopedPackages = readdirSync(`${NODE_MODULES_PATH}/${SCOPE}`, {
+    withFileTypes: true,
+  });
+
+  scopedPackages.forEach((pkg) => {
+    if (pkg.isSymbolicLink()) {
+      symlinkedPackages.push(`${SCOPE}/${pkg.name}`);
+    }
+  });
+
+  if (symlinkedPackages.length > 0) {
+    console.log(
+      `${symlinkedPackages} linked package detected. we will exclude them.`
+    );
+  }
+
+  return symlinkedPackages;
+}


### PR DESCRIPTION
# Summary

This PR adds **example builds to the check workflow** to verify that they build correctly along with the rest of the packages.

To achieve this, I created a script that temporarily adds the `examples` to the workspace so they can access the latest changes and all sub-dependencies.

I explored other approaches (e.g. linking with `yarn`/`yalc` or embedding the built widget as a dependency), but those required linking all related sub-dependencies or caused build issues. The current method proved to be the most efficient and reliable.

Additionally:

* Installed dependencies with `skipLibCheck: true` in the `tsconfig`s to avoid build errors caused by `react-scripts` dependencies in rewired examples.
* Built all packages (including examples) to ensure everything compiles correctly.

Fixes # (issue)

---

# How did you test this change?

I verified the workflow by:

* Running the script locally to ensure examples are added correctly.
* Installing dependencies and confirming builds succeed without errors.
* Running the full build process to ensure all packages (including examples) compile successfully.


---

# Checklist:

* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision
