### PR TITLE
fix: allow users to enter text in the swap input and sanitize it into a valid number

### DIFF
--- a/widget/embedded/src/store/quote.ts
+++ b/widget/embedded/src/store/quote.ts
@@ -26,6 +26,7 @@ import {
 import { isPositiveNumber, sanitizeInputAmount } from '../utils/numbers';
 import {
   ensureLeadingZeroForDecimal,
+  parseNumericValue,
   removeLeadingZeros,
 } from '../utils/sanitizers';
 import { getUsdInputFrom, getUsdOutputFrom } from '../utils/swap';
@@ -249,7 +250,7 @@ const initializer: StateCreator<
     }));
   },
   setInputAmount: (amount) => {
-    let sanitized = amount;
+    let sanitized = parseNumericValue(amount);
     if (!isZeroValue(amount)) {
       // sanitize once a meaningful digit is entered (e.g. "00001" → "1")
       sanitized = removeLeadingZeros(sanitized);

--- a/widget/embedded/src/utils/numbers.ts
+++ b/widget/embedded/src/utils/numbers.ts
@@ -134,5 +134,9 @@ export function sanitizeInputAmount(amount: string): string {
     return '0';
   }
 
+  if (amount.endsWith('.')) {
+    return amount.slice(0, -1);
+  }
+
   return stripTrailingZeros(amount);
 }

--- a/widget/embedded/src/utils/sanitizers.test.ts
+++ b/widget/embedded/src/utils/sanitizers.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from 'vitest';
 import {
   ensureLeadingZeroForDecimal,
   formatThousandsWithCommas,
+  parseNumericValue,
   removeLeadingZeros,
   replaceSpacesWithDash,
   stripTrailingZeros,
@@ -117,6 +118,48 @@ describe('check sanitization behaviors', () => {
 
     test('edge: no decimal point', () => {
       expect(stripTrailingZeros('1000')).toBe('1000');
+    });
+  });
+
+  describe('parseNumericValue', () => {
+    test('removes commas and keeps digits', () => {
+      expect(parseNumericValue('300,222')).toBe('300222');
+    });
+
+    test('removes letters and keeps only the first decimal', () => {
+      expect(parseNumericValue('12a3.4b5')).toBe('123.45');
+    });
+
+    test('removes extra dots and keeps the first one', () => {
+      expect(parseNumericValue('1.2.3.4')).toBe('1.234');
+    });
+
+    test('keeps a leading decimal', () => {
+      expect(parseNumericValue('.5')).toBe('.5');
+    });
+
+    test('removes symbols and letters', () => {
+      expect(parseNumericValue('$1,2a3.4!')).toBe('123.4');
+    });
+
+    test('returns empty string if no digits', () => {
+      expect(parseNumericValue('abc!@#')).toBe('');
+    });
+
+    test('handles empty string', () => {
+      expect(parseNumericValue('')).toBe('');
+    });
+
+    test('keeps only the first dot if string starts with multiple dots', () => {
+      expect(parseNumericValue('...123.45')).toBe('.12345');
+    });
+
+    test('handles string with only dots', () => {
+      expect(parseNumericValue('....')).toBe('.');
+    });
+
+    test('handles string with digits only', () => {
+      expect(parseNumericValue('123456')).toBe('123456');
     });
   });
 });

--- a/widget/embedded/src/utils/sanitizers.ts
+++ b/widget/embedded/src/utils/sanitizers.ts
@@ -39,3 +39,29 @@ export function stripTrailingZeros(input: string): string {
   const s = input.replace(/(\.\d*?[1-9])0+$/, '$1');
   return s.replace(/\.0+$/, '');
 }
+
+/**
+ * Normalize a numeric input string by removing all non-numeric characters
+ * except digits and a single decimal separator.
+ *
+ * This function:
+ * - strips letters, spaces, commas, and symbols
+ * - preserves digits (`0–9`)
+ * - keeps only the first `.` as the decimal point
+ *
+ * @example "300,222"     → "300222"
+ * @example "12a3.4b5"   → "123.45"
+ * @example "1.2.3.4"    → "1.234"
+ * @example ".5"         → ".5"
+ */
+export function parseNumericValue(value: string): string {
+  value = value
+    // 1. Remove everything except digits and dots
+    .replace(/[^\d.]/g, '')
+    // 2. Keep only the first dot
+    .replace(/\./g, (_, offset, string) =>
+      string.indexOf('.') === offset ? '.' : ''
+    );
+
+  return value;
+}

--- a/widget/ui/src/containers/SwapInput/SwapInput.tsx
+++ b/widget/ui/src/containers/SwapInput/SwapInput.tsx
@@ -119,8 +119,8 @@ export function SwapInput(props: SwapInputPropTypes) {
                   style={{ padding: 0 }}
                   value={price.value}
                   id={`${props.id}-input`}
-                  type={'onInputChange' in props ? 'number' : 'text'}
-                  step="any"
+                  type="text"
+                  inputMode="decimal"
                   size="large"
                   placeholder="0"
                   variant="ghost"
@@ -128,7 +128,6 @@ export function SwapInput(props: SwapInputPropTypes) {
                     onBlur: (event: React.ChangeEvent<HTMLInputElement>) =>
                       props.onInputBlur?.(event.target.value),
                   })}
-                  min={0}
                   {...('onInputChange' in props && {
                     onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
                       props.onInputChange(event.target.value),


### PR DESCRIPTION
# Summary

Pasting amounts with thousand separators (e.g., 12,500) into the widget’s amount input is not supported, requiring users to manually remove the commas first.

Fixes # (issue)

Previously, the swap amount input used the number type. To allow users to paste token amounts with thousand separators, we needed to switch the input to text, and I’ve made that change.

We also need a way to parse the raw text input into a valid number. For this, I added a function called `parseNumericValue`, which takes the raw input string and converts it into a valid numeric value. This function:

- strips letters, spaces, commas, and symbols

- preserves digits (0–9)

- keeps only the first . as the decimal separator

We already have existing sanitizers for user input (such as removing leading or trailing zeros). These can remain unchanged; we only use parseNumericValue to convert the raw text into a valid number that the existing sanitizers can then process.

Additionally, I updated the `sanitizeInputAmount` function (triggered on input blur) so that if the value ends with a decimal separator and has no decimal part, the separator is removed.

# How did you test this change?

Try entering both text and numbers. Only digits and a single decimal separator should be accepted in the input.

Paste different combinations of characters and numbers—the value displayed in the input should always be a valid number. For example:

- "300,222" → "300222"

- "12a3.4b5" → "123.45"

- "1.2.3.4" → "1.234"

- ".5" → ".5"


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
