### PR TITLE
feat: enable skip select namespaces in useStatefulConnect hook

### DIFF
--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.types.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.types.ts
@@ -3,6 +3,7 @@ import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 
 export interface HandleConnectOptions {
   // To have a switch between connect and disconnect when user is clicking on a button, this option can be helpful.
+  forceConnectToNamespaces?: Namespace[];
   disconnectIfConnected?: boolean;
   defaultSelectedChains?: string[];
 }


### PR DESCRIPTION
# Summary

Currently, initial and detached modals get displayed when user tries to connect a hub wallet. In this PR, a `forcedNamespaces` parameter is added to `handleConnect` method of `useStatefulConnect` hook to enable selecting some namespaces programmatically without displaying initial and detached modal. So when `handleConnect` gets called with some `forcedNamespaces`, those namespaces get connected and if one of them get an error, all of them get disconnected.


# How did you test this change?

Tested by linking this PR to app and passed `Solana` and `EVM` namespaces as `skipSelectNamespaces` and observed the required behavior.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
