### PR TITLE
chore: update chore dependecies to the latest next

### DIFF
--- a/wallets/provider-all/package.json
+++ b/wallets/provider-all/package.json
@@ -56,7 +56,7 @@
     "@rango-dev/provider-unisat": "^0.8.1-next.1",
     "@rango-dev/provider-walletconnect-2": "^0.46.1-next.1",
     "@rango-dev/provider-xdefi": "^0.54.1-next.1",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-react": "^0.38.1-next.2",
     "@rango-dev/wallets-shared": "^0.52.1-next.1"
   },

--- a/wallets/provider-bitget/package.json
+++ b/wallets/provider-bitget/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-tron": "^0.39.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-brave/package.json
+++ b/wallets/provider-brave/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-clover/package.json
+++ b/wallets/provider-clover/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "bs58": "^5.0.0",
     "rango-types": "^0.1.89"

--- a/wallets/provider-coin98/package.json
+++ b/wallets/provider-coin98/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "@solana/web3.js": "^1.91.4",
     "bs58": "^5.0.0",

--- a/wallets/provider-coinbase/package.json
+++ b/wallets/provider-coinbase/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "bs58": "^5.0.0",
     "rango-types": "^0.1.89"

--- a/wallets/provider-cosmostation/package.json
+++ b/wallets/provider-cosmostation/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-cosmos": "^0.38.0",
     "@rango-dev/signer-evm": "^0.40.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-default/package.json
+++ b/wallets/provider-default/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-enkrypt/package.json
+++ b/wallets/provider-enkrypt/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-exodus/package.json
+++ b/wallets/provider-exodus/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "bs58": "^5.0.0",
     "rango-types": "^0.1.89"

--- a/wallets/provider-frontier/package.json
+++ b/wallets/provider-frontier/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-halo/package.json
+++ b/wallets/provider-halo/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-keplr/package.json
+++ b/wallets/provider-keplr/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/signer-cosmos": "^0.38.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-leap-cosmos/package.json
+++ b/wallets/provider-leap-cosmos/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/signer-cosmos": "^0.38.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-ledger/package.json
+++ b/wallets/provider-ledger/package.json
@@ -28,7 +28,7 @@
     "@ledgerhq/types-cryptoassets": "^7.11.0",
     "@ledgerhq/types-devices": "^6.24.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "@solana/web3.js": "^1.91.4",
     "@types/w3c-web-hid": "^1.0.2",

--- a/wallets/provider-math-wallet/package.json
+++ b/wallets/provider-math-wallet/package.json
@@ -24,7 +24,7 @@
     "@cosmjs/stargate": "^0.31.0",
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-metamask/package.json
+++ b/wallets/provider-metamask/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "@wallet-standard/app": "^1.1.0",
     "bs58": "^5.0.0",

--- a/wallets/provider-okx/package.json
+++ b/wallets/provider-okx/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-phantom/package.json
+++ b/wallets/provider-phantom/package.json
@@ -26,7 +26,7 @@
     "@mysten/wallet-standard": "^0.13.26",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
     "@rango-dev/signer-sui": "^0.8.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "bitcoinjs-lib": "^6.1.7",
     "rango-types": "^0.1.89"

--- a/wallets/provider-rabby/package.json
+++ b/wallets/provider-rabby/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-safe/package.json
+++ b/wallets/provider-safe/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "@safe-global/safe-apps-provider": "^0.17.0",
     "@safe-global/safe-apps-sdk": "^9.1.0",

--- a/wallets/provider-safepal/package.json
+++ b/wallets/provider-safepal/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-slush/package.json
+++ b/wallets/provider-slush/package.json
@@ -24,7 +24,7 @@
     "@mysten/sui": "^1.21.2",
     "@mysten/wallet-standard": "^0.13.26",
     "@rango-dev/signer-sui": "^0.8.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-taho/package.json
+++ b/wallets/provider-taho/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-tokenpocket/package.json
+++ b/wallets/provider-tokenpocket/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-tomo/package.json
+++ b/wallets/provider-tomo/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89"
   },

--- a/wallets/provider-trustwallet/package.json
+++ b/wallets/provider-trustwallet/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/signer-evm": "^0.40.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "bs58": "^5.0.0",
     "rango-types": "^0.1.89"

--- a/wallets/provider-unisat/package.json
+++ b/wallets/provider-unisat/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "bitcoinjs-lib": "^6.1.7",
     "rango-types": "^0.1.89"

--- a/wallets/provider-xdefi/package.json
+++ b/wallets/provider-xdefi/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-cosmos": "^0.38.0",
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "bs58": "^5.0.0",
     "rango-types": "^0.1.89"

--- a/wallets/react/package.json
+++ b/wallets/react/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "rango-types": "^0.1.89",
     "ts-results": "^3.3.0"

--- a/wallets/shared/package.json
+++ b/wallets/shared/package.json
@@ -27,7 +27,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "ethers": "^6.13.2",
     "rango-types": "^0.1.89"
   },

--- a/widget/embedded/package.json
+++ b/widget/embedded/package.json
@@ -31,7 +31,7 @@
     "@rango-dev/queue-manager-react": "^0.33.0",
     "@rango-dev/signer-solana": "^0.44.1-next.0",
     "@rango-dev/ui": "^0.55.1-next.1",
-    "@rango-dev/wallets-core": "^0.51.1-next.1",
+    "@rango-dev/wallets-core": "^0.52.1-next.0",
     "@rango-dev/wallets-react": "^0.38.1-next.2",
     "@rango-dev/wallets-shared": "^0.52.1-next.1",
     "bignumber.js": "^9.1.1",


### PR DESCRIPTION
# Summary

Due to a recent [npm security update](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/), publishing packages with classic tokens is no longer allowed. As a result, the core package has fallen behind and hasn't been updated automatically.

This PR manually updates the package to the latest version as a temporary measure, before we migrate to the new npm token/authentication system.

Fixes # (issue)


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
