### PR TITLE
feat: implement suggest action for hub

### DIFF
--- a/wallets/core/package.json
+++ b/wallets/core/package.json
@@ -80,7 +80,8 @@
     "caip": "^1.1.1",
     "immer": "^10.0.4",
     "rango-types": "^0.1.89",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "@chain-registry/types": "2.0.110"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/core/src/namespaces/cosmos/mod.ts
+++ b/wallets/core/src/namespaces/cosmos/mod.ts
@@ -1,4 +1,10 @@
-export type { CosmosActions, ProviderAPI } from './types.js';
+export type {
+  CosmosActions,
+  ProviderAPI,
+  CosmosChain,
+  CosmosAssetList,
+  CosmosChainAccounts,
+} from './types.js';
 export * as actions from './actions.js';
 export * as after from './after.js';
 export * as and from './and.js';

--- a/wallets/core/src/namespaces/cosmos/types.ts
+++ b/wallets/core/src/namespaces/cosmos/types.ts
@@ -4,12 +4,18 @@ import type {
   CommonActions,
 } from '../common/types.js';
 
+import { type AssetList, type Chain } from '@chain-registry/types';
+
+export type CosmosChain = Chain;
+export type CosmosAssetList = AssetList;
 export interface CosmosActions
   extends AutoImplementedActionsByRecommended,
     CommonActions {
   connect: (options?: ConnectOptions) => Promise<Accounts>;
+  suggest: (chain: CosmosChain, assetList: AssetList) => Promise<void>;
   canEagerConnect: () => Promise<boolean>;
 }
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ProviderAPI = Record<string, any>;
 export type CosmosChainAccounts = {

--- a/wallets/react/package.json
+++ b/wallets/react/package.json
@@ -42,7 +42,8 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.25",
-    "@types/react-dom": "^18.0.25"
+    "@types/react-dom": "^18.0.25",
+    "@chain-registry/types": "2.0.110"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/react/src/hub/chainRegisteryConvertors.ts
+++ b/wallets/react/src/hub/chainRegisteryConvertors.ts
@@ -1,0 +1,184 @@
+import type {
+  Asset,
+  Explorer,
+  FeeToken,
+  StakingToken,
+} from '@chain-registry/types';
+import type {
+  CosmosAssetList,
+  CosmosChain,
+} from '@rango-dev/wallets-core/namespaces/cosmos';
+import type { CosmosBlockchainMeta, CosmosChainInfo } from 'rango-types';
+
+export interface ConversionResult {
+  chain: CosmosChain;
+  assetList: CosmosAssetList;
+}
+
+/**
+ * Converts CosmosBlockchainMeta to Chain and AssetList formats
+ */
+export function convertCosmosMetaToChainRegistry(
+  meta: CosmosBlockchainMeta
+): ConversionResult {
+  const info = meta.info;
+
+  if (!info) {
+    throw new Error('CosmosChainInfo is required for conversion');
+  }
+
+  const chain = convertToChain(meta, info);
+  const assetList = convertToAssetList(info);
+
+  return { chain, assetList };
+}
+
+function convertToChain(
+  meta: CosmosBlockchainMeta,
+  info: CosmosChainInfo
+): CosmosChain {
+  const chain: CosmosChain = {
+    chainName: info.chainName,
+    chainType: 'cosmos',
+    chainId: meta.chainId || undefined,
+    prettyName: meta.displayName,
+    status: meta.enabled ? 'live' : 'killed',
+    networkType: 'mainnet',
+    bech32Prefix: info.bech32Config.bech32PrefixAccAddr,
+    bech32Config: {
+      bech32PrefixAccAddr: info.bech32Config.bech32PrefixAccAddr,
+      bech32PrefixAccPub: info.bech32Config.bech32PrefixAccPub,
+      bech32PrefixValAddr: info.bech32Config.bech32PrefixValAddr,
+      bech32PrefixValPub: info.bech32Config.bech32PrefixValPub,
+      bech32PrefixConsAddr: info.bech32Config.bech32PrefixConsAddr,
+      bech32PrefixConsPub: info.bech32Config.bech32PrefixConsPub,
+    },
+    slip44: info.bip44.coinType,
+    fees: {
+      feeTokens: convertFeeTokens(info),
+    },
+    staking: {
+      stakingTokens: convertStakingTokens(info),
+    },
+    apis: {
+      rpc: info.rpc ? [{ address: info.rpc }] : undefined,
+      rest: info.rest ? [{ address: info.rest }] : undefined,
+    },
+    explorers: convertExplorers(info),
+    logoURIs: meta.logo ? { png: meta.logo } : undefined,
+    keywords: info.experimental ? ['experimental'] : undefined,
+  };
+
+  return chain;
+}
+
+function convertFeeTokens(info: CosmosChainInfo): FeeToken[] {
+  return info.feeCurrencies.map((currency) => {
+    const feeToken: FeeToken = {
+      denom: currency.coinMinimalDenom,
+    };
+
+    if (info.gasPriceStep) {
+      feeToken.lowGasPrice = info.gasPriceStep.low;
+      feeToken.averageGasPrice = info.gasPriceStep.average;
+      feeToken.highGasPrice = info.gasPriceStep.high;
+    }
+
+    return feeToken;
+  });
+}
+
+function convertStakingTokens(info: CosmosChainInfo): StakingToken[] {
+  return [
+    {
+      denom: info.stakeCurrency.coinMinimalDenom,
+    },
+  ];
+}
+
+function convertExplorers(info: CosmosChainInfo): Explorer[] | undefined {
+  const explorers: Explorer[] = [];
+
+  if (info.explorerUrlToTx) {
+    const baseUrl = info.explorerUrlToTx.split('/tx/')[0];
+    explorers.push({
+      url: baseUrl,
+      txPage: info.explorerUrlToTx.replace(
+        /\{txHash\}|\$\{txHash\}/g,
+        '${txHash}'
+      ),
+    });
+  }
+
+  if (info.blockExplorerUrls && info.blockExplorerUrls.length > 0) {
+    info.blockExplorerUrls.forEach((url) => {
+      if (!explorers.some((e) => e.url === url)) {
+        explorers.push({ url });
+      }
+    });
+  }
+
+  return explorers.length > 0 ? explorers : undefined;
+}
+
+function convertToAssetList(info: CosmosChainInfo): CosmosAssetList {
+  const assets: Asset[] = [];
+
+  // Add staking currency
+  assets.push({
+    denomUnits: [
+      {
+        denom: info.stakeCurrency.coinMinimalDenom,
+        exponent: 0,
+      },
+      {
+        denom: info.stakeCurrency.coinDenom.toLowerCase(),
+        exponent: info.stakeCurrency.coinDecimals,
+      },
+    ],
+    base: info.stakeCurrency.coinMinimalDenom,
+    name: info.stakeCurrency.coinDenom,
+    display: info.stakeCurrency.coinDenom.toLowerCase(),
+    symbol: info.stakeCurrency.coinDenom,
+    typeAsset: 'sdk.coin',
+    logoURIs: info.stakeCurrency.coinImageUrl
+      ? { png: info.stakeCurrency.coinImageUrl }
+      : undefined,
+    coingeckoId: info.stakeCurrency.coinGeckoId || undefined,
+  });
+
+  // Add other currencies
+  info.currencies.forEach((currency) => {
+    // Skip if already added as staking currency
+    if (currency.coinMinimalDenom === info.stakeCurrency.coinMinimalDenom) {
+      return;
+    }
+
+    assets.push({
+      denomUnits: [
+        {
+          denom: currency.coinMinimalDenom,
+          exponent: 0,
+        },
+        {
+          denom: currency.coinDenom.toLowerCase(),
+          exponent: currency.coinDecimals,
+        },
+      ],
+      base: currency.coinMinimalDenom,
+      name: currency.coinDenom,
+      display: currency.coinDenom.toLowerCase(),
+      symbol: currency.coinDenom,
+      typeAsset: 'sdk.coin',
+      logoURIs: currency.coinImageUrl
+        ? { png: currency.coinImageUrl }
+        : undefined,
+      coingeckoId: currency.coinGeckoId || undefined,
+    });
+  });
+
+  return {
+    chainName: info.chainName,
+    assets,
+  };
+}

--- a/wallets/react/src/legacy/types.ts
+++ b/wallets/react/src/legacy/types.ts
@@ -66,7 +66,10 @@ export type ProviderContext = {
   providers(): Providers;
   getSigners(type: WalletType): Promise<SignerFactory>;
   getWalletInfo(type: WalletType): ExtendedWalletInfo;
-  suggestAndConnect(type: WalletType, network: Network): Promise<ConnectResult>;
+  suggestAndConnect(
+    type: WalletType,
+    namespace: LegacyNamespaceInputForConnect
+  ): Promise<ConnectResult>;
   hubProvider(type: WalletType): Provider;
 };
 

--- a/wallets/react/src/legacy/useLegacyProviders.ts
+++ b/wallets/react/src/legacy/useLegacyProviders.ts
@@ -111,13 +111,16 @@ export function useLegacyProviders(
       return await Promise.allSettled(disconnect_promises);
     },
 
-    async suggestAndConnect(type, network) {
+    async suggestAndConnect(type, namespace) {
       const wallet = wallets.get(type);
       if (!wallet) {
         throw new Error(`You should add ${type} to provider first.`);
       }
       const walletInstance = getWalletInstance(wallet);
-      const result = await walletInstance.suggestAndConnect(network);
+      if (!namespace.network) {
+        throw new Error(`You should pass network to the suggestAndConnect`);
+      }
+      const result = await walletInstance.suggestAndConnect(namespace.network);
 
       return result;
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2059,6 +2059,11 @@
   dependencies:
     "@noble/curves" "^1.7.0"
 
+"@chain-registry/types@2.0.110":
+  version "2.0.110"
+  resolved "https://registry.yarnpkg.com/@chain-registry/types/-/types-2.0.110.tgz#c113443c72e92173d9ce0597a73c938b6d7585c7"
+  integrity sha512-Y84yCxbJzeMTejYCiqTkHXbEOPHHBZurI9g++Sy8QF1TLyw4CJ0rgpCso35EhqaQiLpIabivWx+qXd0Y8biqEw==
+
 "@chromatic-com/storybook@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@chromatic-com/storybook/-/storybook-1.3.3.tgz#102d173d7e67cbc7f974648eaa459aa3d3d53f91"


### PR DESCRIPTION
# Summary

This PR implements **suggest action support for the Hub** and updates several related components to ensure consistent namespace handling across the system.

### Key changes:

* Added `suggest` action support to the Hub.
* Updated the **legacy version** to correctly accept and propagate the `namespace` parameter.
* Updated the **widget** to pass `namespace` along.
* Adjusted widget logic:
  Previously, because our Hub did not support `suggest`, the widget bypassed suggestion checks.
  Now that `suggest` is available, the widget has been updated to verify whether a suggestion is required. If so, it **prevents the connection process from proceeding** until the suggestion step is completed.

Fixes # (issue)

---

# How did you test this change?

* Verified that the Hub correctly receives and handles the new `suggest` action.
* Tested widget flows with:
  * scenarios where suggestions are required
  * scenarios where they are not

### Tests

* [ ] Test A
* [ ] Test B

---

# Checklist:

* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
