### PR TITLE
fix: replace metamask with keplr in playground external wallet

### DIFF
--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
@@ -36,8 +36,8 @@ export function WalletSection() {
 
   const onChangeExternalWallet = (checked: boolean) => {
     if (!checked) {
-      if (state('metamask').connected) {
-        void disconnect(WalletTypes.META_MASK);
+      if (state(WalletTypes.KEPLR).connected) {
+        void disconnect(WalletTypes.KEPLR);
       }
     }
     onChangeBooleansConfig('externalWallets', checked);
@@ -94,7 +94,7 @@ export function WalletSection() {
         </SwitchField>
         <Divider size={16} />
         <Typography size="small" variant="body" color="neutral600">
-          It's a sample using metamask, You can use your own wallet or what we
+          It's a sample using Keplr, You can use your own wallet or what we
           already implemented, check it out here.
         </Typography>
         <Divider size={16} />
@@ -107,15 +107,15 @@ export function WalletSection() {
             disabled={!externalWallets}
             className={connectButtonStyles()}
             onClick={() => {
-              if (state('metamask').connected) {
-                void disconnect('metamask');
+              if (state(WalletTypes.KEPLR).connected) {
+                void disconnect(WalletTypes.KEPLR);
               } else {
-                void connect('metamask');
+                void connect(WalletTypes.KEPLR);
               }
             }}>
-            {externalWallets && state('metamask').connected
-              ? 'Disconnect MetaMask'
-              : 'Connect MetaMask'}
+            {externalWallets && state(WalletTypes.KEPLR).connected
+              ? 'Disconnect Keplr'
+              : 'Connect Keplr'}
           </Button>
         </Footer>
       </ExternalSection>


### PR DESCRIPTION
# Summary

There was an error in connecting `Metamask` wallet in external wallet section in playground caused by migrating `Metamask` to hub. In this PR, the issue is resolved replacing `Metamask` with `Keplr` which is a legacy wallet.
Fixes # (issue)


# How did you test this change?

Tested by connecting and disconnecting `Keplr` through connecting and disconnecting from external wallet section in playground.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
