### PR TITLE
feat: add zcash chain to utxo namespace and make formatAccountsToCAIP reusable

### DIFF
--- a/global-wallets-env.d.ts
+++ b/global-wallets-env.d.ts
@@ -36,5 +36,6 @@ declare global {
     solflare?: any;
     unisat?: any;
     XverseProviders?: any;
+    vultisig?: any;
   }
 }

--- a/wallets/core/src/legacy/types.ts
+++ b/wallets/core/src/legacy/types.ts
@@ -73,6 +73,7 @@ export enum Networks {
   BASE = 'BASE',
   SUI = 'SUI',
   XRPL = 'XRPL',
+  ZCASH = 'ZCASH',
 
   // Using instead of null
   Unknown = 'Unkown',

--- a/wallets/core/src/namespaces/utxo/constants.ts
+++ b/wallets/core/src/namespaces/utxo/constants.ts
@@ -1,2 +1,3 @@
 export const CAIP_NAMESPACE = 'bip122';
 export const CAIP_BITCOIN_CHAIN_ID = '000000000019d6689c085ae165831e93';
+export const CAIP_ZCASH_CHAIN_ID = 'zcash';

--- a/wallets/core/src/namespaces/utxo/mod.ts
+++ b/wallets/core/src/namespaces/utxo/mod.ts
@@ -5,4 +5,8 @@ export * as before from './before.js';
 export * as builders from './builders.js';
 export * as utils from './utils.js';
 export type { ProviderAPI, UtxoActions } from './types.js';
-export { CAIP_NAMESPACE, CAIP_BITCOIN_CHAIN_ID } from './constants.js';
+export {
+  CAIP_NAMESPACE,
+  CAIP_BITCOIN_CHAIN_ID,
+  CAIP_ZCASH_CHAIN_ID,
+} from './constants.js';

--- a/wallets/core/src/namespaces/utxo/utils.ts
+++ b/wallets/core/src/namespaces/utxo/utils.ts
@@ -2,16 +2,16 @@ import type { CaipAccount } from '../common/mod.js';
 
 import { AccountId } from 'caip';
 
-import { CAIP_BITCOIN_CHAIN_ID, CAIP_NAMESPACE } from './constants.js';
+import { CAIP_NAMESPACE } from './constants.js';
 
-export function formatAccountsToCAIP(accounts: string[]) {
+export function formatAccountsToCAIP(accounts: string[], chainId: string) {
   return accounts.map(
     (account) =>
       AccountId.format({
         address: account.toString(),
         chainId: {
           namespace: CAIP_NAMESPACE,
-          reference: CAIP_BITCOIN_CHAIN_ID,
+          reference: chainId,
         },
       }) as CaipAccount
   );

--- a/wallets/provider-all/package.json
+++ b/wallets/provider-all/package.json
@@ -52,6 +52,7 @@
     "@rango-dev/provider-trezor": "^0.26.1",
     "@rango-dev/provider-tron-link": "^0.59.1",
     "@rango-dev/provider-trustwallet": "^0.59.1",
+    "@rango-dev/provider-vultisig": "^0.1.0",
     "@rango-dev/provider-unisat": "^0.15.1",
     "@rango-dev/provider-walletconnect-2": "^0.53.1",
     "@rango-dev/provider-xdefi": "^0.61.1",

--- a/wallets/provider-all/src/index.ts
+++ b/wallets/provider-all/src/index.ts
@@ -36,6 +36,7 @@ import * as trezor from '@rango-dev/provider-trezor';
 import { versions as tronLink } from '@rango-dev/provider-tron-link';
 import { versions as trustwallet } from '@rango-dev/provider-trustwallet';
 import { versions as unisat } from '@rango-dev/provider-unisat';
+import { versions as vultisig } from '@rango-dev/provider-vultisig';
 import * as walletconnect2 from '@rango-dev/provider-walletconnect-2';
 import * as xdefi from '@rango-dev/provider-xdefi';
 import { versions as xverse } from '@rango-dev/provider-xverse';
@@ -131,6 +132,7 @@ export const allProviders = (
     solflare,
     slush,
     unisat,
+    vultisig,
     gemwallet,
   ];
 };

--- a/wallets/provider-bitget/src/actions/utxo.ts
+++ b/wallets/provider-bitget/src/actions/utxo.ts
@@ -3,6 +3,7 @@ import {
   type FunctionWithContext,
 } from '@rango-dev/wallets-core';
 import {
+  CAIP_BITCOIN_CHAIN_ID,
   type ProviderAPI,
   utils,
   type UtxoActions,
@@ -21,7 +22,7 @@ export function connect(
     }
     const accounts = await utxoInstance.requestAccounts();
 
-    return utils.formatAccountsToCAIP(accounts);
+    return utils.formatAccountsToCAIP(accounts, CAIP_BITCOIN_CHAIN_ID);
   };
 }
 

--- a/wallets/provider-bitget/src/builders/utxo.ts
+++ b/wallets/provider-bitget/src/builders/utxo.ts
@@ -1,6 +1,7 @@
 import { ActionBuilder } from '@rango-dev/wallets-core';
 import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
 import {
+  CAIP_BITCOIN_CHAIN_ID,
   type ProviderAPI,
   utils,
   type UtxoActions,
@@ -17,7 +18,10 @@ export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
     })
 
     .format(async (_, address) => {
-      return utils.formatAccountsToCAIP(address ? [address] : []);
+      return utils.formatAccountsToCAIP(
+        address ? [address] : [],
+        CAIP_BITCOIN_CHAIN_ID
+      );
     })
     .addEventListener((instance, callback) => {
       return instance.addListener('accountChanged', callback);

--- a/wallets/provider-okx/src/builders/utxo.ts
+++ b/wallets/provider-okx/src/builders/utxo.ts
@@ -3,6 +3,7 @@ import type { OkxBtcAddress } from '../types.js';
 import { ActionBuilder } from '@rango-dev/wallets-core';
 import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
 import {
+  CAIP_BITCOIN_CHAIN_ID,
   type ProviderAPI,
   utils,
   type UtxoActions,
@@ -22,7 +23,10 @@ export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
     })
 
     .format(async (_, event) => {
-      return utils.formatAccountsToCAIP(event ? [event.address] : []);
+      return utils.formatAccountsToCAIP(
+        event ? [event.address] : [],
+        CAIP_BITCOIN_CHAIN_ID
+      );
     })
     .addEventListener((instance, callback) => {
       return instance.addListener('accountChanged', callback);

--- a/wallets/provider-okx/src/namespaces/utxo.ts
+++ b/wallets/provider-okx/src/namespaces/utxo.ts
@@ -4,6 +4,7 @@ import {
   standardizeAndThrowError,
 } from '@rango-dev/wallets-core/namespaces/common';
 import {
+  CAIP_BITCOIN_CHAIN_ID,
   utils,
   type UtxoActions,
 } from '@rango-dev/wallets-core/namespaces/utxo';
@@ -27,7 +28,10 @@ const connect = builders
     if (!accountsResult?.address) {
       throw new Error("Couldn't find any address!");
     }
-    return utils.formatAccountsToCAIP([accountsResult.address]);
+    return utils.formatAccountsToCAIP(
+      [accountsResult.address],
+      CAIP_BITCOIN_CHAIN_ID
+    );
   })
   .before(changeAccountSubscriber)
   .or(changeAccountCleanup)

--- a/wallets/provider-vultisig/package.json
+++ b/wallets/provider-vultisig/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@rango-dev/provider-vultisig",
+  "version": "0.1.0",
+  "license": "MIT",
+  "type": "module",
+  "source": "./src/mod.ts",
+  "main": "./dist/mod.js",
+  "exports": {
+    ".": "./dist/mod.js"
+  },
+  "typings": "dist/mod.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "node ../../scripts/build/command.mjs --path wallets/provider-vultisig --inputs src/mod.ts",
+    "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
+    "clean": "rimraf dist",
+    "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",
+    "lint": "eslint \"**/*.{ts,tsx}\""
+  },
+  "dependencies": {
+    "@rango-dev/wallets-shared": "^0.59.1",
+    "rango-types": "^0.1.98"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/wallets/provider-vultisig/readme.md
+++ b/wallets/provider-vultisig/readme.md
@@ -1,0 +1,28 @@
+# Vultisig Provider
+
+Vultisig integration for hub.
+[Homepage](https://vultisig.com/) | [Docs](https://docs.vultisig.com/)
+
+More about implementation status can be found [here](../readme.md).
+
+## Implementation notes/limitation
+
+### Group
+
+#### ⚠️ UTXO
+
+Only supports Zcash.
+
+### Feature
+
+#### ⚠️ Sign transaction
+
+It only supports Zcash transparent transactions.
+
+### ❌ Switch Account
+
+Switch account is not supported because the provider does not emit any events on switch account.
+
+---
+
+More wallet information can be found in [readme.md](../readme.md).

--- a/wallets/provider-vultisig/src/constants.ts
+++ b/wallets/provider-vultisig/src/constants.ts
@@ -1,0 +1,39 @@
+import type { ProviderMetadata } from '@rango-dev/wallets-core';
+import type { BlockchainMeta } from 'rango-types';
+
+import getSigners from './signer.js';
+
+export const WALLET_ID = 'vultisig';
+
+export const info: ProviderMetadata = {
+  name: 'Vultisig',
+  icon: 'https://raw.githubusercontent.com/rango-exchange/assets/main/wallets/vultisig/icon.svg',
+  extensions: {
+    chrome:
+      'https://chromewebstore.google.com/detail/vultisig-extension/ggafhcdaplkhmmnlbfjpnnkepdfjaelb',
+    homepage: 'https://vultisig.com/',
+  },
+  properties: [
+    {
+      name: 'namespaces',
+      value: {
+        selection: 'multiple',
+        data: [
+          {
+            label: 'Zcash',
+            value: 'UTXO',
+            id: 'ZCASH',
+            getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
+              allBlockchains.filter(
+                (blockchain) => blockchain.name === 'ZCASH'
+              ),
+          },
+        ],
+      },
+    },
+    {
+      name: 'signers',
+      value: { getSigners: async () => getSigners() },
+    },
+  ],
+};

--- a/wallets/provider-vultisig/src/mod.ts
+++ b/wallets/provider-vultisig/src/mod.ts
@@ -1,0 +1,8 @@
+import { defineVersions } from '@rango-dev/wallets-core/utils';
+
+import { buildProvider } from './provider.js';
+
+const versions = () =>
+  defineVersions().version('1.0.0', buildProvider()).build();
+
+export { versions };

--- a/wallets/provider-vultisig/src/namespaces/utxo/helpers.ts
+++ b/wallets/provider-vultisig/src/namespaces/utxo/helpers.ts
@@ -1,0 +1,10 @@
+import { vultisigZcash } from '../../utils.js';
+
+export async function requestZcashAccounts() {
+  return vultisigZcash().requestAccounts();
+}
+
+// Get accounts silently
+export async function getZcashAccounts() {
+  return await vultisigZcash().request({ method: 'get_accounts' });
+}

--- a/wallets/provider-vultisig/src/namespaces/utxo/mod.ts
+++ b/wallets/provider-vultisig/src/namespaces/utxo/mod.ts
@@ -1,0 +1,2 @@
+export { namespace } from './namespace.js';
+export { Signer } from './singer.js';

--- a/wallets/provider-vultisig/src/namespaces/utxo/namespace.ts
+++ b/wallets/provider-vultisig/src/namespaces/utxo/namespace.ts
@@ -1,0 +1,43 @@
+import type { UtxoActions } from '@rango-dev/wallets-core/namespaces/utxo';
+
+import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
+import {
+  builders as commonBuilders,
+  standardizeAndThrowError,
+} from '@rango-dev/wallets-core/namespaces/common';
+import {
+  builders,
+  CAIP_ZCASH_CHAIN_ID,
+  utils,
+} from '@rango-dev/wallets-core/namespaces/utxo';
+
+import { WALLET_ID } from '../../constants.js';
+
+import { getZcashAccounts, requestZcashAccounts } from './helpers.js';
+
+const connect = builders
+  .connect()
+  .action(async function () {
+    const accounts = await requestZcashAccounts();
+
+    return utils.formatAccountsToCAIP(accounts, CAIP_ZCASH_CHAIN_ID);
+  })
+  .or(standardizeAndThrowError)
+  .build();
+
+const canEagerConnect = new ActionBuilder<UtxoActions, 'canEagerConnect'>(
+  'canEagerConnect'
+)
+  .action(async () => {
+    const accounts = await getZcashAccounts().catch(() => []);
+    return accounts.length > 0;
+  })
+  .build();
+
+const disconnect = commonBuilders.disconnect<UtxoActions>().build();
+
+export const namespace = new NamespaceBuilder<UtxoActions>('UTXO', WALLET_ID)
+  .action(connect)
+  .action(disconnect)
+  .action(canEagerConnect)
+  .build();

--- a/wallets/provider-vultisig/src/namespaces/utxo/singer.ts
+++ b/wallets/provider-vultisig/src/namespaces/utxo/singer.ts
@@ -1,0 +1,58 @@
+import type { SendTransactionArgs } from '../../types.js';
+import type { Transfer } from 'rango-types/mainApi';
+
+import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { type GenericSigner, SignerError, SignerErrorCode } from 'rango-types';
+
+import { vultisigZcash } from '../../utils.js';
+
+import { getZcashAccounts } from './helpers.js';
+
+export class Signer implements GenericSigner<Transfer> {
+  async signMessage(): Promise<string> {
+    throw SignerError.UnimplementedError('signMessage');
+  }
+
+  async signAndSendTx(tx: Transfer): Promise<{ hash: string }> {
+    const { memo, fromWalletAddress, recipientAddress, amount, asset } = tx;
+
+    // TODO: check should be performed on the blockchain field of transaction instead of asset, but currently it is not available in the transaction object
+    if (asset.blockchain !== LegacyNetworks.ZCASH) {
+      throw new Error(`You can not sign ${tx.blockChain} using ZCash signer.`);
+    }
+
+    const accounts = await getZcashAccounts();
+
+    if (fromWalletAddress !== accounts[0]) {
+      throw new Error(
+        'fromWalletAddress is not matched with the connected account'
+      );
+    }
+
+    try {
+      const transactionRequest: SendTransactionArgs = {
+        method: 'send_transaction',
+        params: [
+          {
+            from: fromWalletAddress,
+            to: recipientAddress,
+            value: amount,
+            memo,
+          },
+        ],
+      };
+
+      const response = await vultisigZcash().request(transactionRequest);
+      return { hash: response };
+    } catch (error) {
+      if (typeof error === 'string') {
+        throw new SignerError(
+          SignerErrorCode.UNEXPECTED_BEHAVIOUR,
+          error,
+          undefined
+        );
+      }
+      throw new SignerError(SignerErrorCode.SEND_TX_ERROR, undefined, error);
+    }
+  }
+}

--- a/wallets/provider-vultisig/src/provider.ts
+++ b/wallets/provider-vultisig/src/provider.ts
@@ -1,0 +1,20 @@
+import { ProviderBuilder } from '@rango-dev/wallets-core';
+
+import { info, WALLET_ID } from './constants.js';
+import { namespace as utxo } from './namespaces/utxo/namespace.js';
+import { vultisig } from './utils.js';
+
+const buildProvider = () =>
+  new ProviderBuilder(WALLET_ID)
+    .init(function (context) {
+      const [, setState] = context.state();
+      if (vultisig()) {
+        setState('installed', true);
+        console.debug('[vultisig] instance detected.', context);
+      }
+    })
+    .config('metadata', info)
+    .add('utxo', utxo)
+    .build();
+
+export { buildProvider };

--- a/wallets/provider-vultisig/src/signer.ts
+++ b/wallets/provider-vultisig/src/signer.ts
@@ -1,0 +1,11 @@
+import type { SignerFactory } from 'rango-types';
+
+import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
+
+export default async function getSigners(): Promise<SignerFactory> {
+  const { Signer: UtxoSigner } = await import('./namespaces/utxo/mod.js');
+  const signers = new DefaultSignerFactory();
+
+  signers.registerSigner(TxType.TRANSFER, new UtxoSigner());
+  return signers;
+}

--- a/wallets/provider-vultisig/src/types.ts
+++ b/wallets/provider-vultisig/src/types.ts
@@ -1,0 +1,28 @@
+import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+
+export type SendTransactionArgs = {
+  method: 'send_transaction';
+  params: {
+    from: string;
+    to: string;
+    value: string;
+    memo: string | null;
+  }[];
+};
+
+export type VultisigZcashProviderApi = {
+  requestAccounts: () => Promise<string[]>;
+  request: {
+    (args: { method: 'get_accounts' }): Promise<string[]>;
+    (args: SendTransactionArgs): Promise<string>;
+  };
+};
+
+export type ProviderObject = {
+  [LegacyNetworks.ZCASH]: VultisigZcashProviderApi;
+};
+
+export type Provider = Map<
+  keyof ProviderObject,
+  ProviderObject[keyof ProviderObject]
+>;

--- a/wallets/provider-vultisig/src/utils.ts
+++ b/wallets/provider-vultisig/src/utils.ts
@@ -1,0 +1,29 @@
+import type { Provider, VultisigZcashProviderApi } from './types.js';
+
+import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+
+export function vultisig(): Provider | null {
+  const { vultisig } = window;
+  if (!vultisig) {
+    return null;
+  }
+
+  const instances: Provider = new Map();
+
+  if (vultisig.zcash) {
+    instances.set(LegacyNetworks.ZCASH, vultisig.zcash);
+  }
+
+  return instances;
+}
+
+export function vultisigZcash(): VultisigZcashProviderApi {
+  const instances = vultisig();
+  const zcashInstance = instances?.get(LegacyNetworks.ZCASH);
+
+  if (!zcashInstance) {
+    throw new Error('Vultisig not injected. Please check your wallet.');
+  }
+
+  return zcashInstance;
+}

--- a/wallets/provider-vultisig/tsconfig.build.json
+++ b/wallets/provider-vultisig/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
+  "extends": "../../tsconfig.libnext.json",
+  "include": ["src", "types"],
+  "files": ["../../global-wallets-env.d.ts"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./src",
+    "lib": ["dom", "esnext"]
+    // match output dir to input dir. e.g. dist/index instead of dist/src/index
+  }
+}

--- a/wallets/provider-vultisig/tsconfig.json
+++ b/wallets/provider-vultisig/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "./tsconfig.build.json", "include": ["src", "tests"] }

--- a/wallets/provider-xverse/src/builders/utxo.ts
+++ b/wallets/provider-xverse/src/builders/utxo.ts
@@ -3,6 +3,7 @@ import type { XVerseEvent } from '../types.js';
 import { ActionBuilder } from '@rango-dev/wallets-core';
 import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
 import {
+  CAIP_BITCOIN_CHAIN_ID,
   type ProviderAPI,
   utils,
   type UtxoActions,
@@ -26,7 +27,8 @@ export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
       return utils.formatAccountsToCAIP(
         event.addresses
           .filter((address) => address.purpose === 'payment')
-          .map((address) => address.address)
+          .map((address) => address.address),
+        CAIP_BITCOIN_CHAIN_ID
       );
     })
     .addEventListener((instance, callback) => {

--- a/wallets/provider-xverse/src/namespaces/utxo.ts
+++ b/wallets/provider-xverse/src/namespaces/utxo.ts
@@ -4,6 +4,7 @@ import {
   standardizeAndThrowError,
 } from '@rango-dev/wallets-core/namespaces/common';
 import {
+  CAIP_BITCOIN_CHAIN_ID,
   utils,
   type UtxoActions,
 } from '@rango-dev/wallets-core/namespaces/utxo';
@@ -28,7 +29,8 @@ const connect = builders
       throw new Error("Couldn't find any address!");
     }
     return utils.formatAccountsToCAIP(
-      accountsResult.result.addresses.map((address) => address.address)
+      accountsResult.result.addresses.map((address) => address.address),
+      CAIP_BITCOIN_CHAIN_ID
     );
   })
   .before(changeAccountSubscriber)

--- a/wallets/react/src/hub/helpers.ts
+++ b/wallets/react/src/hub/helpers.ts
@@ -9,7 +9,10 @@ import type { Result } from 'ts-results';
 import { legacyFormatAddressWithNetwork as formatAddressWithNetwork } from '@rango-dev/wallets-core/legacy';
 import { CAIP_NAMESPACE as CAIP_COSMOS_NAMESPACE } from '@rango-dev/wallets-core/namespaces/cosmos';
 import { CAIP_TRON_CHAIN_ID } from '@rango-dev/wallets-core/namespaces/tron';
-import { CAIP_BITCOIN_CHAIN_ID } from '@rango-dev/wallets-core/namespaces/utxo';
+import {
+  CAIP_BITCOIN_CHAIN_ID,
+  CAIP_ZCASH_CHAIN_ID,
+} from '@rango-dev/wallets-core/namespaces/utxo';
 import { CAIP } from '@rango-dev/wallets-core/utils';
 import { getBlockChainNameFromId } from '@rango-dev/wallets-shared';
 import { Err, Ok } from 'ts-results';
@@ -31,6 +34,8 @@ export function mapCaipNamespaceToLegacyNetworkName(
     return 'ETH';
   } else if (chainId.reference === CAIP_BITCOIN_CHAIN_ID) {
     return 'BTC';
+  } else if (chainId.reference === CAIP_ZCASH_CHAIN_ID) {
+    return 'ZCASH';
   }
 
   if (chainId.namespace.toLowerCase() === CAIP_COSMOS_NAMESPACE) {

--- a/wallets/readme.md
+++ b/wallets/readme.md
@@ -131,38 +131,38 @@ For better user experience, wallet provider tries to connect to a wallet only wh
 
 ## By Group
 
-
 | Wallet                                          | EVM | UTXO | Solana | Cosmos | TON | Tron | SUI | StarkNet |
 | ----------------------------------------------- | --- | ---- | ------ | ------ | --- | ---- | --- | -------- |
-| [Binance](provider-binance/readme.md)           | ✅  | 🚧   | 🚧     | 🚧     | 🚧  | 🚧  | 🚧  |    ❌    |
-| [Bitget](provider-bitget/readme.md)             | ✅  | 🚧   | 🚧     | ❌     | ❌  | ✅  | ❌  |    ❌    |
-| [Braavos](provider-braavos/readme.md)           | ❌  | ❌   | ❌     | ❌     | ❌  | ❌  | ❌  |    ✅    |
-| [Brave](provider-brave/readme.md)               | ✅  | ❌   | ✅     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [CoinBase](provider-coinbase/readme.md)         | ✅  | ❌   | ✅     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [Cosmostation](provider-cosmostation/readme.md) | ✅  | ❌   | ❌     | ✅     | ❌  | ❌  | ❌  |    ❌    |
-| [Enkrypt](provider-enkrypt/readme.md)           | ✅  | 🚧   | 🚧     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [Exodus](provider-exodus/readme.md)             | ⚠️  | 🚧   | ✅     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [Keplr](provider-keplr/readme.md)               | 🚧  | ❌   | ❌     | ✅     | ❌  | ❌  | ❌  |    ❌    |
-| [Leap](provider-leap-cosmos/readme.md)          | 🚧  | ❌   | 🚧     | ✅     | ❌  | 🚧  | ❌  |    ❌    |
-| [Ledger](provider-ledger/readme.md)             | ⚠️  | ❌   | ✅     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [MathWallet](provider-math-wallet/readme.md)    | ✅  | 🚧   | ✅     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [MetaMask](provider-metamask/readme.md)         | ✅  | ❌   | ✅     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [Phantom](provider-phantom/readme.md)           | ⚠️  | ⚠️   | ✅     | ❌     | ❌  | ❌  | ✅  |    ❌    |
-| [OKX](provider-okx/readme.md)                   | ⚠️  | ⚠️   | ✅     | 🚧     | 🚧  | ❌  | 🚧  |    ❌    |
-| [Rabby](provider-rabby/readme.md)               | ✅  | ❌   | ❌     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [Ready](provider-ready/readme.md)               | ❌  | ❌   | ❌     | ❌     | ❌  | ❌  | ❌  |    ✅    |
-| [Slush](provider-slush/readme.md)               | ❌  | ❌   | ❌     | ❌     | ❌  | ❌  | ✅  |    ❌    |
-| [SafePal](provider-safepal/readme.md)           | ✅  | 🚧   | 🚧     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [Solflare](provider-solflare/readme.md)         | ❌  | ❌   | ✅     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [Taho](provider-taho/readme.md)                 | ⚠️  | ❌   | ❌     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [Token Pocket](provider-tokenpocket/readme.md)  | ✅  | ❌   | 🚧     | ❌     | ❌  | ❌  | 🚧  |    ❌    |
-| [Tron Link](provider-tron-link/readme.md)       | 🚧  | ❌   | ❌     | ❌     | ❌  | ❌  | ✅  |    ❌    |
-| [Trust Wallet](provider-trust-wallet/readme.md) | ✅  | ❌   | ✅     | 🚧     | 🚧  | ❌  | 🚧  |    ❌    |
-| [UniSat](provider-unisat/readme.md)             | ❌  | ⚠️   | ❌     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [Xverse](provider-xverse/readme.md)             | ❌  | ⚠️   | ❌     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [Tomo](provider-tomo/readme.md)                 | ✅  | ❌   | ❌     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [Coin98](provider-coin98/readme.md)             | ✅  | ❌   | ✅     | ❌     | ❌  | ❌  | ❌  |    ❌    |
-| [GemWallet](provider-gemwallet/readme.md)       | ❌  | ❌   | ❌     | ❌     | ❌  | ❌  | ✅   |   ❌   |
+| [Binance](provider-binance/readme.md)           | ✅  | 🚧   | 🚧     | 🚧     | 🚧  | 🚧   | 🚧  | ❌       |
+| [Bitget](provider-bitget/readme.md)             | ✅  | 🚧   | 🚧     | ❌     | ❌  | ✅   | ❌  | ❌       |
+| [Braavos](provider-braavos/readme.md)           | ❌  | ❌   | ❌     | ❌     | ❌  | ❌   | ❌  | ✅       |
+| [Brave](provider-brave/readme.md)               | ✅  | ❌   | ✅     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [CoinBase](provider-coinbase/readme.md)         | ✅  | ❌   | ✅     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [Cosmostation](provider-cosmostation/readme.md) | ✅  | ❌   | ❌     | ✅     | ❌  | ❌   | ❌  | ❌       |
+| [Enkrypt](provider-enkrypt/readme.md)           | ✅  | 🚧   | 🚧     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [Exodus](provider-exodus/readme.md)             | ⚠️  | 🚧   | ✅     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [Keplr](provider-keplr/readme.md)               | 🚧  | ❌   | ❌     | ✅     | ❌  | ❌   | ❌  | ❌       |
+| [Leap](provider-leap-cosmos/readme.md)          | 🚧  | ❌   | 🚧     | ✅     | ❌  | 🚧   | ❌  | ❌       |
+| [Ledger](provider-ledger/readme.md)             | ⚠️  | ❌   | ✅     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [MathWallet](provider-math-wallet/readme.md)    | ✅  | 🚧   | ✅     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [MetaMask](provider-metamask/readme.md)         | ✅  | ❌   | ✅     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [Phantom](provider-phantom/readme.md)           | ⚠️  | ⚠️   | ✅     | ❌     | ❌  | ❌   | ✅  | ❌       |
+| [OKX](provider-okx/readme.md)                   | ⚠️  | ⚠️   | ✅     | 🚧     | 🚧  | ❌   | 🚧  | ❌       |
+| [Rabby](provider-rabby/readme.md)               | ✅  | ❌   | ❌     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [Ready](provider-ready/readme.md)               | ❌  | ❌   | ❌     | ❌     | ❌  | ❌   | ❌  | ✅       |
+| [Slush](provider-slush/readme.md)               | ❌  | ❌   | ❌     | ❌     | ❌  | ❌   | ✅  | ❌       |
+| [SafePal](provider-safepal/readme.md)           | ✅  | 🚧   | 🚧     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [Solflare](provider-solflare/readme.md)         | ❌  | ❌   | ✅     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [Taho](provider-taho/readme.md)                 | ⚠️  | ❌   | ❌     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [Token Pocket](provider-tokenpocket/readme.md)  | ✅  | ❌   | 🚧     | ❌     | ❌  | ❌   | 🚧  | ❌       |
+| [Tron Link](provider-tron-link/readme.md)       | 🚧  | ❌   | ❌     | ❌     | ❌  | ❌   | ✅  | ❌       |
+| [Trust Wallet](provider-trust-wallet/readme.md) | ✅  | ❌   | ✅     | 🚧     | 🚧  | ❌   | 🚧  | ❌       |
+| [UniSat](provider-unisat/readme.md)             | ❌  | ⚠️   | ❌     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [Xverse](provider-xverse/readme.md)             | ❌  | ⚠️   | ❌     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [Tomo](provider-tomo/readme.md)                 | ✅  | ❌   | ❌     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [Coin98](provider-coin98/readme.md)             | ✅  | ❌   | ✅     | ❌     | ❌  | ❌   | ❌  | ❌       |
+| [GemWallet](provider-gemwallet/readme.md)       | ❌  | ❌   | ❌     | ❌     | ❌  | ❌   | ✅  | ❌       |
+| [Vultisig](provider-vultisig/readme.md)         | ❌  | ⚠️   | ❌     | ❌     | ❌  | ❌   | ❌  | ❌       |
 
 ## By Feature
 
@@ -196,15 +196,17 @@ For better user experience, wallet provider tries to connect to a wallet only wh
 | Tomo         | ✅             | ✅             | ✅           | Injected                  | ❌            |
 | Coin98       | ✅             | ✅             | ❌           | Injected                  | ❌            |
 | GemWallet    | ✅             | ❌             | ⚠️           | Injected                  | ❌            |
+| Vultisig     | ❌             | ❌             | ✅           | Injected                  | ❌            |
 
 # Supported Wallets (Legacy)
 
-| Wallet         | Supported Chains                                                                                                        | Not Implemented                                   | Auto Connect Support | Source                               |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | -------------------- | ------------------------------------ |
+| Wallet | Supported Chains | Not Implemented | Auto Connect Support | Source |
+| ------ | ---------------- | --------------- | -------------------- | ------ |
+
 rate ready to the hub)
-| Safe           | EVM                                                                                                                     | -                                                 | &check;              | https://safe.global/                 |
-| Solflare Snap  | Solana                                                                                                                  | -                                                 | &cross;              | https://solflare.com/metamask        |
-| Station        | Terra Classic, Terra                                                                                                    | -                                                 | &cross;              | https://station.terra.money/         |
-| Trezor         | Ethereum,Solana                                                                                                         | Solana                                            | &cross;              | https://trezor.io/                   |
-| Wallet Connect | Evm,Solana,Cosmos                                                                                                       | Solana,Cosmos                                     | &cross;              | -                                    |
-| XDefi          | EVM,Solana,Binance,BTC,LTC,Thorchain,Terra,Doge,Cosmos,Akash,Axelar,Crypto.org,Juno,Kujira,Mars,Osmosis,Stargaze,Stride |                                                   | &check;              | https://www.xdefi.io/                |
+| Safe | EVM | - | &check; | https://safe.global/ |
+| Solflare Snap | Solana | - | &cross; | https://solflare.com/metamask |
+| Station | Terra Classic, Terra | - | &cross; | https://station.terra.money/ |
+| Trezor | Ethereum,Solana | Solana | &cross; | https://trezor.io/ |
+| Wallet Connect | Evm,Solana,Cosmos | Solana,Cosmos | &cross; | - |
+| XDefi | EVM,Solana,Binance,BTC,LTC,Thorchain,Terra,Doge,Cosmos,Akash,Axelar,Crypto.org,Juno,Kujira,Mars,Osmosis,Stargaze,Stride | | &check; | https://www.xdefi.io/ |


### PR DESCRIPTION
# Summary

Added `CAIP_ZCASH_CHAIN_ID` to "UTXO" namespace and made `formatAccountsToCAIP` function reusable for other chains.


# How did you test this change?

Test will be done in usage PR.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
