### PR TITLE
feat: storing `connectArgs` to the namespace state

### DIFF
--- a/wallets/core/src/hub/store/namespaces.ts
+++ b/wallets/core/src/hub/store/namespaces.ts
@@ -21,6 +21,8 @@ export interface NamespaceData {
   network: null | string;
   connected: boolean;
   connecting: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  connectArgs: Record<string, any> | null;
 }
 
 interface NamespaceInfo {
@@ -73,6 +75,7 @@ const namespacesStore: NamespaceStateCreator = (set, get) => ({
       network: null,
       connected: false,
       connecting: false,
+      connectArgs: null,
     };
 
     const item = {

--- a/wallets/core/src/namespaces/common/actions.ts
+++ b/wallets/core/src/namespaces/common/actions.ts
@@ -6,6 +6,7 @@ export function disconnect(context: Context): void {
   setState('accounts', null);
   setState('connected', false);
   setState('connecting', false);
+  setState('connectArgs', null);
 }
 
 export const recommended = [['disconnect', disconnect] as const];

--- a/wallets/core/src/namespaces/evm/actions.ts
+++ b/wallets/core/src/namespaces/evm/actions.ts
@@ -17,7 +17,10 @@ export function connect(
   instance: () => ProviderAPI,
   options?: ConnectOptions
 ): FunctionWithContext<EvmActions['connect'], Context> {
-  return async (_context, chain) => {
+  return async (context, chain) => {
+    // Setting connect args to be used on other actions
+    const [, setState] = context.state();
+    setState('connectArgs', { chain });
     const evmInstance = instance();
 
     if (!evmInstance) {


### PR DESCRIPTION
# Summary

This PR introduces a **`connectArgs` state field for each namespace**, enabling actions within a namespace to access the most recent connection arguments.

Some actions occasionally require access to the latest `connectArgs`. Until now, those arguments were not persisted in namespace state, limiting what follow-up actions could reliably do.

This PR includes the following changes:

* Added `connectArgs` to the namespace state structure.
* Stored arguments whenever a `connect` action was called with additional args.
* Cleaned up the `connectArgs` field on **disconnect** in the common logic.
* Ensured all other actions within the namespace can now safely access the latest connection args.


Fixes # (issue)

# How did you test this change?

Testing included validating that `connectArgs` is correctly stored, retrieved, and cleared:

* Ensured `connectArgs` is set when calling connect actions with custom arguments.

* Ensured other actions in the namespace can access the most recent `connectArgs`.

* Ensured disconnect logic removes the stored arguments without side effects.


# Checklist:

* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision (N/A)
