### PR TITLE
feat: track confirm button click by configuration type

### DIFF
--- a/widget/playground/global.d.ts
+++ b/widget/playground/global.d.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export {};
+
+declare global {
+  interface Window {
+    dataLayer: Record<string, unknown>[];
+    gtag: (...args: any[]) => void;
+  }
+}

--- a/widget/playground/public/index.html
+++ b/widget/playground/public/index.html
@@ -11,9 +11,35 @@
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"
       rel="stylesheet"
     />
+    <!-- Google Tag Manager -->
+    <script>
+      if (process.env.NODE_ENV === 'production') {
+        (function (w, d, s, l, i) {
+          w[l] = w[l] || [];
+          w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+          var f = d.getElementsByTagName(s)[0],
+            j = d.createElement(s),
+            dl = l != 'dataLayer' ? '&l=' + l : '';
+          j.async = true;
+          j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+          f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', 'GTM-M369VCNV');
+      }
+    </script>
+    <!-- End Google Tag Manager -->
     <link rel="stylesheet" href="../src/styles.css" />
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript
+      ><iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-M369VCNV"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden"
+      ></iframe
+    ></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="app"></div>
     <script type="module" src="../src/index.tsx"></script>
   </body>

--- a/widget/playground/src/components/MultiList/MultiList.tsx
+++ b/widget/playground/src/components/MultiList/MultiList.tsx
@@ -10,6 +10,7 @@ import {
 } from '@rango-dev/ui';
 import React, { useState } from 'react';
 
+import { GTMEvents } from '../../constants/events';
 import { useMetaStore } from '../../store/meta';
 import { SearchInput } from '../SearchInput';
 import { EmptyContainer, StyledButton } from '../SingleList/SingleList.styles';
@@ -33,6 +34,7 @@ export function MultiList(props: MultiListPropTypes) {
     type,
     onChange,
     showCategory,
+    marketingMetaData,
   } = props;
   const [category, setCategory] = useState<string>('ALL');
   const [searchValue, setSearchValue] = useState('');
@@ -82,6 +84,11 @@ export function MultiList(props: MultiListPropTypes) {
   };
 
   const handleConfirm = () => {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: GTMEvents.CONFIRM_CONFIGURATION,
+      ...marketingMetaData,
+    });
     onChange(selectedItems.length === list.length ? undefined : selectedItems);
   };
 

--- a/widget/playground/src/components/MultiList/MultiList.types.ts
+++ b/widget/playground/src/components/MultiList/MultiList.types.ts
@@ -1,7 +1,11 @@
-import type { CommonListProps } from '../MultiSelect/MultiSelect.types';
+import type {
+  CommonListProps,
+  MarketingMetaData,
+} from '../MultiSelect/MultiSelect.types';
 
 export type MultiListPropTypes = {
   label: string;
   icon: React.ReactNode;
   showCategory?: boolean;
-} & CommonListProps;
+} & CommonListProps &
+  MarketingMetaData;

--- a/widget/playground/src/components/MultiSelect/MultiSelect.tsx
+++ b/widget/playground/src/components/MultiSelect/MultiSelect.tsx
@@ -72,10 +72,14 @@ export function MultiSelect(props: MuliSelectPropTypes) {
         <OverlayPanel onBack={onBack}>
           {type !== 'Tokens' ? (
             <MultiList
+              marketingMetaData={{
+                configurationType: 'functional',
+                subject: `select_${type.toLowerCase()}`,
+              }}
               defaultSelectedItems={props.defaultSelectedItems}
               type={type}
               list={list}
-              showCategory={type === 'Blockchains' || type === 'Wallets'}
+              showCategory={type === 'Chains' || type === 'Wallets'}
               icon={
                 type === 'Wallets' ? (
                   <WalletIcon size={18} />

--- a/widget/playground/src/components/MultiSelect/MultiSelect.types.ts
+++ b/widget/playground/src/components/MultiSelect/MultiSelect.types.ts
@@ -8,6 +8,13 @@ export interface CommonListProps {
   onChange: (items?: string[]) => void;
 }
 
+export type MarketingMetaData = {
+  marketingMetaData?: {
+    configurationType: 'functional' | 'style';
+    subject: `select_${string}` | `change_${string}`;
+  };
+};
+
 interface TokensListProps {
   type: 'Tokens';
   list: TokenType[];

--- a/widget/playground/src/components/SingleList/SingleList.tsx
+++ b/widget/playground/src/components/SingleList/SingleList.tsx
@@ -12,6 +12,7 @@ import {
 } from '@rango-dev/ui';
 import React, { useEffect, useState } from 'react';
 
+import { GTMEvents } from '../../constants/events';
 import { SearchInput } from '../SearchInput';
 
 import {
@@ -24,8 +25,15 @@ import {
 const PAGE_SIZE = 30;
 
 export function SingleList(props: PropTypes) {
-  const { list, onChange, defaultValue, title, icon, searchPlaceholder } =
-    props;
+  const {
+    list,
+    onChange,
+    defaultValue,
+    title,
+    icon,
+    searchPlaceholder,
+    marketingMetaData,
+  } = props;
   const [virtualList, setVirtualList] = useState(list);
   const [hasNextPage, setHasNextPage] = useState(true);
 
@@ -38,6 +46,11 @@ export function SingleList(props: PropTypes) {
     : list;
 
   const handleConfirm = () => {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: GTMEvents.CONFIRM_CONFIGURATION,
+      ...marketingMetaData,
+    });
     onChange(item);
   };
 

--- a/widget/playground/src/components/SingleList/SingleList.types.ts
+++ b/widget/playground/src/components/SingleList/SingleList.types.ts
@@ -1,4 +1,6 @@
-export interface PropTypes {
+import type { MarketingMetaData } from '../MultiSelect/MultiSelect.types';
+
+export type PropTypes = {
   title: string;
   icon: React.ReactNode;
   defaultValue?: string | null;
@@ -10,4 +12,4 @@ export interface PropTypes {
     Icon?: React.ComponentType<{ size?: number }>;
   }[];
   searchPlaceholder?: string;
-}
+} & MarketingMetaData;

--- a/widget/playground/src/constants/events.ts
+++ b/widget/playground/src/constants/events.ts
@@ -1,0 +1,3 @@
+export const GTMEvents = {
+  CONFIRM_CONFIGURATION: 'event_confirm_configuration',
+};

--- a/widget/playground/src/containers/DefaultChainAndToken/DefaultChainAndToken.tsx
+++ b/widget/playground/src/containers/DefaultChainAndToken/DefaultChainAndToken.tsx
@@ -101,6 +101,10 @@ export function DefaultChainAndToken({ type }: { type: Type }) {
       {modalState === ModalState.DEFAULT_BLOCKCHAIN && (
         <OverlayPanel onBack={onBack}>
           <SingleList
+            marketingMetaData={{
+              configurationType: 'functional',
+              subject: 'select_default_chain',
+            }}
             onChange={handleDefaultBlockchainConfirm}
             list={filteredBlockchains.map((chain) => ({
               name: chain.displayName,
@@ -117,6 +121,10 @@ export function DefaultChainAndToken({ type }: { type: Type }) {
       {modalState === ModalState.DEFAULT_TOKEN && (
         <OverlayPanel onBack={onBack}>
           <SingleList
+            marketingMetaData={{
+              configurationType: 'functional',
+              subject: 'select_default_token',
+            }}
             onChange={handleDefaultTokenConfirm}
             list={filteredTokens.map((token) => ({
               name: token.symbol,

--- a/widget/playground/src/containers/StyleLayout/StyleLayout.General.tsx
+++ b/widget/playground/src/containers/StyleLayout/StyleLayout.General.tsx
@@ -112,6 +112,7 @@ export function General() {
           </FieldTitle>
           <Divider size={16} />
           <Select
+            id="style-layout-select-widget-variant"
             variant="outlined"
             container={
               document.getElementById(PLAYGROUND_CONTAINER_ID) as HTMLElement
@@ -186,6 +187,10 @@ export function General() {
       {modalState === ModalState.DEFAULT_FONT && (
         <OverlayPanel onBack={onBack}>
           <SingleList
+            marketingMetaData={{
+              configurationType: 'style',
+              subject: 'change_font',
+            }}
             onChange={handleFontChange}
             title="Fonts"
             icon={<FontIcon size={18} />}
@@ -198,6 +203,10 @@ export function General() {
       {modalState === ModalState.DEFAULT_LANGUAGE && (
         <OverlayPanel onBack={onBack}>
           <SingleList
+            marketingMetaData={{
+              configurationType: 'style',
+              subject: 'change_language',
+            }}
             onChange={handleLanguageChange}
             title="Default Language"
             icon={<LanguageIcon size={18} color="gray" />}

--- a/widget/playground/tsconfig.build.json
+++ b/widget/playground/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
   "extends": "../../tsconfig.lib.json",
-  "include": ["src", "types"],
+  "include": ["src", "types", "./global.d.ts"],
   "compilerOptions": {
     "outDir": "dist",
     "lib": ["dom", "esnext"],

--- a/widget/playground/tsconfig.json
+++ b/widget/playground/tsconfig.json
@@ -1,1 +1,4 @@
-{ "extends": "./tsconfig.build.json", "include": ["src", "tests"] }
+{
+  "extends": "./tsconfig.build.json",
+  "include": ["src", "tests", "./global.d.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6088,6 +6088,18 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@rango-dev/signer-cosmos@^0.39.1":
+  version "0.39.1"
+  resolved "https://registry.yarnpkg.com/@rango-dev/signer-cosmos/-/signer-cosmos-0.39.1.tgz#209b501a787c9893857e22a6f5718c930e317d31"
+  integrity sha512-l8lP65gO0p7gJuTvJIly95A6/WcVZj3l2RZ4EjpiFd5+7eUoVT39YE2yJzTFgkRmfjg7dTANLY9XzLI0zz/HXA==
+  dependencies:
+    "@cosmjs/launchpad" "^0.27.1"
+    "@cosmjs/stargate" "^0.31.0"
+    "@keplr-wallet/cosmos" "^0.9.12"
+    cosmjs-types "^0.5.2"
+    long "^5.2.3"
+    rango-types "^0.1.98"
+
 "@reach/router@^1.2.1":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@reach/router/-/router-1.3.4.tgz#d2574b19370a70c80480ed91f3da840136d10f8c"
@@ -16151,6 +16163,11 @@ long@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
+long@^5.2.3:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
# Summary

Set up Google Analytics on `playground.rango.exchange` to track clicks on the “Confirm” button that applies user configurations.
Capture event data with a parameter specifying the configuration category (functional or style) to enable segmented analysis of user preferences and behavior.

Fixes # (issue)


# How did you test this change?

You can test this by opening the playground deployment from this pull request using the preview in Google Tag Manager, then modifying the settings and confirming them in the playground.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
