### PR TITLE
chore: accept get accounts on evm connect

### DIFF
--- a/wallets/core/src/namespaces/evm/actions.ts
+++ b/wallets/core/src/namespaces/evm/actions.ts
@@ -1,4 +1,9 @@
-import type { ConnectOptions, EvmActions, ProviderAPI } from './types.js';
+import type {
+  ConnectOptions,
+  EvmActions,
+  ProviderAccounts,
+  ProviderAPI,
+} from './types.js';
 import type { Context } from '../../hub/namespaces/mod.js';
 import type { CanEagerConnect } from '../../hub/namespaces/types.js';
 import type { FunctionWithContext } from '../../types/actions.js';
@@ -43,7 +48,17 @@ export function connect(
       }
     }
 
-    const providerAccounts = await getAccounts(evmInstance);
+    let providerAccounts: ProviderAccounts;
+    /*
+     * The `getAccounts` function can be optionally provided through `options`
+     * to handle getting address and chainId of the specific wallet provider.
+     * This approach is necessary because not all providers follow the same conventions.
+     */
+    if (options?.getAccounts) {
+      providerAccounts = await options.getAccounts(evmInstance);
+    } else {
+      providerAccounts = await getAccounts(evmInstance);
+    }
 
     /*
      * Ensure that the provider returns at least one valid account before proceeding.

--- a/wallets/core/src/namespaces/evm/types.ts
+++ b/wallets/core/src/namespaces/evm/types.ts
@@ -26,8 +26,12 @@ export type ProviderAPI = EIP1193Provider;
 // A 0x-prefixed hexadecimal string
 export type ChainId = string;
 export type Chain = AddEthereumChainParameter;
-
+export type ProviderAccounts = {
+  accounts: string[];
+  chainId: ChainId;
+};
 export type ConnectOptions = {
   switchOrAddNetwork?: (instance: ProviderAPI, chain: ChainId | Chain) => void;
+  getAccounts?: (provider: ProviderAPI) => Promise<ProviderAccounts>;
   derivationPath?: string;
 };


### PR DESCRIPTION
# Summary

Changed default EVM connect to accept `getAccounts` for providers that may have different flows for getting accounts.

Fixes # (issue)


# How did you test this change?



- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
