### PR TITLE
chore: passing actions type to the subscriber builder

### DIFF
--- a/wallets/core/src/namespaces/common/hooks/changeAccountSubscriber.test.ts
+++ b/wallets/core/src/namespaces/common/hooks/changeAccountSubscriber.test.ts
@@ -1,3 +1,6 @@
+import type { Actions } from '../../../hub/namespaces/types.js';
+import type { AutoImplementedActionsByRecommended } from '../types.js';
+
 import { waitFor } from '@testing-library/dom';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -29,7 +32,11 @@ describe('check changeAccountSubscriber', () => {
     __: (event: string[]) => void
   ) => {};
 
-  let builder: ChangeAccountSubscriberBuilder<string[], typeof garbageProvider>;
+  let builder: ChangeAccountSubscriberBuilder<
+    string[],
+    typeof garbageProvider,
+    Actions<AutoImplementedActionsByRecommended>
+  >;
 
   const setupNamespace = () => {
     const actions = new Map();

--- a/wallets/core/src/namespaces/common/hooks/changeAccountSubscriber.ts
+++ b/wallets/core/src/namespaces/common/hooks/changeAccountSubscriber.ts
@@ -11,16 +11,18 @@ type OnSwitchAccountEvent<EventType> = {
   preventDefault: () => void;
 };
 
-export class ChangeAccountSubscriberBuilder<EventType, ProviderAPI> {
+export class ChangeAccountSubscriberBuilder<
+  EventType,
+  ProviderAPI,
+  ActionsType extends Actions<ActionsType> &
+    Actions<AutoImplementedActionsByRecommended>
+> {
   #getInstance: (() => ProviderAPI) | null = null;
   #format:
     | ((instance: ProviderAPI, event: EventType) => Promise<string[]>)
     | null = null;
   #onSwitchAccount:
-    | (<
-        ActionsType extends Actions<ActionsType> &
-          Actions<AutoImplementedActionsByRecommended>
-      >(
+    | ((
         event: OnSwitchAccountEvent<EventType>,
         context: Context<ActionsType>
       ) => void)
@@ -99,10 +101,7 @@ export class ChangeAccountSubscriberBuilder<EventType, ProviderAPI> {
    * ```
    */
   public onSwitchAccount(
-    operator: <
-      ActionsType extends Actions<ActionsType> &
-        Actions<AutoImplementedActionsByRecommended>
-    >(
+    operator: (
       event: OnSwitchAccountEvent<EventType>,
       context: Context<ActionsType>
     ) => void
@@ -152,10 +151,7 @@ export class ChangeAccountSubscriberBuilder<EventType, ProviderAPI> {
     this.#removeEventListener = operator;
     return this;
   }
-  public build<
-    ActionsType extends Actions<ActionsType> &
-      Actions<AutoImplementedActionsByRecommended>
-  >(): [Subscriber<ActionsType>, SubscriberCleanUp<ActionsType>] {
+  public build(): [Subscriber<ActionsType>, SubscriberCleanUp<ActionsType>] {
     if (this.#getInstance === null) {
       throw new Error(this.#getErrorMessage('getInstance'));
     }
@@ -197,7 +193,6 @@ export class ChangeAccountSubscriberBuilder<EventType, ProviderAPI> {
         }
         subscriber = async (event) => {
           let shouldProceedWithDefault = true;
-
           onSwitchAccount?.(
             {
               payload: event,

--- a/wallets/core/src/namespaces/evm/builders.ts
+++ b/wallets/core/src/namespaces/evm/builders.ts
@@ -24,7 +24,7 @@ export const canSwitchNetwork = () =>
 
 // Hooks
 export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
-  new ChangeAccountSubscriberBuilder<string[], ProviderAPI>()
+  new ChangeAccountSubscriberBuilder<string[], ProviderAPI, EvmActions>()
     .getInstance(getInstance)
     /*
      * In some wallets, when a user switches to an account not yet connected to the dApp, it returns null.

--- a/wallets/core/src/namespaces/solana/builders.ts
+++ b/wallets/core/src/namespaces/solana/builders.ts
@@ -19,7 +19,7 @@ export const connect = () =>
 
 // Hooks
 export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
-  new ChangeAccountSubscriberBuilder<string, ProviderAPI>()
+  new ChangeAccountSubscriberBuilder<string, ProviderAPI, SolanaActions>()
     .getInstance(getInstance)
     /*
      * In some wallets, when a user switches to an account not yet connected to the dApp, it returns null.

--- a/wallets/core/src/namespaces/sui/builders.ts
+++ b/wallets/core/src/namespaces/sui/builders.ts
@@ -56,7 +56,8 @@ export const changeAccountSubscriber = (
 ) =>
   new ChangeAccountSubscriberBuilder<
     { accounts: readonly WalletAccount[] },
-    ProviderAPI
+    ProviderAPI,
+    SuiActions
   >()
     .getInstance(() => getInstanceOrThrow(params.name))
     /*

--- a/wallets/provider-metamask/src/builders/solana.ts
+++ b/wallets/provider-metamask/src/builders/solana.ts
@@ -2,7 +2,10 @@ import type { WalletStandardSolanaInstance } from '../types.js';
 import type { StandardEventsChangeProperties } from '@wallet-standard/features';
 
 import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
-import { utils } from '@rango-dev/wallets-core/namespaces/solana';
+import {
+  type SolanaActions,
+  utils,
+} from '@rango-dev/wallets-core/namespaces/solana';
 
 // Hooks
 const changeAccountSubscriber = (
@@ -10,7 +13,8 @@ const changeAccountSubscriber = (
 ) =>
   new ChangeAccountSubscriberBuilder<
     StandardEventsChangeProperties,
-    WalletStandardSolanaInstance
+    WalletStandardSolanaInstance,
+    SolanaActions
   >()
     .getInstance(getInstance)
     .onSwitchAccount((event, context) => {

--- a/wallets/provider-okx/src/builders/utxo.ts
+++ b/wallets/provider-okx/src/builders/utxo.ts
@@ -9,7 +9,7 @@ import {
 } from '@rango-dev/wallets-core/namespaces/utxo';
 
 export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
-  new ChangeAccountSubscriberBuilder<OkxBtcAddress, ProviderAPI>()
+  new ChangeAccountSubscriberBuilder<OkxBtcAddress, ProviderAPI, UtxoActions>()
     .getInstance(getInstance)
     /*
      * Okx wallet may call the `changeAccount` event with `null` value

--- a/wallets/provider-xverse/src/builders/utxo.ts
+++ b/wallets/provider-xverse/src/builders/utxo.ts
@@ -11,7 +11,7 @@ import {
 import { XVERSE_ACCESS_DENIED_ERROR_CODE } from '../constants.js';
 
 export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
-  new ChangeAccountSubscriberBuilder<XVerseEvent, ProviderAPI>()
+  new ChangeAccountSubscriberBuilder<XVerseEvent, ProviderAPI, UtxoActions>()
     .getInstance(getInstance)
     /*
      * Xverse wallet may call the `changeAccount` event with `empty` value


### PR DESCRIPTION
# Summary

This PR introduces support for **passing action types to the SubscriberBuilder**, with a fallback to `AutoImplementedByDefault`.
The goal is to make the **context more strongly typed per namespace**, ensuring that each namespace exposes **only its specific action types**.

This improves type safety and developer experience by enabling consumers to call **all actions of a namespace** directly inside `onSwitchAccount`.

Additionally, this change preserves backward compatibility: when a namespace does not explicitly define an action type map, we gracefully fall back to `AutoImplementedByDefault`.

Fixes # (issue)

# How did you test this change?

To validate the change, I tested the updated typing behavior in multiple scenarios:

* Verifying that a namespace with custom action types exposes those types properly in the subscriber context.
* Verifying that a namespace without explicit action types continues to work using `AutoImplementedByDefault`.
* Ensuring `onSwitchAccount` receives a fully typed action map for each namespace.

Test cases:

* [x] Ensure typed namespace actions are accessible inside `onSwitchAccount`
* [x] Ensure fallback to `AutoImplementedByDefault` works when no custom action types are provided

# Checklist:

* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision (N/A)