### PR TITLE
fix: fix wrong export for Networks from widget-embedded

### DIFF
--- a/widget/embedded/src/index.ts
+++ b/widget/embedded/src/index.ts
@@ -37,6 +37,7 @@ import type {
 } from '@rango-dev/queue-manager-rango-preset';
 import type {
   LegacyEventHandler as HandleWalletsUpdate,
+  LegacyNetworks as Networks,
   LegacyProviderInterface as ProviderInterface,
 } from '@rango-dev/wallets-core/legacy';
 import type {
@@ -55,7 +56,7 @@ import {
 } from '@rango-dev/queue-manager-rango-preset';
 import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/wallets-core/legacy';
 import { useWallets, Events as WalletEvents } from '@rango-dev/wallets-react';
-import { Networks, WalletTypes } from '@rango-dev/wallets-shared';
+import { WalletTypes } from '@rango-dev/wallets-shared';
 import { PendingSwapNetworkStatus } from 'rango-types';
 
 import {


### PR DESCRIPTION
# Summary

Currently, `Networks` is getting exported from `@rango-dev/widget-embedded` which is imported from '@rango-dev/wallets-shared' by mistake. Changed it to import from '@rango-dev/wallets-core/legacy'.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
