### PR TITLE
chore: export UseStatefulConnect interface from widget

### DIFF
--- a/widget/embedded/src/hooks/useStatefulConnect/index.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/index.ts
@@ -1,4 +1,5 @@
 export { useStatefulConnect } from './useStatefulConnect';
+export type { UseStatefulConnect } from './useStatefulConnect';
 export { ResultStatus } from './useStatefulConnect.types';
 export type {
   NeedsNamespacesState,

--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
@@ -17,7 +17,7 @@ import {
 import { initState, reducer, type State } from './useStatefulConnect.state';
 import { ResultStatus } from './useStatefulConnect.types';
 
-interface UseStatefulConnect {
+export interface UseStatefulConnect {
   handleConnect: (
     wallet: WalletInfoWithExtra,
     options?: HandleConnectOptions

--- a/widget/embedded/src/index.ts
+++ b/widget/embedded/src/index.ts
@@ -1,4 +1,5 @@
 import type { WidgetProps } from './containers/Widget';
+import type { UseStatefulConnect } from './hooks/useStatefulConnect';
 import type { ConnectedWallet } from './store/slices/wallets';
 import type {
   BlockchainAndTokenConfig,
@@ -131,6 +132,7 @@ export type {
   QuoteEventData,
   UiEventData,
   WalletInfoWithExtra,
+  UseStatefulConnect,
 };
 export {
   Widget,


### PR DESCRIPTION
# Summary

We are wrapping useStatefulConnect in app-v2 (to solve the global use case there), so besides the implementation we need to have the interface as well. so this PR make it public.

Part of RF-2675


# How did you test this change?

No need to test, just exporting a type for widget-embedded. 


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
