### PR TITLE
feat: add cosmos namespace to the hub

### DIFF
--- a/wallets/core/src/namespaces/cosmos/actions.ts
+++ b/wallets/core/src/namespaces/cosmos/actions.ts
@@ -1,0 +1,3 @@
+import { recommended as commonRecommended } from '../common/actions.js';
+
+export const recommended = [...commonRecommended];

--- a/wallets/core/src/namespaces/cosmos/after.ts
+++ b/wallets/core/src/namespaces/cosmos/after.ts
@@ -1,0 +1,3 @@
+import { recommended as commonRecommended } from '../common/after.js';
+
+export const recommended = [...commonRecommended];

--- a/wallets/core/src/namespaces/cosmos/and.ts
+++ b/wallets/core/src/namespaces/cosmos/and.ts
@@ -1,0 +1,5 @@
+import { connectAndUpdateStateForMultiNetworks } from '../common/mod.js';
+
+export const recommended = [
+  ['connect', connectAndUpdateStateForMultiNetworks] as const,
+];

--- a/wallets/core/src/namespaces/cosmos/before.ts
+++ b/wallets/core/src/namespaces/cosmos/before.ts
@@ -1,0 +1,3 @@
+import { beforeRecommended } from '../common/mod.js';
+
+export const recommended = [...beforeRecommended];

--- a/wallets/core/src/namespaces/cosmos/builders.ts
+++ b/wallets/core/src/namespaces/cosmos/builders.ts
@@ -1,0 +1,15 @@
+import type { CosmosActions } from './types.js';
+
+import { ActionBuilder } from '../../mod.js';
+import {
+  connectAndUpdateStateForSingleNetwork,
+  intoConnecting,
+  intoConnectionFinished,
+} from '../common/mod.js';
+
+// Actions
+export const connect = () =>
+  new ActionBuilder<CosmosActions, 'connect'>('connect')
+    .and(connectAndUpdateStateForSingleNetwork)
+    .before(intoConnecting)
+    .after(intoConnectionFinished);

--- a/wallets/core/src/namespaces/cosmos/constants.ts
+++ b/wallets/core/src/namespaces/cosmos/constants.ts
@@ -1,0 +1,1 @@
+export const CAIP_NAMESPACE = 'cosmos';

--- a/wallets/core/src/namespaces/cosmos/mod.ts
+++ b/wallets/core/src/namespaces/cosmos/mod.ts
@@ -1,1 +1,9 @@
 export type { CosmosActions, ProviderAPI } from './types.js';
+export * as actions from './actions.js';
+export * as after from './after.js';
+export * as and from './and.js';
+export * as before from './before.js';
+export * as utils from './utils.js';
+export * as builders from './builders.js';
+
+export { CAIP_NAMESPACE } from './constants.js';

--- a/wallets/core/src/namespaces/cosmos/types.ts
+++ b/wallets/core/src/namespaces/cosmos/types.ts
@@ -1,3 +1,4 @@
+import type { Accounts } from '../common/mod.js';
 import type {
   AutoImplementedActionsByRecommended,
   CommonActions,
@@ -6,10 +7,20 @@ import type {
 export interface CosmosActions
   extends AutoImplementedActionsByRecommended,
     CommonActions {
-  // TODO
-  connect: () => Promise<string>;
+  connect: (options?: ConnectOptions) => Promise<Accounts>;
   canEagerConnect: () => Promise<boolean>;
 }
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ProviderAPI = Record<string, any>;
+export type CosmosChainAccounts = {
+  accounts: string[];
+  chainId: string;
+};
+
+export type ConnectOptions = {
+  chainIds: string[];
+  /**
+   * For chains that may not be natively supported by the provider.
+   */
+  customChainIds?: string[];
+};

--- a/wallets/core/src/namespaces/cosmos/utils.ts
+++ b/wallets/core/src/namespaces/cosmos/utils.ts
@@ -1,0 +1,21 @@
+import type { CosmosChainAccounts } from './types.js';
+import type { CaipAccount } from '../common/mod.js';
+
+import { AccountId } from 'caip';
+
+import { CAIP_NAMESPACE } from './constants.js';
+
+export function formatAccountsToCAIP(accounts: CosmosChainAccounts[]) {
+  return accounts.flatMap((networkAccounts) =>
+    networkAccounts.accounts.map(
+      (networkAccount) =>
+        AccountId.format({
+          address: networkAccount,
+          chainId: {
+            namespace: CAIP_NAMESPACE,
+            reference: networkAccounts.chainId,
+          },
+        }) as CaipAccount
+    )
+  );
+}

--- a/wallets/react/src/hub/helpers.ts
+++ b/wallets/react/src/hub/helpers.ts
@@ -3,16 +3,20 @@ import type {
   Accounts,
   AccountsWithActiveChain,
 } from '@rango-dev/wallets-core/namespaces/common';
+import type { BlockchainMeta } from 'rango-types';
 import type { Result } from 'ts-results';
 
 import { legacyFormatAddressWithNetwork as formatAddressWithNetwork } from '@rango-dev/wallets-core/legacy';
+import { CAIP_NAMESPACE as CAIP_COSMOS_NAMESPACE } from '@rango-dev/wallets-core/namespaces/cosmos';
 import { CAIP_TRON_CHAIN_ID } from '@rango-dev/wallets-core/namespaces/tron';
 import { CAIP_BITCOIN_CHAIN_ID } from '@rango-dev/wallets-core/namespaces/utxo';
 import { CAIP } from '@rango-dev/wallets-core/utils';
+import { getBlockChainNameFromId } from '@rango-dev/wallets-shared';
 import { Err, Ok } from 'ts-results';
 
 export function mapCaipNamespaceToLegacyNetworkName(
-  chainId: CAIP.ChainIdParams | string
+  chainId: CAIP.ChainIdParams | string,
+  allBlockChains: BlockchainMeta[]
 ): string {
   if (typeof chainId === 'string') {
     return chainId;
@@ -29,6 +33,15 @@ export function mapCaipNamespaceToLegacyNetworkName(
     return 'BTC';
   }
 
+  if (chainId.namespace.toLowerCase() === CAIP_COSMOS_NAMESPACE) {
+    const network = getBlockChainNameFromId(chainId.reference, allBlockChains);
+    if (!network) {
+      throw new Error(
+        `Network didn't found for given chainId: ${chainId.reference}`
+      );
+    }
+    return network;
+  }
   if (chainId.namespace === 'sui' || chainId.reference === CAIP_TRON_CHAIN_ID) {
     return chainId.reference.toUpperCase();
   }
@@ -43,9 +56,12 @@ export function mapCaipNamespaceToLegacyNetworkName(
  *
  * @see https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md
  */
-export function fromAccountIdToLegacyAddressFormat(account: string): string {
+export function fromAccountIdToLegacyAddressFormat(
+  account: string,
+  allBlockChains: BlockchainMeta[]
+): string {
   const { chainId, address } = CAIP.AccountId.parse(account);
-  const network = mapCaipNamespaceToLegacyNetworkName(chainId);
+  const network = mapCaipNamespaceToLegacyNetworkName(chainId, allBlockChains);
   return formatAddressWithNetwork(address, network);
 }
 

--- a/wallets/react/src/hub/utils.ts
+++ b/wallets/react/src/hub/utils.ts
@@ -236,8 +236,11 @@ export function mapHubEventsToLegacy(
           );
         }
 
-        const formattedAddresses = event.accounts.map(
-          fromAccountIdToLegacyAddressFormat
+        const formattedAddresses = event.accounts.map((accounts) =>
+          fromAccountIdToLegacyAddressFormat(
+            accounts,
+            metadata.allBlockChains || []
+          )
         );
         onUpdateState(
           event.provider,
@@ -380,4 +383,11 @@ export function isEvmNamespace(
   >
 ): ns is ProxiedNamespace<EvmActions> & { namespaceId: 'EVM' } {
   return ns.namespaceId === 'EVM';
+}
+export function isCosmosNamespace(
+  ns: ProxiedNamespace<
+    EvmActions | SolanaActions | CosmosActions | SuiActions | UtxoActions
+  >
+): ns is ProxiedNamespace<CosmosActions> & { namespaceId: 'Cosmos' } {
+  return ns.namespaceId === 'Cosmos';
 }


### PR DESCRIPTION
# Summary

I've reviewed several providers and SDKs, and after checking how we implemented our legacy code, the final approach is essentially a combination of all of them. This makes the current solution the most efficient way to handle the connection flow.

I also removed `network` from the `connect` method because it had different meanings for EVM and Cosmos accounts. Since we now always run the suggestion flow before attempting to connect, having a suggestion step inside `connect` itself is no longer meaningful. In `connect`, I simply retrieve the addresses for both the experimental and main chains. Once the chain has been successfully suggested and added, we can obtain its address without needing an additional `network` parameter.

Additionally, in practice the `network` value was always `cosmos` rather than the actual `chainId`, so it wasn’t providing any useful functionality.

fixes # (issue)

# How did you test this change?

I tested connecting, suggesting chains, and retrieving addresses from suggested chains, and everything worked as expected.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
