### PR TITLE
chore: add classname to initial and detached modal dividers

### DIFF
--- a/widget/embedded/src/components/WalletStatefulConnect/Detached.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Detached.tsx
@@ -75,7 +75,10 @@ export function Detached(props: PropTypes) {
     if (!!singleSelection) {
       return (
         <>
-          <Divider size={20} />
+          <Divider
+            size={20}
+            className="_detached_namespace_list_header_alert_top_divider"
+          />
           <Alert
             id="widget-wallet-stateful-connect-alert"
             variant="alarm"
@@ -84,13 +87,19 @@ export function Detached(props: PropTypes) {
               'This wallet can only connect to one chain at a time.'
             )}
           />
-          <Divider size={30} />
+          <Divider
+            size={30}
+            className="_detached_namespace_list_header_alert_bottom_divider"
+          />
         </>
       );
     }
     return (
       <>
-        <Divider size={30} />
+        <Divider
+          size={30}
+          className="_detached_namespace_list_header_button_top_divider"
+        />
         <NamespacesHeader>
           <Button
             id="widget-detached-disconnect-wallet-btn"
@@ -102,7 +111,10 @@ export function Detached(props: PropTypes) {
             {i18n.t('Disconnect wallet')}
           </Button>
         </NamespacesHeader>
-        <Divider size={16} />
+        <Divider
+          size={16}
+          className="_detached_namespace_list_header_button_bottom_divider"
+        />
       </>
     );
   };

--- a/widget/embedded/src/components/WalletStatefulConnect/Namespaces.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Namespaces.tsx
@@ -120,7 +120,10 @@ export function Namespaces(props: PropTypes) {
       />
       {singleNamespace ? (
         <>
-          <Divider size={20} />
+          <Divider
+            size={20}
+            className="_initial_namespace_list_header_alert_top_divider"
+          />
           <Alert
             id="widget-wallet-stateful-connect-alert"
             variant="alarm"
@@ -129,11 +132,17 @@ export function Namespaces(props: PropTypes) {
               'This wallet can only connect to one chain at a time. '
             )}
           />
-          <Divider size={30} />
+          <Divider
+            size={30}
+            className="_initial_namespace_list_header_alert_bottom_divider"
+          />
         </>
       ) : (
         <>
-          <Divider size={30} />
+          <Divider
+            size={30}
+            className="_initial_namespace_list_header_button_top_divider"
+          />
           <Button
             style={{ marginLeft: 'auto' }}
             id="widget-name-space-select-all-btn"
@@ -145,7 +154,10 @@ export function Namespaces(props: PropTypes) {
               ? i18n.t('Deselect all')
               : i18n.t('Select all')}
           </Button>
-          <Divider size={10} />
+          <Divider
+            size={10}
+            className="_initial_namespace_list_header_button_bottom_divider"
+          />
         </>
       )}
       <NamespaceList>

--- a/widget/ui/src/components/Divider/Divider.types.ts
+++ b/widget/ui/src/components/Divider/Divider.types.ts
@@ -7,4 +7,5 @@ type BaseSizes = Exclude<BaseProps['size'], object>;
 export interface PropTypes {
   size?: BaseSizes;
   direction?: 'vertical' | 'horizontal';
+  className?: string;
 }


### PR DESCRIPTION
# Summary

Added classname to initial and detached modal dividers to enable styling them from outside.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
