### PR TITLE
fix: okx reconnect behaviour

### DIFF
--- a/wallets/provider-okx/readme.md
+++ b/wallets/provider-okx/readme.md
@@ -49,11 +49,15 @@ The wallet supports UTXO-based networks, but they are **not implemented** in the
 ### Feature
 
 #### ⚠️ Disconnect
-After a dApp is disconnected, it **cannot reconnect automatically** unless the user also manually disconnects from the wallet itself.  
+The disconnect function will not work for this wallet, as it attempts to invoke disconnect on the connect method for private key imported wallets.
+If the user disconnects the dApp from the wallet itself, we won't disconnect ourself. But we will get disconnected after refreshing the page.
+If the user connects the wallet to one account, switches to another account, and then disconnects one of the two from the wallet, the dApp automatically switches to the remaining account that wasn’t disconnected.
+
+
 
 #### ⚠️ Switch Account
-Switching accounts from the wallet interface **is not reflected in the dApp**.  
-The previously connected account remains active until the user performs a **full disconnect and reconnect**.  
+If you switch accounts while still connected to the application, the `accountChanged` event will only emit for the last connected namespace. In result of that, the account for previously connected namespaces will not get updated and requires a disconnect and reconnect to properly connect to the desired account.
+Also, when you call connect on a previously connected namespace, it doesn't return the address of the new account the user switched to. To prevent the user from being stuck in such situation, we call `disconnect` on the wallet whenever user disconnects the wallet from the provider. This results in a limitation which is explained in the `Disconnect` section.
 
 
 ---

--- a/wallets/provider-okx/src/namespaces/evm.ts
+++ b/wallets/provider-okx/src/namespaces/evm.ts
@@ -41,6 +41,9 @@ const connect = builders
 
 const disconnect = commonBuilders
   .disconnect<EvmActions>()
+  .before(() => {
+    evmOKX().disconnect();
+  })
   .after(changeAccountCleanup)
   .build();
 

--- a/wallets/provider-okx/src/namespaces/solana.ts
+++ b/wallets/provider-okx/src/namespaces/solana.ts
@@ -41,6 +41,9 @@ const connect = builders
 
 const disconnect = commonBuilders
   .disconnect<SolanaActions>()
+  .before(() => {
+    solanaOKX().disconnect();
+  })
   .after(changeAccountCleanup)
   .build();
 


### PR DESCRIPTION
# Summary

This PR updates the disconnect flow for **OKX wallet integration**:

* When a user disconnects from the dApp, the app will now also **actively disconnect from OKX wallet**.
* This ensures that reconnecting will not automatically restore the **previously used account**, but instead prompt the user to select/connect an account again.
* As a side effect, all namespaces (EVM + Solana) in OKX will be disconnected together.

This behavior aligns with the product decision, prioritizing a smoother user experience over per-namespace disconnect granularity.

Fixes # (issue)
* Added active OKX wallet disconnect on app-level disconnect.
* Updated reconnect logic to prevent auto-connection to the last used account.
* Preserved existing known limitation: account switching still requires a full disconnect/reconnect.

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
