### PR TITLE
feat: add fallback to the switch account builder

### DIFF
--- a/wallets/core/src/namespaces/common/hooks/changeAccountSubscriber.test.ts
+++ b/wallets/core/src/namespaces/common/hooks/changeAccountSubscriber.test.ts
@@ -99,22 +99,26 @@ describe('check changeAccountSubscriber', () => {
     });
   });
 
-  test('calls disconnect if event is not valid', () => {
-    const { context, disconnectAction } = setupNamespace();
+  test('wont update accounts if preventDefault called', async () => {
+    const { context } = setupNamespace();
     const spiedAddEventListener = vi.fn(garbageAddEventListener);
-
+    const [getState, setState] = context.state();
+    setState('accounts', ['Initial State']);
     builder
       .getInstance(() => garbageProvider)
       .format(garbageFormatter)
       .addEventListener(spiedAddEventListener)
-      .validateEventPayload((event) => !event)
+      .onSwitchAccount((event) => {
+        event.preventDefault();
+      })
       .removeEventListener(garbageRemoveEventListener);
 
     const [subscriber] = builder.build();
 
-    expect(disconnectAction).toHaveBeenCalledTimes(0);
     subscriber(context);
-    expect(disconnectAction).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(getState('accounts')?.[0]).toBe('Initial State');
+    });
   });
 
   test('calls removeEventListener', () => {

--- a/wallets/core/src/namespaces/solana/builders.ts
+++ b/wallets/core/src/namespaces/solana/builders.ts
@@ -21,14 +21,16 @@ export const connect = () =>
 export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
   new ChangeAccountSubscriberBuilder<string, ProviderAPI>()
     .getInstance(getInstance)
-    .validateEventPayload(
-      (accounts) =>
-        /*
-         * In some wallets, when a user switches to an account not yet connected to the dApp, it returns null.
-         * A null value indicates no access to the account, requiring a disconnect and user reconnection.
-         */
-        !!accounts
-    )
+    /*
+     * In some wallets, when a user switches to an account not yet connected to the dApp, it returns null.
+     * A null value indicates no access to the account, requiring a disconnect and user reconnection.
+     */
+    .onSwitchAccount((event, context) => {
+      if (!event.payload) {
+        context.action('disconnect');
+        event.preventDefault();
+      }
+    })
     .format(async (_, accounts) => formatAccountsToCAIP([accounts]))
     .addEventListener((instance, callback) => {
       instance.on('accountChanged', callback);

--- a/wallets/core/src/namespaces/sui/builders.ts
+++ b/wallets/core/src/namespaces/sui/builders.ts
@@ -59,15 +59,16 @@ export const changeAccountSubscriber = (
     ProviderAPI
   >()
     .getInstance(() => getInstanceOrThrow(params.name))
-    .validateEventPayload(
-      (event) =>
-        /*
-         * In some wallets, when a user switches to an account not yet connected to the dApp, it returns null.
-         * A null value indicates no access to the account, requiring a disconnect and user reconnection.
-         */
-
-        event.accounts?.length !== 0
-    )
+    /*
+     * In some wallets, when a user switches to an account not yet connected to the dApp, it returns null.
+     * A null value indicates no access to the account, requiring a disconnect and user reconnection.
+     */
+    .onSwitchAccount((event, context) => {
+      if (!event.payload.accounts?.length) {
+        context.action('disconnect');
+        event.preventDefault();
+      }
+    })
     .format(async (_, event) => formatAccountsToCAIP(event.accounts))
     .addEventListener((instance, callback) =>
       instance.features['standard:events'].on('change', callback)

--- a/wallets/provider-metamask/src/builders/solana.ts
+++ b/wallets/provider-metamask/src/builders/solana.ts
@@ -13,7 +13,12 @@ const changeAccountSubscriber = (
     WalletStandardSolanaInstance
   >()
     .getInstance(getInstance)
-    .validateEventPayload((accounts) => !!accounts.accounts?.length)
+    .onSwitchAccount((event, context) => {
+      if (!event.payload.accounts?.length) {
+        context.action('disconnect');
+        event.preventDefault();
+      }
+    })
     .format(async (_, event) =>
       utils.formatAccountsToCAIP(
         event.accounts!.map((account) => account.address)


### PR DESCRIPTION
# Summary

This PR updates the `ChangeAccountSubscriberBuilder` to support passing a fallback action alongside the validation result.
The fallback action allows consumers to define what should happen when the provided accounts are invalid. This makes the flow more flexible and configurable instead of always disconnecting, we can now choose whether to disconnect, ignore, or trigger a reconnect if needed.

This change improves extensibility and removes the previously hard-coded disconnect behavior.

Fixes #

# How did you test this change?

I added tests to verify that:

* The fallback action is executed when validation fails.

Tests performed:

* [x] Test A: Validate that fallback is called on invalid accounts

# Checklist:

* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision. (N/A if no UI changes)

