### PR TITLE
chore: fix cosmos logo in cosmostation wallet

### DIFF
--- a/wallets/provider-cosmostation/src/constants.ts
+++ b/wallets/provider-cosmostation/src/constants.ts
@@ -36,7 +36,7 @@ export const metadata: ProviderMetadata = {
           {
             label: 'Cosmos',
             value: 'Cosmos',
-            id: 'Cosmos',
+            id: 'COSMOS',
             getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
               cosmosBlockchains(allBlockchains),
           },


### PR DESCRIPTION
# Summary

Blockchain ID should be uppercase. I changed the blockchain ID in Cosmostation to uppercase.



# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
