### PR TITLE
fix: changed tonconnect manifest url to use the manifest in the assets repo

### DIFF
--- a/widget/embedded/src/store/slices/config.ts
+++ b/widget/embedded/src/store/slices/config.ts
@@ -40,7 +40,7 @@ export const DEFAULT_CONFIG: WidgetConfig = {
   },
   tonConnect: {
     manifestUrl:
-      'https://raw.githubusercontent.com/rango-exchange/rango-types/main/assets/manifests/tonconnect-manifest.json',
+      'https://raw.githubusercontent.com/rango-exchange/assets/refs/heads/main/manifests/tonconnect/manifest.json',
   },
 };
 

--- a/widget/embedded/src/store/slices/data.test.ts
+++ b/widget/embedded/src/store/slices/data.test.ts
@@ -32,7 +32,7 @@ const DEFAULT_CONFIG: WidgetConfig = {
   },
   tonConnect: {
     manifestUrl:
-      'https://raw.githubusercontent.com/rango-exchange/rango-types/main/assets/manifests/tonconnect-manifest.json',
+      'https://raw.githubusercontent.com/rango-exchange/assets/refs/heads/main/manifests/tonconnect/manifest.json',
   },
 };
 


### PR DESCRIPTION
# Summary

Since rango-types repo is about to move from its current repo, I change URLs we use from it



# How did you test this change?

I've built all packages and tested playground app to ensure nothing has been broken

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
