### PR TITLE
fix: validate evm address for safepal connect

### DIFF
--- a/wallets/provider-safepal/readme.md
+++ b/wallets/provider-safepal/readme.md
@@ -14,6 +14,10 @@ The wallet also supports **TON, Sui, Tron, and Aptos**, but these namespaces are
 
 ### Feature
 
+#### ⚠️ Connect
+- SafePal Wallet sometimes returns **non-EVM addresses** (e.g., **Solana addresses**) during connect, which can incorrectly set invalid addresses for the EVM network.  
+- In such cases, the integration will **display an error** to prevent incorrect address usage.
+
 #### ⚠️ Switch Account
 - On **Solana**, switching accounts triggers a **full page reload**.
 - Since **auto-connect is not supported**, the wallet **does not reconnect automatically** after reload.

--- a/wallets/provider-safepal/src/utils.ts
+++ b/wallets/provider-safepal/src/utils.ts
@@ -1,6 +1,7 @@
 import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { isEvmAddress } from '@rango-dev/wallets-shared';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Provider = Record<string, any>;
@@ -35,4 +36,16 @@ export function getInstanceOrThrow(): Provider {
   }
 
   return instances;
+}
+/**
+ * Return true if address is a valid EVM address.
+ * Accepts:
+ *  - all-lowercase or all-uppercase 0x-prefixed hex (non-checksummed - allowed)
+ *  - checksummed (mixed-case according to EIP-55)
+ */
+export function isValidEvmAddress(address: string): boolean {
+  // Pick wallet address.
+  const walletAddress = address.split(':')[2];
+
+  return isEvmAddress(walletAddress);
 }


### PR DESCRIPTION
# Summary

SafePal wallet sometimes returns non-EVM addresses (e.g., Solana addresses) during connection, which incorrectly sets invalid addresses for the EVM network. This PR adds validation to check that all returned addresses are valid EVM addresses before completing the connection.

Fixes BUG-SafePal Connect Sets Solana Address for EVM

**Note:** This implementation must be kept in sync with `wallets/core/src/namespaces/evm/builders`

# How did you test this change?

- [x] Tested connection with SafePal account that has only Solana address - connection is now blocked with error message
- [x] Tested connection with SafePal account that has valid EVM address - connection works normally
- [x] Verified error message displays: "Non valid EVM address returned from wallet"

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.