### PR TITLE
fix: use the exact balance instead of the rounded value when the user clicks max balance

### DIFF
--- a/widget/embedded/src/containers/Inputs/Inputs.tsx
+++ b/widget/embedded/src/containers/Inputs/Inputs.tsx
@@ -116,14 +116,9 @@ export function Inputs(props: PropTypes) {
           loadingBalance={fetchingBalance}
           tooltipContainer={getContainer()}
           onSelectMaxBalance={() => {
-            const tokenBalanceReal = numberToString(
-              fromBalanceAmount,
-              fromTokenBalance?.decimals
-            );
-
             // if a token hasn't any value, we will reset the input by setting an empty string.
-            const nextInputAmount = !!fromTokenBalance?.amount
-              ? tokenBalanceReal.split(',').join('')
+            const nextInputAmount = fromBalanceAmount.isGreaterThan(ZERO)
+              ? fromBalanceAmount.toFixed()
               : '';
 
             setInputAmount(nextInputAmount);


### PR DESCRIPTION
# Summary

When user wants to swap full token balance, if the number of tokens is above a threshold and user clicks on max balance, we allow him to swap rounded balance not max balance.

If user clicks on Max button, max balance should be selected. Not rounded down balance.

Fixes # (issue)

Fixed by using the actual token balance amount instead of the formatted value shown to the user.

# How did you test this change?

You can compare the production deployment with the current pull request deployment.
Choose a source token that has a large balance in your wallet, for example 100,000,000.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
