### PR TITLE
fix: publish flow compile translations

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -23,3 +23,7 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       run: yarn install --frozen-lockfile
       shell: 'bash'
+    - name: Call prepare on cache hit
+      if: steps.cache.outputs.cache-hit != 'false'
+      run: yarn prepare
+      shell: 'bash'


### PR DESCRIPTION
# Summary

In the new flow, `yarn install` won't be run if cache hits to avoid reinstalling dependencies, but in this case, `yarn prepare` won't be run to compile translations, so in this PR, I will make sure `yarn i18n:compile` will be run before publishing.
Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
