### PR TITLE
fix: update the solana signer to support devnet

### DIFF
--- a/signers/signer-solana/src/utils/main.ts
+++ b/signers/signer-solana/src/utils/main.ts
@@ -74,6 +74,7 @@ export async function executeSolanaTransaction(
         solanaWeb3Transaction
       );
       return signedTransaction.serialize();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       const REJECTION_CODE = 4001;
       if (e && Object.hasOwn(e, 'code') && e.code === REJECTION_CODE) {

--- a/signers/signer-solana/src/utils/prepare.ts
+++ b/signers/signer-solana/src/utils/prepare.ts
@@ -12,25 +12,18 @@ export const prepareTransaction = (
   recentBlockhash: string
 ): Transaction | VersionedTransaction => {
   if (tx.txType === 'VERSIONED') {
-    return prepareVersionedTransaction(tx, recentBlockhash);
+    return prepareVersionedTransaction(tx);
   }
 
   return prepareLegacyTransaction(tx, recentBlockhash);
 };
 
 export function prepareVersionedTransaction(
-  tx: SolanaTransaction,
-  recentBlockhash: string
+  tx: SolanaTransaction
 ): VersionedTransaction {
   const versionedTransaction = VersionedTransaction.deserialize(
     new Uint8Array(tx.serializedMessage || [])
   );
-  /*
-   * We shouldn't override the recent blockhash provided by the API
-   * Otherwise, the transaction will become invalid if partially signed by the API
-   */
-  versionedTransaction.message.recentBlockhash =
-    tx.recentBlockhash || recentBlockhash;
 
   tx.signatures.forEach(({ publicKey, signature }) => {
     versionedTransaction.addSignature(


### PR DESCRIPTION
# Summary

Currently, we’re modifying the `recent blockhash` in the `Solana` transaction returned by the server, which causes transactions to fail on `Devnet`. I removed the related code to properly test `Solana` transactions on `Devnet`.

Fixes # (issue)


# How did you test this change?

You can test this by signing a transaction on Devnet. Make sure to pass a Devnet RPC URL to the widget:
https://api.devnet.solana.com

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
