### PR TITLE
refactor: remove dependency to legacy providers and add getChainId action to evm namespace

### DIFF
--- a/queue-manager/rango-preset/src/actions/common/checkEnvironmentBeforeExecuteTransaction.ts
+++ b/queue-manager/rango-preset/src/actions/common/checkEnvironmentBeforeExecuteTransaction.ts
@@ -115,7 +115,7 @@ async function ensureWalletIsOnCorrectNetwork(
   actions: ExecuterActions<SwapStorage, SwapActionTypes, SwapQueueContext>
 ): Promise<Result<true, BlockedReason>> {
   const { getStorage, context } = actions;
-  const { meta, wallets, providers } = context;
+  const { meta, wallets, providers, hubProvider } = context;
   const swap = getStorage().swapDetails;
   const currentStep = getCurrentStep(swap)!;
 
@@ -124,7 +124,8 @@ async function ensureWalletIsOnCorrectNetwork(
     currentStep,
     wallets,
     meta,
-    providers
+    providers,
+    hubProvider
   );
 
   const { claimedBy } = claimQueue();

--- a/wallets/core/src/namespaces/evm/actions.ts
+++ b/wallets/core/src/namespaces/evm/actions.ts
@@ -98,3 +98,19 @@ export function canSwitchNetwork(): FunctionWithContext<
     return filterAndGetEvmBlockchainNames(supportedChains).includes(network);
   };
 }
+
+export function getChainId(
+  instance: () => ProviderAPI | undefined
+): FunctionWithContext<EvmActions['getChainId'], Context> {
+  return async () => {
+    const evmInstance = instance();
+
+    if (!evmInstance) {
+      throw new Error(
+        'Trying to get chain id from your EVM wallet, but instance is not available.'
+      );
+    }
+
+    return evmInstance.request({ method: 'eth_chainId' });
+  };
+}

--- a/wallets/core/src/namespaces/evm/builders.ts
+++ b/wallets/core/src/namespaces/evm/builders.ts
@@ -45,3 +45,6 @@ export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
     .removeEventListener((instance, callback) => {
       instance.removeListener?.('accountsChanged', callback);
     });
+
+export const getChainId = () =>
+  new ActionBuilder<EvmActions, 'getChainId'>('getChainId');

--- a/wallets/core/src/namespaces/evm/types.ts
+++ b/wallets/core/src/namespaces/evm/types.ts
@@ -15,6 +15,7 @@ export interface EvmActions
   ) => Promise<AccountsWithActiveChain>;
   canEagerConnect: () => Promise<boolean>;
   canSwitchNetwork: (params: CanSwitchNetworkParams) => boolean;
+  getChainId: () => Promise<`0x${string}`>;
 }
 type CanSwitchNetworkParams = {
   network: string;

--- a/wallets/provider-coinbase/src/namespaces/evm.ts
+++ b/wallets/provider-coinbase/src/namespaces/evm.ts
@@ -72,11 +72,17 @@ const canSwitchNetwork = builders
   .action(actions.canSwitchNetwork())
   .build();
 
+const getChainId = builders
+  .getChainId()
+  .action(actions.getChainId(evmCoinbase))
+  .build();
+
 const evm = new NamespaceBuilder<EvmActions>('EVM', WALLET_ID)
   .action(connect)
   .action(disconnect)
   .action(canEagerConnect)
   .action(canSwitchNetwork)
+  .action(getChainId)
   .build();
 
 export { evm };

--- a/wallets/provider-ledger/src/namespaces/evm.ts
+++ b/wallets/provider-ledger/src/namespaces/evm.ts
@@ -10,6 +10,7 @@ import {
   CAIP_NAMESPACE,
 } from '@rango-dev/wallets-core/namespaces/evm';
 import { CAIP } from '@rango-dev/wallets-core/utils';
+import { ETHEREUM_CHAIN_ID } from '@rango-dev/wallets-shared';
 
 import { WALLET_ID } from '../constants.js';
 import { setDerivationPath } from '../state.js';
@@ -50,9 +51,15 @@ const connect = builders
 
 const disconnect = commonBuilders.disconnect<EvmActions>().build();
 
+const getChainId = builders
+  .getChainId()
+  .action(() => ETHEREUM_CHAIN_ID)
+  .build();
+
 const evm = new NamespaceBuilder<EvmActions>('EVM', WALLET_ID)
   .action(connect)
   .action(disconnect)
+  .action(getChainId)
   .build();
 
 export { evm };

--- a/wallets/provider-metamask/src/namespaces/evm.ts
+++ b/wallets/provider-metamask/src/namespaces/evm.ts
@@ -65,11 +65,17 @@ const canSwitchNetwork = builders
   .action(actions.canSwitchNetwork())
   .build();
 
+const getChainId = builders
+  .getChainId()
+  .action(actions.getChainId(evmMetamask))
+  .build();
+
 const evm = new NamespaceBuilder<EvmActions>('EVM', WALLET_ID)
   .action(connect)
   .action(disconnect)
   .action(canSwitchNetwork)
   .action(canEagerConnect)
+  .action(getChainId)
   .build();
 
 export { evm };

--- a/wallets/provider-okx/src/namespaces/evm.ts
+++ b/wallets/provider-okx/src/namespaces/evm.ts
@@ -40,11 +40,17 @@ const canEagerConnect = builders
   .action(actions.canEagerConnect(evmOKX))
   .build();
 
+const getChainId = builders
+  .getChainId()
+  .action(actions.getChainId(evmOKX))
+  .build();
+
 const evm = new NamespaceBuilder<EvmActions>('EVM', WALLET_ID)
   .action(connect)
   .action(disconnect)
   .action(canEagerConnect)
   .action(canSwitchNetwork)
+  .action(getChainId)
   .build();
 
 export { evm };

--- a/wallets/provider-phantom/src/namespaces/evm.ts
+++ b/wallets/provider-phantom/src/namespaces/evm.ts
@@ -46,11 +46,17 @@ const canSwitchNetwork = builders
   .action(actions.canSwitchNetwork())
   .build();
 
+const getChainId = builders
+  .getChainId()
+  .action(actions.getChainId(evmPhantom))
+  .build();
+
 const evm = new NamespaceBuilder<EvmActions>('EVM', WALLET_ID)
   .action(connect)
   .action(disconnect)
   .action(canEagerConnect)
   .action(canSwitchNetwork)
+  .action(getChainId)
   .build();
 
 export { evm };

--- a/wallets/provider-rabby/src/namespaces/evm.ts
+++ b/wallets/provider-rabby/src/namespaces/evm.ts
@@ -40,11 +40,17 @@ const canEagerConnect = builders
   .action(actions.canEagerConnect(evmRabby))
   .build();
 
+const getChainId = builders
+  .getChainId()
+  .action(actions.getChainId(evmRabby))
+  .build();
+
 const evm = new NamespaceBuilder<EvmActions>('EVM', WALLET_ID)
   .action(connect)
   .action(disconnect)
   .action(canEagerConnect)
   .action(canSwitchNetwork)
+  .action(getChainId)
   .build();
 
 export { evm };

--- a/wallets/provider-safepal/src/namespaces/evm.ts
+++ b/wallets/provider-safepal/src/namespaces/evm.ts
@@ -32,10 +32,16 @@ const canSwitchNetwork = builders
   .action(actions.canSwitchNetwork())
   .build();
 
+const getChainId = builders
+  .getChainId()
+  .action(actions.getChainId(evmSafepal))
+  .build();
+
 const evm = new NamespaceBuilder<EvmActions>('EVM', WALLET_ID)
   .action(connect)
   .action(disconnect)
   .action(canSwitchNetwork)
+  .action(getChainId)
   .build();
 
 export { evm };

--- a/wallets/provider-trustwallet/src/namespaces/evm.ts
+++ b/wallets/provider-trustwallet/src/namespaces/evm.ts
@@ -39,10 +39,16 @@ const canSwitchNetwork = builders
   .action(actions.canSwitchNetwork())
   .build();
 
+const getChainId = builders
+  .getChainId()
+  .action(actions.getChainId(evmTrustWallet))
+  .build();
+
 const evm = new NamespaceBuilder<EvmActions>('EVM', WALLET_ID)
   .action(connect)
   .action(disconnect)
   .action(canSwitchNetwork)
+  .action(getChainId)
   .build();
 
 export { evm };

--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -1,5 +1,5 @@
 import type { AllProxiedNamespaces, ExtensionLink } from './types.js';
-import type { ProviderContext, Providers } from '../index.js';
+import type { ProviderContext } from '../index.js';
 import type { Provider } from '@rango-dev/wallets-core';
 import type { LegacyNamespaceInputForConnect } from '@rango-dev/wallets-core/legacy';
 import type {
@@ -25,7 +25,6 @@ import { createQueue, fromAccountIdToLegacyAddressFormat } from './helpers.js';
 import { LastConnectedWalletsFromStorage } from './lastConnectedWallets.js';
 import { useHubRefs } from './useHubRefs.js';
 import {
-  getLegacyProvider,
   getSupportedChainsFromProvider,
   isEvmNamespace,
   isSolanaNamespace,
@@ -444,18 +443,7 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
       };
     },
     providers() {
-      const output: Providers = {};
-
-      Array.from(getHub().getAll().keys()).forEach((id) => {
-        try {
-          const provider = getLegacyProvider(params.allVersionedProviders, id);
-          output[id] = provider.getInstance();
-        } catch (e) {
-          console.warn(e);
-        }
-      });
-
-      return output;
+      throw new Error('This method is not available on hub providers.');
     },
     state(type) {
       const hubState = getHub().state();

--- a/wallets/react/src/hub/utils.ts
+++ b/wallets/react/src/hub/utils.ts
@@ -275,29 +275,6 @@ export function getAllLegacyProviders(
   return legacyProviders;
 }
 
-export function getLegacyProvider(
-  allProviders: VersionedProviders[],
-  type: string
-): LegacyProviderInterface {
-  const legacyProviders: LegacyProviderInterface[] =
-    getAllLegacyProviders(allProviders);
-
-  const provider = legacyProviders.find((legacyProvider) => {
-    return legacyProvider.config.type === type;
-  });
-
-  if (!provider) {
-    console.warn(
-      `You have a provider that doesn't have legacy provider. It causes some problems since we need some legacy functionality. Provider Id: ${type}`
-    );
-    throw new Error(
-      `You need to have legacy implementation to use some methods. Provider Id: ${type}`
-    );
-  }
-
-  return provider;
-}
-
 /**
  * In legacy mode, for those who have switch network functionality (like evm), we are using an enum for network names
  * this enum only has meaning for us, and when we are going to connect an instance (e.g. window.ethereum) we should pass chain id.

--- a/wallets/react/src/useProviders.ts
+++ b/wallets/react/src/useProviders.ts
@@ -79,16 +79,9 @@ function useProviders(props: ProviderProps) {
 
       return legacyApi.getWalletInfo(type);
     },
+    // This method only returns the legacy providers.
     providers(): Providers {
-      let output: Providers = {};
-      if (hubProviders.length > 0) {
-        output = { ...output, ...hubApi.providers() };
-      }
-      if (legacyProviders.length > 0) {
-        output = { ...output, ...legacyApi.providers() };
-      }
-
-      return output;
+      return legacyApi.providers();
     },
     state(type): LegacyState {
       const hubProvider = findProviderByType(hubProviders, type);


### PR DESCRIPTION
# Summary

The last dependency to legacy Providers which was on `providers` method in api is removed.

## Key changes

- Removed returning legacy providers from `providers` method in `useHubAdapter`
- Added `getChainId` action to `evm` namespace and hub evm wallets
- Modified `@rango-dev/queue-manager-rango-preset` to get chain id for hub adapters directly from hub adapter itself instead of related legacy provider

Fixes # (issue)


# How did you test this change?

Tested by signing transactions on legacy and hub wallets on different chains.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
