### PR TITLE
fix: address getting for cosmos chains with null info

### DIFF
--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -265,7 +265,7 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
             connectNamespacePromise = async () => {
               return namespace.connect({
                 chainIds: cosmosBlockChains
-                  .filter((chain) => chain.info && !chain.info.experimental)
+                  .filter((chain) => !chain.info || !chain.info.experimental)
                   ?.map((chain) => chain.chainId!),
                 customChainIds: cosmosBlockChains
                   .filter((chain) => chain.info?.experimental)


### PR DESCRIPTION
# Summary

This PR fixes an issue where users were unable to generate addresses for certain Cosmos chains (e.g. Rune) when using wallets like Cosmostation, Keplr, and Leap.

The problem was caused by the experimental-chain detection logic. We were first checking for the existence of `chain.info`, and then reading `info.experimental`. For some chains, `info` can be `null`, which caused them to be incorrectly treated as experimental and blocked from address generation.

This change updates the logic to **assume chains with `info === null` are non-experimental**, and only treat a chain as experimental when `info.experimental === true`.

Fixes # (issue)

---

# How did you test this change?

* Verified address generation for chains with `info === null` (e.g. Rune)
* Confirmed existing behavior remains unchanged for chains explicitly marked as experimental
* Tested wallet integrations with Cosmostation, Keplr, and Leap to ensure addresses are returned correctly


# Checklist:

* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision

---

If you want, I can also:

* Make this **more formal or more concise**
* Align it with your team’s usual PR tone
* Add a **small code snippet** to the summary for extra clarity
