### PR TITLE
fix: display the response error message instead of the axios error

### DIFF
--- a/queue-manager/rango-preset/src/shared-errors.ts
+++ b/queue-manager/rango-preset/src/shared-errors.ts
@@ -2,12 +2,14 @@ import type {
   APIErrorCode,
   SignerErrorCode as SignerErrorCodeType,
 } from 'rango-types';
+
 import {
-  SignerErrorCode,
-  SignerError,
-  isSignerErrorCode,
   isAPIErrorCode,
+  isSignerErrorCode,
+  SignerError,
+  SignerErrorCode,
 } from 'rango-types';
+
 import { DEFAULT_ERROR_CODE } from './constants';
 
 export type ErrorDetail = {
@@ -23,10 +25,10 @@ const ERROR_INPUT_WALLET_NOT_FOUND = 'Input wallet not found';
 type ErrorRoot = string | Record<string, string> | null;
 
 export class PrettyError extends Error {
+  public _isPrettyError = true;
   private readonly detail?: string;
   private readonly root?: ErrorRoot;
   private readonly code?: APIErrorCode;
-  public _isPrettyError = true;
 
   constructor(
     code: APIErrorCode,
@@ -47,24 +49,6 @@ export class PrettyError extends Error {
       obj instanceof PrettyError ||
       Object.prototype.hasOwnProperty.call(obj, '_isPrettyError')
     );
-  }
-
-  getErrorDetail(): ErrorDetail {
-    const rawMessage =
-      typeof this.root === 'object' && this.root && this.root.error
-        ? this.root.error
-        : JSON.stringify(this.root);
-    const rootStr =
-      typeof this.root === 'string'
-        ? this.root
-        : this.root instanceof Error
-        ? this.root.message
-        : rawMessage;
-    return {
-      extraMessage: this.message,
-      extraMessageDetail: this.detail || rootStr,
-      extraMessageErrorCode: this.code || null,
-    };
   }
 
   static AssertionFailed(m: string): PrettyError {
@@ -114,14 +98,36 @@ export class PrettyError extends Error {
       'Server requested for a blockchain or address not selected by user'
     );
   }
+
+  getErrorDetail(): ErrorDetail {
+    const rawMessage =
+      typeof this.root === 'object' && this.root && this.root.error
+        ? this.root.error
+        : JSON.stringify(this.root);
+    const rootStr =
+      typeof this.root === 'string'
+        ? this.root
+        : this.root instanceof Error
+        ? this.root.message
+        : rawMessage;
+    return {
+      extraMessage: this.message,
+      extraMessageDetail: this.detail || rootStr,
+      extraMessageErrorCode: this.code || null,
+    };
+  }
 }
 
 export function mapAppErrorCodesToAPIErrorCode(
   errorCode: string | null
 ): APIErrorCode {
   try {
-    if (!errorCode) return DEFAULT_ERROR_CODE;
-    if (isAPIErrorCode(errorCode)) return errorCode;
+    if (!errorCode) {
+      return DEFAULT_ERROR_CODE;
+    }
+    if (isAPIErrorCode(errorCode)) {
+      return errorCode;
+    }
     if (isSignerErrorCode(errorCode)) {
       const t: { [key in SignerErrorCodeType]: APIErrorCode } = {
         [SignerErrorCode.REJECTED_BY_USER]: 'USER_REJECT',
@@ -135,14 +141,40 @@ export function mapAppErrorCodesToAPIErrorCode(
       return t[errorCode];
     }
     return DEFAULT_ERROR_CODE;
-  } catch (err) {
+  } catch {
     return DEFAULT_ERROR_CODE;
   }
 }
 
+type AxiosError = {
+  isAxiosError: true;
+  response?: {
+    data?: { error?: string };
+  };
+};
+
+export function isAxiosError(obj: unknown): obj is AxiosError {
+  return (
+    !!obj &&
+    typeof obj === 'object' &&
+    'isAxiosError' in obj &&
+    obj.isAxiosError === true
+  );
+}
+
 export const prettifyErrorMessage = (obj: unknown): ErrorDetail => {
-  if (!obj) return { extraMessage: '', extraMessageErrorCode: null };
-  if (PrettyError.isPrettyError(obj)) return obj.getErrorDetail();
+  if (!obj) {
+    return { extraMessage: '', extraMessageErrorCode: null };
+  }
+  if (isAxiosError(obj)) {
+    return {
+      extraMessage: obj.response?.data?.error || 'Unknown error',
+      extraMessageErrorCode: null,
+    };
+  }
+  if (PrettyError.isPrettyError(obj)) {
+    return obj.getErrorDetail();
+  }
   if (SignerError.isSignerError(obj)) {
     const t = obj.getErrorDetail();
     return {
@@ -151,15 +183,18 @@ export const prettifyErrorMessage = (obj: unknown): ErrorDetail => {
       extraMessageErrorCode: t.code,
     };
   }
-  if (obj instanceof Error)
+  if (obj instanceof Error) {
     return {
       extraMessage: obj.toString(),
       extraMessageErrorCode: null,
     };
-  if (typeof obj !== 'string')
+  }
+  if (typeof obj !== 'string') {
     return {
       extraMessage: JSON.stringify(obj),
       extraMessageErrorCode: null,
     };
+  }
+
   return { extraMessage: obj, extraMessageErrorCode: null };
 };


### PR DESCRIPTION
# Summary

When a user tries to make a swap and the server cannot create the transaction, the API returns an HTTP error status along with an error message in the response body. Previously, we incorrectly displayed the HTTP library (Axios) error instead of the server-provided error message.


Fixes # (issue)


* Updated the `prettifyErrorMessage` helper to check whether the error is an Axios error.
* If the error is an `Axios` error, we now return the `error` field from the response object instead of the default Axios error message.

# How did you test this change?

Override the `/tx/create` response with the following:

status code: `400`

```json
{
  "ok": false,
  "error": "failed for test",
  "errorCode": 1234,
  "traceId": 123456,
  "transaction": null
}
```

Steps:

1. Select a route for a swap.
2. Start the swap flow.

Expected result:
The displayed error message should be `"failed for test"` from the response object, instead of the `Axios` error mess

You can also verify this by trying this route on XO Swap:
`/?fromBlockchain=ARBITRUM&fromToken=USDT--0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9&toBlockchain=TRON&toToken=USDT--TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t&fromAmount=10`

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
