### PR TITLE
fix: virtual list dynamic height

### DIFF
--- a/widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx
+++ b/widget/embedded/src/components/HistoryGroupedList/HistoryGroupedList.tsx
@@ -81,6 +81,11 @@ export function HistoryGroupedList(props: PropTypes) {
 
   return (
     <GroupedVirtualizedList
+      style={{
+        // See note on https://github.com/rango-exchange/rango-client/pull/1284
+        flexGrow: 1,
+        minHeight: 0,
+      }}
       endReached={() => {
         if (loadedItems.current < list.length) {
           loadMore();

--- a/widget/embedded/src/components/TokenList/TokenList.styles.ts
+++ b/widget/embedded/src/components/TokenList/TokenList.styles.ts
@@ -69,8 +69,12 @@ export const Title = styled('div', {
 });
 export const List = styled('ul', {
   flexGrow: 1,
+  height: '100%',
   padding: 0,
   margin: 0,
+  // See note on https://github.com/rango-exchange/rango-client/pull/1284
+  display: 'flex',
+  flexDirection: 'column',
   listStyle: 'none',
 
   '& li': {

--- a/widget/embedded/src/components/TokenList/TokenList.tsx
+++ b/widget/embedded/src/components/TokenList/TokenList.tsx
@@ -195,6 +195,11 @@ export function TokenList(props: PropTypes) {
   const renderList = () => {
     return (
       <VirtualizedList
+        style={{
+          // See note on https://github.com/rango-exchange/rango-client/pull/1284
+          flexGrow: 1,
+          minHeight: 0,
+        }}
         itemContent={(index) => {
           const token = tokens[index];
           if (token === 'skeleton') {

--- a/widget/embedded/src/pages/HistoryPage.tsx
+++ b/widget/embedded/src/pages/HistoryPage.tsx
@@ -40,6 +40,9 @@ const HistoryGroupedListContainer = styled('div', {
   flexDirection: 'column',
   gap: 15,
   height: '100%',
+  // See note on https://github.com/rango-exchange/rango-client/pull/1284
+  minHeight: 0,
+  flexGrow: 1,
 });
 
 const SearchAndFilterBar = styled('div', {


### PR DESCRIPTION
# Summary
Fix VirtualizedList not rendering when height is inferred from flexbox containers.


## Fixes (issue)

Virtual lists render empty without an explicit height, which causes failures in flex layouts.
Add `height: '100%' `to List container
Add `flex: 1, minHeight: 0 `to VirtualizedList for proper sizing
According to this reference:
https://virtuoso.dev/#virtuoso

# How did you test this change?

To test this issue, you can remove any` height: 100%` from `widget/app/public/index.css`, and run `yarn dev:widget`

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
