### PR TITLE
hotfix: set vercel's enviroment correctly for deploy command

### DIFF
--- a/scripts/deploy/utils.mjs
+++ b/scripts/deploy/utils.mjs
@@ -65,7 +65,15 @@ export async function deploySingleProjectToVercel(pkg) {
 
   const vercelResult = await execa(
     'vercel',
-    [pkg.location, '--prebuilt', '--token', VERCEL_TOKEN],
+    [
+      'deploy',
+      pkg.location,
+      '--prebuilt',
+      '--token',
+      VERCEL_TOKEN,
+      '--target',
+      deployTo,
+    ],
     { env }
   )
     .then((result) => result.stdout)


### PR DESCRIPTION
# Summary

Vercel has changed its policy and don't let a deployment with `preview` environment to be promoted as prod.
This PR set the enviroment (using target flag) when we are deploying.

