### PR TITLE
fix(ci): add workspaces list hash to prepare action cache key

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -10,19 +10,28 @@ runs:
         git config --global user.email 'github-actions[bot]@users.noreply.github.com'
       shell: 'bash'
 
+    # Do not enable setup-node dependency caching for this step.
+    # Caching will be handled by the cache step below.
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24'
+
+    - name: Hash workspace keys
+      id: workspace-keys
+      run: |
+        WORKSPACE_KEYS_HASH="$(node ./scripts/workspace-keys-hash/command.mjs)"
+        echo "hash=$WORKSPACE_KEYS_HASH" >> "$GITHUB_OUTPUT"
+      shell: 'bash'
+
     - name: Cache dependencies
       uses: actions/cache@v4
       id: cache
       with:
         path: '**/node_modules'
-        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
+        key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.workspace-keys.outputs.hash }}
         restore-keys: |
           ${{ runner.os }}-node-modules-
-
-    - name: Setup Node.js                                                                                                                                                          
-      uses: actions/setup-node@v4                                                                                                                                                  
-      with:
-        node-version: '24'
 
     - name: Install packages
       if: steps.cache.outputs.cache-hit != 'true'

--- a/scripts/workspace-keys-hash/command.mjs
+++ b/scripts/workspace-keys-hash/command.mjs
@@ -1,0 +1,42 @@
+import { createHash } from 'node:crypto';
+import { exec as execCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execCallbackAsync = promisify(execCallback);
+
+function getWorkspaceKeysHash(stringifiedWorkspaceInfo) {
+  let workspaceInfo;
+  try {
+    workspaceInfo = JSON.parse(stringifiedWorkspaceInfo);
+  } catch (error) {
+    throw new Error(
+      'Unable to parse output from yarn workspaces -s info --json',
+      { cause: stringifiedWorkspaceInfo }
+    );
+  }
+  const workspaceKeys = Object.keys(workspaceInfo).sort().join('|');
+
+  return createHash('sha256').update(workspaceKeys).digest('hex');
+}
+
+async function run() {
+  const { stdout, error, stderr } = await execCallbackAsync(
+    'yarn workspaces -s info --json'
+  );
+
+  if (error) {
+    throw error;
+  }
+
+  if (stderr) {
+    throw new Error(stderr);
+  }
+
+  const hash = getWorkspaceKeysHash(stdout);
+  process.stdout.write(hash);
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
# Summary

Added hash of the list of workspaces to the cache key in prepare action so if a local dependency gets added to the dependency list and `yarn.lock` does not change, still a cache hit will not happen and it will run the `yarn install` so symlink of local packages gets updated in `node_modules`.



# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
