### PR TITLE
chore: upgrade rango-types to 0.1.93

### DIFF
--- a/queue-manager/queue-manager-demo/package.json
+++ b/queue-manager/queue-manager-demo/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "process": "^0.11.10",
-    "rango-sdk": "^0.1.70"
+    "rango-sdk": "^0.1.72"
   },
   "dependencies": {
     "@rango-dev/provider-all": "^0.60.1-next.3",
@@ -27,7 +27,7 @@
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "bignumber.js": "^9.1.1",
     "ethers": "^6.13.2",
-    "rango-sdk-basic": "^0.1.70",
+    "rango-sdk-basic": "^0.1.72",
     "rango-types": "^0.1.93"
   }
 }

--- a/queue-manager/queue-manager-demo/package.json
+++ b/queue-manager/queue-manager-demo/package.json
@@ -28,6 +28,6 @@
     "bignumber.js": "^9.1.1",
     "ethers": "^6.13.2",
     "rango-sdk-basic": "^0.1.70",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   }
 }

--- a/queue-manager/rango-preset/package.json
+++ b/queue-manager/rango-preset/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@rango-dev/logging-core": "^0.12.1",
-    "rango-types": "^0.1.89",
+    "rango-types": "^0.1.93",
     "ts-results": "^3.3.0",
     "uuid": "^9.0.0"
   },

--- a/signers/signer-cosmos/package.json
+++ b/signers/signer-cosmos/package.json
@@ -26,7 +26,7 @@
     "@keplr-wallet/cosmos": "^0.9.12",
     "cosmjs-types": "^0.5.2",
     "long": "^5.2.3",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "devDependencies": {
     "@keplr-wallet/types": "^0.9.12"

--- a/signers/signer-evm/package.json
+++ b/signers/signer-evm/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "ethers": "^6.13.2",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/signers/signer-solana/package.json
+++ b/signers/signer-solana/package.json
@@ -24,7 +24,7 @@
     "@solana/web3.js": "^1.91.4",
     "bs58": "^5.0.0",
     "promise-retry": "^2.0.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "devDependencies": {
     "@types/promise-retry": "^1.1.6"

--- a/signers/signer-starknet/package.json
+++ b/signers/signer-starknet/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/signers/signer-sui/package.json
+++ b/signers/signer-sui/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "devDependencies": {
     "@mysten/sui": "^1.21.2",

--- a/signers/signer-ton/package.json
+++ b/signers/signer-ton/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "peerDependencies": {
     "@ton/core": ">=0.59.0",

--- a/signers/signer-tron/package.json
+++ b/signers/signer-tron/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/core/package.json
+++ b/wallets/core/package.json
@@ -85,7 +85,7 @@
     "@chain-registry/types": "2.0.110",
     "caip": "^1.1.1",
     "immer": "^10.0.4",
-    "rango-types": "^0.1.89",
+    "rango-types": "^0.1.93",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/wallets/provider-binance/package.json
+++ b/wallets/provider-binance/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-bitget/package.json
+++ b/wallets/provider-bitget/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-tron": "^0.39.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-braavos/package.json
+++ b/wallets/provider-braavos/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-starknet": "^0.40.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-brave/package.json
+++ b/wallets/provider-brave/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-solana": "^0.46.1",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-coin98/package.json
+++ b/wallets/provider-coin98/package.json
@@ -27,7 +27,7 @@
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "@solana/web3.js": "^1.91.4",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-coinbase/package.json
+++ b/wallets/provider-coinbase/package.json
@@ -26,7 +26,7 @@
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-cosmostation/package.json
+++ b/wallets/provider-cosmostation/package.json
@@ -26,7 +26,7 @@
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-default/package.json
+++ b/wallets/provider-default/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-enkrypt/package.json
+++ b/wallets/provider-enkrypt/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-exodus/package.json
+++ b/wallets/provider-exodus/package.json
@@ -26,7 +26,7 @@
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-keplr/package.json
+++ b/wallets/provider-keplr/package.json
@@ -32,7 +32,7 @@
     "@rango-dev/signer-cosmos": "^0.38.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "devDependencies": {
     "@keplr-wallet/types": "^0.11.21"

--- a/wallets/provider-leap-cosmos/package.json
+++ b/wallets/provider-leap-cosmos/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-cosmos": "^0.38.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-ledger/package.json
+++ b/wallets/provider-ledger/package.json
@@ -34,7 +34,7 @@
     "@types/w3c-web-hid": "^1.0.2",
     "bs58": "^5.0.0",
     "ethers": "^6.13.2",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-math-wallet/package.json
+++ b/wallets/provider-math-wallet/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-solana": "^0.46.1",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-metamask/package.json
+++ b/wallets/provider-metamask/package.json
@@ -27,7 +27,7 @@
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "@wallet-standard/app": "^1.1.0",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "devDependencies": {
     "@solana/wallet-standard-features": "^1.3.0",

--- a/wallets/provider-okx/package.json
+++ b/wallets/provider-okx/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-solana": "^0.46.1",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-phantom/package.json
+++ b/wallets/provider-phantom/package.json
@@ -29,7 +29,7 @@
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "bitcoinjs-lib": "^6.1.7",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-rabby/package.json
+++ b/wallets/provider-rabby/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-ready/package.json
+++ b/wallets/provider-ready/package.json
@@ -20,7 +20,7 @@
     "@rango-dev/signer-starknet": "^0.40.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-safe/package.json
+++ b/wallets/provider-safe/package.json
@@ -27,7 +27,7 @@
     "@safe-global/safe-apps-provider": "^0.17.0",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "ethers": "^6.13.2",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-safepal/package.json
+++ b/wallets/provider-safepal/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-solana": "^0.46.1",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-slush/package.json
+++ b/wallets/provider-slush/package.json
@@ -26,7 +26,7 @@
     "@rango-dev/signer-sui": "^0.8.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-solflare/package.json
+++ b/wallets/provider-solflare/package.json
@@ -26,7 +26,7 @@
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "@solana/web3.js": "^1.91.4",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-taho/package.json
+++ b/wallets/provider-taho/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-tokenpocket/package.json
+++ b/wallets/provider-tokenpocket/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-tomo/package.json
+++ b/wallets/provider-tomo/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.40.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-tonconnect/package.json
+++ b/wallets/provider-tonconnect/package.json
@@ -28,7 +28,7 @@
     "@ton/core": "^0.59.0",
     "@ton/crypto": "^3.3.0",
     "@tonconnect/ui": "^2.0.9",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-trezor/package.json
+++ b/wallets/provider-trezor/package.json
@@ -28,7 +28,7 @@
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "@trezor/connect-web": "^9.5.0",
     "ethers": "^6.13.2",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-tron-link/package.json
+++ b/wallets/provider-tron-link/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-tron": "^0.39.0",
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.92"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-trustwallet/package.json
+++ b/wallets/provider-trustwallet/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-unisat/package.json
+++ b/wallets/provider-unisat/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "bitcoinjs-lib": "^6.1.7",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-walletconnect-2/package.json
+++ b/wallets/provider-walletconnect-2/package.json
@@ -36,7 +36,7 @@
     "bs58": "^5.0.0",
     "caip": "^1.1.1",
     "cosmos-wallet": "^1.2.0",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "devDependencies": {
     "@walletconnect/modal": "^2.6.2",

--- a/wallets/provider-xdefi/package.json
+++ b/wallets/provider-xdefi/package.json
@@ -27,7 +27,7 @@
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-xverse/package.json
+++ b/wallets/provider-xverse/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/react/package.json
+++ b/wallets/react/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@rango-dev/wallets-core": "^0.57.0",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
-    "rango-types": "^0.1.89",
+    "rango-types": "^0.1.93",
     "ts-results": "^3.3.0"
   },
   "devDependencies": {

--- a/wallets/shared/package.json
+++ b/wallets/shared/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@rango-dev/wallets-core": "^0.57.0",
     "ethers": "^6.13.2",
-    "rango-types": "^0.1.89"
+    "rango-types": "^0.1.93"
   },
   "publishConfig": {
     "access": "public"

--- a/widget/embedded/package.json
+++ b/widget/embedded/package.json
@@ -40,7 +40,7 @@
     "ethers": "^6.13.2",
     "immer": "^9.0.19",
     "mitt": "^3.0.0",
-    "rango-sdk": "^0.1.70",
+    "rango-sdk": "^0.1.72",
     "rango-types": "^0.1.93",
     "react-i18next": "^12.2.0",
     "react-router-dom": "^6.8.0",

--- a/widget/embedded/package.json
+++ b/widget/embedded/package.json
@@ -41,7 +41,7 @@
     "immer": "^9.0.19",
     "mitt": "^3.0.0",
     "rango-sdk": "^0.1.70",
-    "rango-types": "^0.1.89",
+    "rango-types": "^0.1.93",
     "react-i18next": "^12.2.0",
     "react-router-dom": "^6.8.0",
     "values.js": "2.1.1",

--- a/widget/playground/package.json
+++ b/widget/playground/package.json
@@ -27,7 +27,7 @@
     "@rango-dev/wallets-react": "^0.44.1-next.1",
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "@rango-dev/widget-embedded": "^0.58.1-next.3",
-    "rango-sdk": "^0.1.70",
+    "rango-sdk": "^0.1.72",
     "react": "^18.2.0",
     "react-color": "^2.19.3",
     "react-dom": "^18.2.0",

--- a/widget/ui/package.json
+++ b/widget/ui/package.json
@@ -56,7 +56,7 @@
     "@rango-dev/wallets-shared": "^0.58.1-next.1",
     "@stitches/react": "^1.2.8",
     "copy-to-clipboard": "^3.3.3",
-    "rango-types": "^0.1.92",
+    "rango-types": "^0.1.93",
     "react-virtuoso": "^4.6.2"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18036,10 +18036,10 @@ rango-types@^0.1.89:
   resolved "https://registry.yarnpkg.com/rango-types/-/rango-types-0.1.89.tgz#023e68f76f12746476ef68f658eed62735e23c4f"
   integrity sha512-14ynaYTLYnwY867RCl9UbZrFtW4LAiBET7ONS6eiCRhvl4ROvdiqopmzIDnsR6jma67QvcusHikBu9EcwhHTlw==
 
-rango-types@^0.1.92:
-  version "0.1.92"
-  resolved "https://registry.yarnpkg.com/rango-types/-/rango-types-0.1.92.tgz#45d5f7cf5bbed4ea652a36a0c21ba83ae6c03e87"
-  integrity sha512-NMXLv/zJosC+wgxuh/8rhfOK0mXlMAaj9AWTIcKQoYI0gaAUIHtYhegdk4q085em4/k276CZHKCDSQcZgQJXpg==
+rango-types@^0.1.93:
+  version "0.1.93"
+  resolved "https://registry.yarnpkg.com/rango-types/-/rango-types-0.1.93.tgz#556377d12eccc85c0ea3087e42040308aa3cde68"
+  integrity sha512-Sek7l5T7QWUMidSSaeSpPid3bK+ii93Vl1QDw4GSYRzoR1mc1EoqLI62OZw1whlogVKF5BtoUsoZ2k8SxWbT1g==
 
 raw-body@2.5.2:
   version "2.5.2"
@@ -19587,16 +19587,7 @@ string-argv@0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -19723,14 +19714,7 @@ stringify-object@^5.0.0:
     is-obj "^3.0.0"
     is-regexp "^3.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -21414,7 +21398,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -21427,15 +21411,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18013,28 +18013,23 @@ range-parser@^1.2.1, range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-rango-sdk-basic@^0.1.70:
-  version "0.1.70"
-  resolved "https://registry.yarnpkg.com/rango-sdk-basic/-/rango-sdk-basic-0.1.70.tgz#c95d0501c18f7b4d2d9ef7aea8d578a047db3741"
-  integrity sha512-oi8Zzwwa+CEmtvlXnGNDGf3yzz1nAWTWIsGUEi5E5jItpy7dbURBB3E5w5IUGVs/eiZnRw1uRQLc2kO49ua7Gw==
+rango-sdk-basic@^0.1.72:
+  version "0.1.72"
+  resolved "https://registry.yarnpkg.com/rango-sdk-basic/-/rango-sdk-basic-0.1.72.tgz#9f8356e43755be8fe3a9c2d977783c389a30707a"
+  integrity sha512-J9kevhC6vB6Wr0+EPuQdEHMr4NkaCsrJDhoXlwh0bEkAbDI4pl71meXepm5jjlrK5TTVtcpW3mKeQ6fDWlFFMQ==
   dependencies:
     axios "^1.7.4"
-    rango-types "^0.1.89"
+    rango-types "^0.1.93"
     uuid-random "^1.3.2"
 
-rango-sdk@^0.1.70:
-  version "0.1.70"
-  resolved "https://registry.yarnpkg.com/rango-sdk/-/rango-sdk-0.1.70.tgz#9fd4454aef0b3148d1851b9c9c6df0954e0e293b"
-  integrity sha512-tz+n9F53sA4LDcbUlSHccUR9JXo+kf83BxN/s94MXXn20D0ekcgjqMO8QLekcNXuVFFFqjNSzBu6roCFJgJ7Zg==
+rango-sdk@^0.1.72:
+  version "0.1.72"
+  resolved "https://registry.yarnpkg.com/rango-sdk/-/rango-sdk-0.1.72.tgz#f5c9b0c30cbf5e8854112437bfc2db3e92cb6b36"
+  integrity sha512-aOFFMdEtf1EVQyFgjf3bBuq6A7H/uW7OLqWky4C2yhQHz2bzTOJuMnkIjSl/fLXW/fSyV28xgUz7Di5EPqHFaA==
   dependencies:
     axios "^1.7.4"
-    rango-types "^0.1.89"
+    rango-types "^0.1.93"
     uuid-random "^1.3.2"
-
-rango-types@^0.1.89:
-  version "0.1.89"
-  resolved "https://registry.yarnpkg.com/rango-types/-/rango-types-0.1.89.tgz#023e68f76f12746476ef68f658eed62735e23c4f"
-  integrity sha512-14ynaYTLYnwY867RCl9UbZrFtW4LAiBET7ONS6eiCRhvl4ROvdiqopmzIDnsR6jma67QvcusHikBu9EcwhHTlw==
 
 rango-types@^0.1.93:
   version "0.1.93"


### PR DESCRIPTION
# Summary

Upgrade rango types to 0.1.93.
Upgrade rango sdk to 0.1.72.

Part of https://github.com/rango-exchange/rango-client/pull/1096


# How did you test this change?

build should be passed.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
