### PR TITLE
feat: adding hubProvider to wallets-adapter

### DIFF
--- a/queue-manager/rango-preset/src/types.ts
+++ b/queue-manager/rango-preset/src/types.ts
@@ -4,6 +4,7 @@ import type {
   QueueDef,
   QueueStorage,
 } from '@rango-dev/queue-manager-core';
+import type { Provider } from '@rango-dev/wallets-core';
 import type { LegacyConnectResult as ConnectResult } from '@rango-dev/wallets-core/legacy';
 import type {
   Meta,
@@ -67,6 +68,7 @@ export interface SwapQueueContext extends QueueContext {
   meta: Meta;
   wallets: Wallet | null;
   providers: Providers;
+  hubProvider: (type: WalletType) => Provider;
   getSigners: (type: WalletType) => Promise<SignerFactory>;
   switchNetwork: (
     wallet: WalletType,

--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -496,6 +496,11 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
     suggestAndConnect(_type, _network): never {
       throw new Error('`suggestAndConnect` is not implemented');
     },
+    hubProvider() {
+      throw new Error(
+        'Unreachable code. the method has been implemented in main adapter instance.'
+      );
+    },
   };
 
   return api;

--- a/wallets/react/src/legacy/context.ts
+++ b/wallets/react/src/legacy/context.ts
@@ -31,6 +31,9 @@ const defaultContext: ProviderContext = {
   getSigners() {
     throw new Error(defaultErrorMessage);
   },
+  hubProvider() {
+    throw new Error(defaultErrorMessage);
+  },
 };
 
 export const WalletContext = createContext<ProviderContext>(defaultContext);

--- a/wallets/react/src/legacy/types.ts
+++ b/wallets/react/src/legacy/types.ts
@@ -67,6 +67,7 @@ export type ProviderContext = {
   getSigners(type: WalletType): Promise<SignerFactory>;
   getWalletInfo(type: WalletType): ExtendedWalletInfo;
   suggestAndConnect(type: WalletType, network: Network): Promise<ConnectResult>;
+  hubProvider(type: WalletType): Provider;
 };
 
 export type ProviderProps = PropsWithChildren<{

--- a/wallets/react/src/legacy/useLegacyProviders.ts
+++ b/wallets/react/src/legacy/useLegacyProviders.ts
@@ -173,6 +173,9 @@ export function useLegacyProviders(
 
       return result;
     },
+    hubProvider() {
+      throw new Error('This method is not available on legacy providers.');
+    },
   };
 
   // Initialize instances

--- a/wallets/react/src/useProviders.ts
+++ b/wallets/react/src/useProviders.ts
@@ -108,6 +108,17 @@ function useProviders(props: ProviderProps) {
 
       return await legacyApi.suggestAndConnect(type, network);
     },
+    hubProvider(type) {
+      const hubProvider = findProviderByType(hubProviders, type);
+
+      if (hubProvider) {
+        return hubProvider;
+      }
+
+      throw new Error(
+        `You're trying to access ${type} provider which is not found in hub providers. you may try to access a legacy provider or it's not been registered yet.`
+      );
+    },
   };
 
   return api;

--- a/widget/embedded/src/QueueManager.tsx
+++ b/widget/embedded/src/QueueManager.tsx
@@ -29,6 +29,7 @@ function QueueManager(props: PropsWithChildren<{ apiKey?: string }>) {
     connect,
     canSwitchNetworkTo,
     getWalletInfo,
+    hubProvider,
   } = useWallets();
 
   const swapQueueDef = useMemo(() => {
@@ -98,6 +99,7 @@ function QueueManager(props: PropsWithChildren<{ apiKey?: string }>) {
     canSwitchNetworkTo,
     state,
     isMobileWallet,
+    hubProvider,
   };
 
   const isActiveTab = useUiStore.use.isActiveTab();


### PR DESCRIPTION
# Summary

Hub has a dynamic interface through its actions concept, but the the legacy only have a limited and fixed limit. 

In this PR, we can have access to hub provider to run any actions. Legacy will goes through an error. so this method only works on hub wallets. 

You can see the usage on https://github.com/rango-exchange/rango-client/pull/1276

Part of https://github.com/rango-exchange/rango-client/pull/1096

Fixes RF-2294


# How did you test this change?

No need to test.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
