### PR TITLE
Feat/add hub provider to widget config wallets

### DIFF
--- a/wallets/provider-all/src/helpers.ts
+++ b/wallets/provider-all/src/helpers.ts
@@ -2,17 +2,23 @@ import type { VersionedProviders } from '@rango-dev/wallets-core/utils';
 import type { ProviderInterface } from '@rango-dev/wallets-react';
 import type { WalletType, WalletTypes } from '@rango-dev/wallets-shared';
 
+import { Provider } from '@rango-dev/wallets-core';
+
 export const isWalletExcluded = (
-  providers: (WalletType | ProviderInterface)[],
+  providers: (WalletType | ProviderInterface | Provider)[],
   wallet: { name: string; type: WalletTypes }
 ) => {
   return (
     providers.length &&
-    !providers.find((provider) =>
-      typeof provider === 'string'
-        ? provider === wallet.type
-        : provider.getWalletInfo([]).name === wallet.name
-    )
+    !providers.find((provider) => {
+      if (typeof provider === 'string') {
+        return provider === wallet.type;
+      }
+      if (provider instanceof Provider) {
+        return provider.id === wallet.type;
+      }
+      return provider.getWalletInfo([]).name === wallet.name;
+    })
   );
 };
 

--- a/wallets/provider-all/src/index.ts
+++ b/wallets/provider-all/src/index.ts
@@ -1,6 +1,7 @@
 import type { Environments as TonConnectEnvironments } from '@rango-dev/provider-tonconnect';
 import type { Environments as TrezorEnvironments } from '@rango-dev/provider-trezor';
 import type { Environments as WalletConnectEnvironments } from '@rango-dev/provider-walletconnect-2';
+import type { Provider } from '@rango-dev/wallets-core';
 import type { ProviderInterface } from '@rango-dev/wallets-react';
 
 import * as bitget from '@rango-dev/provider-bitget';
@@ -48,7 +49,7 @@ import { isWalletExcluded, lazyProvider } from './helpers.js';
 
 interface Options {
   walletconnect2: WalletConnectEnvironments;
-  selectedProviders?: (WalletType | ProviderInterface)[];
+  selectedProviders?: (WalletType | ProviderInterface | Provider)[];
   trezor?: TrezorEnvironments;
   tonConnect?: TonConnectEnvironments;
 }

--- a/wallets/react/src/legacy/types.ts
+++ b/wallets/react/src/legacy/types.ts
@@ -1,5 +1,6 @@
 import type {
   GenerateDeepLink,
+  Provider,
   ProviderMetadata,
   VersionedProviders,
 } from '@rango-dev/wallets-core';
@@ -75,7 +76,7 @@ export type ProviderProps = PropsWithChildren<{
   autoConnect?: boolean;
   providers: VersionedProviders[];
   configs?: {
-    wallets?: (WalletType | LegacyProviderInterface)[];
+    wallets?: (WalletType | LegacyProviderInterface | Provider)[];
   };
 }>;
 

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -5,7 +5,7 @@ import type {
   WidgetContextInterface,
 } from './Wallets.types';
 import type { ProvidersOptions } from '../../utils/providers';
-import type { LegacyEventHandler } from '@rango-dev/wallets-core/dist/legacy/mod';
+import type { LegacyEventHandler } from '@rango-dev/wallets-core/legacy';
 import type { PropsWithChildren } from 'react';
 
 import { Provider } from '@rango-dev/wallets-react';

--- a/widget/embedded/src/hooks/useWalletProviders/useWalletProviders.helpers.ts
+++ b/widget/embedded/src/hooks/useWalletProviders/useWalletProviders.helpers.ts
@@ -1,12 +1,17 @@
 import type { ProviderInterface } from '@rango-dev/wallets-react';
 
+import { Provider } from '@rango-dev/wallets-core';
+
 export function hashProviders(
-  providers: (string | ProviderInterface)[]
+  providers: (string | ProviderInterface | Provider)[]
 ): string {
   return providers
     .map((provider) => {
       if (typeof provider === 'string') {
         return provider;
+      }
+      if (provider instanceof Provider) {
+        return provider.id;
       }
       return provider.config.type;
     })

--- a/widget/embedded/src/index.ts
+++ b/widget/embedded/src/index.ts
@@ -87,6 +87,7 @@ import {
   WalletEventTypes,
   WidgetEvents,
 } from './types';
+import { pickProviderVersionWithFallbackToLegacy } from './utils/providers';
 import { customizedThemeTokens } from './utils/ui';
 
 export const StatefulConnect = {
@@ -182,6 +183,7 @@ export type {
 // Internal function and enum exports for Rango
 export {
   readAccountAddress,
+  pickProviderVersionWithFallbackToLegacy,
   Networks,
   WalletEvents,
   WalletTypes,

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -1,5 +1,6 @@
 import type { Language, theme } from '@rango-dev/ui';
-import type { LegacyProviderInterface } from '@rango-dev/wallets-core/dist/legacy/mod';
+import type { Provider } from '@rango-dev/wallets-core';
+import type { LegacyProviderInterface } from '@rango-dev/wallets-core/legacy';
 import type { WalletType } from '@rango-dev/wallets-shared';
 import type { Asset } from 'rango-sdk';
 import type { ReactElement } from 'react';
@@ -272,7 +273,7 @@ export type WidgetConfig = {
   from?: BlockchainAndTokenConfig;
   to?: BlockchainAndTokenConfig;
   liquiditySources?: string[];
-  wallets?: (WalletType | LegacyProviderInterface)[];
+  wallets?: (WalletType | LegacyProviderInterface | Provider)[];
   multiWallets?: boolean;
   customDestination?: boolean;
   defaultCustomDestinations?: { [blockchain: string]: string };

--- a/widget/embedded/src/utils/providers.ts
+++ b/widget/embedded/src/utils/providers.ts
@@ -95,7 +95,7 @@ export function matchAndGenerateProviders({
   return allProviders;
 }
 
-function pickProviderVersionWithFallbackToLegacy(
+export function pickProviderVersionWithFallbackToLegacy(
   provider: VersionedProviders
 ): BothProvidersInterface {
   try {


### PR DESCRIPTION
# Summary

- Added `Provider` type from `@rango-dev/wallets-core` to `WidgetConfig.wallets` to enable passing hub providers as config alongside with `LegacyProvider` and wallet name.
- Exported `pickProviderVersionWithFallbackToLegacy` from `widget/embedded`.
- Added a second commit to test the changes. It will be removed before merging.


# How did you test this change?

Tested by connecting and disconnecting various wallets.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
