### PR TITLE
chore: bump `rango-types` and `rango-sdk` to v0.3.0 and fix incorrect versions in several packages

### DIFF
--- a/queue-manager/queue-manager-demo/package.json
+++ b/queue-manager/queue-manager-demo/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "process": "^0.11.10",
-    "rango-sdk": "^0.1.77"
+    "rango-sdk": "^0.3.0"
   },
   "dependencies": {
     "@rango-dev/provider-all": "^0.61.1",
@@ -28,6 +28,6 @@
     "bignumber.js": "^9.1.1",
     "ethers": "^6.13.2",
     "rango-sdk-basic": "^0.1.77",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   }
 }

--- a/queue-manager/queue-manager-demo/src/flows/rango/mock.ts
+++ b/queue-manager/queue-manager-demo/src/flows/rango/mock.ts
@@ -1,5 +1,7 @@
-import { Meta, Networks, WalletTypes } from '@rango-dev/wallets-shared';
-import { RawAccounts, Wallet } from './types';
+import type { RawAccounts, Wallet } from './types';
+import type { Meta } from '@rango-dev/wallets-shared';
+
+import { Networks, WalletTypes } from '@rango-dev/wallets-shared';
 
 const evmAddress = '0x2702d89c1c8658b49c45dd460deebcc45faec03c';
 const cosmosAddress = 'cosmos1unf2rcytjxfpz8x8ar63h4qeftadptg5r5qswd';
@@ -3628,6 +3630,7 @@ export const meta = {
         blockExplorerUrls: ['https://bscscan.com'],
         addressUrl: 'https://bscscan.com/address/{wallet}',
         transactionUrl: 'https://bscscan.com/tx/{txHash}',
+        tokenUrl: 'https://bscscan.com/token/{address}',
       },
     },
     POLYGON: {
@@ -3650,6 +3653,7 @@ export const meta = {
         blockExplorerUrls: ['https://polygonscan.com'],
         addressUrl: 'https://polygonscan.com/address/{wallet}',
         transactionUrl: 'https://polygonscan.com/tx/{txHash}',
+        tokenUrl: 'https://polygonscan.com/token/{address}',
       },
     },
     ETH: {
@@ -3672,6 +3676,7 @@ export const meta = {
         blockExplorerUrls: ['https://etherscan.io'],
         addressUrl: 'https://etherscan.io/address/{wallet}',
         transactionUrl: 'https://etherscan.io/tx/{txHash}',
+        tokenUrl: 'https://etherscan.io/token/{address}',
       },
     },
     OSMOSIS: {
@@ -3740,6 +3745,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://www.mintscan.io/osmosis/txs/{txHash}',
         gasPriceStep: { low: 0, average: 0.025, high: 0.04 },
+        tokenUrl: 'https://www.mintscan.io/osmosis/assets/{address}',
       },
     },
     JUNO: {
@@ -3801,6 +3807,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://www.mintscan.io/juno/txs/{txHash}',
         gasPriceStep: { low: 0.001, average: 0.0025, high: 0.004 },
+        tokenUrl: null,
       },
     },
     AVAX_CCHAIN: {
@@ -3823,6 +3830,7 @@ export const meta = {
         blockExplorerUrls: ['https://snowtrace.io'],
         addressUrl: 'https://snowtrace.io/address/{wallet}',
         transactionUrl: 'https://snowtrace.io/tx/{txHash}',
+        tokenUrl: 'https://snowtrace.dev/token/{address}',
       },
     },
     ARBITRUM: {
@@ -3845,6 +3853,7 @@ export const meta = {
         blockExplorerUrls: ['https://arbiscan.io'],
         addressUrl: 'https://arbiscan.io/address/{wallet}',
         transactionUrl: 'https://arbiscan.io/tx/{txHash}',
+        tokenUrl: 'https://arbiscan.io/token/{address}',
       },
     },
     COSMOS: {
@@ -3906,6 +3915,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://www.mintscan.io/cosmos/txs/{txHash}',
         gasPriceStep: { low: 0.01, average: 0.025, high: 0.04 },
+        tokenUrl: 'https://www.mintscan.io/cosmos/assets/{address}',
       },
     },
     STARKNET: {
@@ -3950,6 +3960,7 @@ export const meta = {
         blockExplorerUrls: ['https://ftmscan.com'],
         addressUrl: 'https://ftmscan.com/address/{wallet}',
         transactionUrl: 'https://ftmscan.com/tx/{txHash}',
+        tokenUrl: 'https://explorer.fantom.network/token/{address}',
       },
     },
     OPTIMISM: {
@@ -3972,6 +3983,7 @@ export const meta = {
         blockExplorerUrls: ['https://optimistic.etherscan.io'],
         addressUrl: 'https://optimistic.etherscan.io/address/{wallet}',
         transactionUrl: 'https://optimistic.etherscan.io/tx/{txHash}',
+        tokenUrl: 'https://optimistic.etherscan.io/token/{address}',
       },
     },
     SOLANA: {
@@ -4009,6 +4021,7 @@ export const meta = {
         blockExplorerUrls: ['https://www.oklink.com/en/okc'],
         addressUrl: 'https://www.oklink.com/en/okc/address/{wallet}',
         transactionUrl: 'https://www.oklink.com/en/okc/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     CRONOS: {
@@ -4031,6 +4044,7 @@ export const meta = {
         blockExplorerUrls: ['https://cronoscan.com'],
         addressUrl: 'https://cronoscan.com/address/{wallet}',
         transactionUrl: 'https://cronoscan.com/tx/{txHash}',
+        tokenUrl: 'https://cronoscan.com/token/{address}',
       },
     },
     MOONRIVER: {
@@ -4053,6 +4067,7 @@ export const meta = {
         blockExplorerUrls: ['https://moonriver.moonscan.io'],
         addressUrl: 'https://moonriver.moonscan.io/address/{wallet}',
         transactionUrl: 'https://moonriver.moonscan.io/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     MOONBEAM: {
@@ -4075,6 +4090,7 @@ export const meta = {
         blockExplorerUrls: ['https://moonbeam.moonscan.io'],
         addressUrl: 'https://moonbeam.moonscan.io/address/{wallet}',
         transactionUrl: 'https://moonbeam.moonscan.io/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     HECO: {
@@ -4097,6 +4113,7 @@ export const meta = {
         blockExplorerUrls: ['https://hecoinfo.com'],
         addressUrl: 'https://hecoinfo.com/address/{wallet}',
         transactionUrl: 'https://hecoinfo.com/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     AURORA: {
@@ -4119,6 +4136,7 @@ export const meta = {
         blockExplorerUrls: ['https://explorer.mainnet.aurora.dev'],
         addressUrl: 'https://explorer.mainnet.aurora.dev/address/{wallet}',
         transactionUrl: 'https://explorer.mainnet.aurora.dev/tx/{txHash}',
+        tokenUrl: 'https://explorer.mainnet.aurora.dev/token/{address}',
       },
     },
     HARMONY: {
@@ -4141,6 +4159,7 @@ export const meta = {
         blockExplorerUrls: ['https://explorer.harmony.one'],
         addressUrl: 'https://explorer.harmony.one/address/{wallet}',
         transactionUrl: 'https://explorer.harmony.one/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     EVMOS: {
@@ -4163,6 +4182,7 @@ export const meta = {
         blockExplorerUrls: ['https://evm.evmos.org'],
         addressUrl: 'https://evm.evmos.org/address/{wallet}',
         transactionUrl: 'https://evm.evmos.org/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     SIF: {
@@ -4228,6 +4248,7 @@ export const meta = {
           average: 1500000000000,
           high: 2000000000000,
         },
+        tokenUrl: null,
       },
     },
     THOR: {
@@ -4319,6 +4340,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
         explorerUrlToTx: 'https://www.mintscan.io/stargaze/txs/{txHash}',
         gasPriceStep: { low: 1, average: 1, high: 1 },
+        tokenUrl: null,
       },
     },
     BTC: {
@@ -4397,6 +4419,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://www.mintscan.io/crypto-org/txs/{txHash}',
         gasPriceStep: { low: 0.025, average: 0.03, high: 0.04 },
+        tokenUrl: null,
       },
     },
     CHIHUAHUA: {
@@ -4458,6 +4481,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
         explorerUrlToTx: 'https://ping.pub/chihuahua/tx/{txHash}',
         gasPriceStep: { low: 0.025, average: 0.03, high: 0.035 },
+        tokenUrl: null,
       },
     },
     BANDCHAIN: {
@@ -4519,6 +4543,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
         explorerUrlToTx: 'https://cosmoscan.io/tx/{txHash}',
         gasPriceStep: null,
+        tokenUrl: null,
       },
     },
     COMDEX: {
@@ -4580,6 +4605,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
         explorerUrlToTx: 'https://www.mintscan.io/comdex/txs/{txHash}',
         gasPriceStep: null,
+        tokenUrl: null,
       },
     },
     REGEN: {
@@ -4641,6 +4667,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://regen.aneka.io/txs/{txHash}',
         gasPriceStep: { low: 0.015, average: 0.025, high: 0.04 },
+        tokenUrl: null,
       },
     },
     IRIS: {
@@ -4702,6 +4729,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://www.mintscan.io/iris/txs/{txHash}',
         gasPriceStep: { low: 0.2, average: 0.3, high: 0.4 },
+        tokenUrl: null,
       },
     },
     EMONEY: {
@@ -4771,6 +4799,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://emoney.bigdipper.live/transactions/{txHash}',
         gasPriceStep: { low: 1, average: 1, high: 1 },
+        tokenUrl: null,
       },
     },
     GNOSIS: {
@@ -4793,6 +4822,7 @@ export const meta = {
         blockExplorerUrls: ['https://blockscout.com/xdai/mainnet'],
         addressUrl: 'https://blockscout.com/xdai/mainnet/address/{wallet}',
         transactionUrl: 'https://blockscout.com/xdai/mainnet/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     LTC: {
@@ -4847,6 +4877,7 @@ export const meta = {
         blockExplorerUrls: ['https://explorer.fuse.io'],
         addressUrl: 'https://explorer.fuse.io/address/{wallet}',
         transactionUrl: 'https://explorer.fuse.io/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     AKASH: {
@@ -4908,6 +4939,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://www.mintscan.io/akash/txs/{txHash}',
         gasPriceStep: { low: 0.001, average: 0.0025, high: 0.004 },
+        tokenUrl: null,
       },
     },
     KI: {
@@ -4969,6 +5001,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://www.mintscan.io/ki-chain/txs/{txHash}',
         gasPriceStep: null,
+        tokenUrl: null,
       },
     },
     KUJIRA: {
@@ -5030,6 +5063,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://finder.kujira.app/kaiyo-1/tx/{txHash}',
         gasPriceStep: { low: 0.01, average: 0.025, high: 0.03 },
+        tokenUrl: null,
       },
     },
     PERSISTENCE: {
@@ -5091,6 +5125,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://www.mintscan.io/persistence/txs/{txHash}',
         gasPriceStep: { low: 0, average: 0.025, high: 0.04 },
+        tokenUrl: null,
       },
     },
     SENTINEL: {
@@ -5152,6 +5187,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://www.mintscan.io/sentinel/txs/{txHash}',
         gasPriceStep: { low: 0.1, average: 0.25, high: 0.4 },
+        tokenUrl: null,
       },
     },
     STARNAME: {
@@ -5214,6 +5250,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer'],
         explorerUrlToTx: 'https://www.mintscan.io/starname/txs/{txHash}',
         gasPriceStep: { low: 1, average: 2, high: 3 },
+        tokenUrl: null,
       },
     },
     UMEE: {
@@ -5275,6 +5312,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
         explorerUrlToTx: 'https://www.mintscan.io/umee/txs/{txHash}',
         gasPriceStep: { low: 0.05, average: 0.06, high: 0.1 },
+        tokenUrl: null,
       },
     },
     BITCANNA: {
@@ -5336,6 +5374,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
         explorerUrlToTx: 'https://www.mintscan.io/bitcanna/txs/{txHash}',
         gasPriceStep: null,
+        tokenUrl: null,
       },
     },
     DESMOS: {
@@ -5398,6 +5437,7 @@ export const meta = {
         explorerUrlToTx:
           'https://explorer.desmos.network/transactions/{txHash}',
         gasPriceStep: null,
+        tokenUrl: null,
       },
     },
     LUMNETWORK: {
@@ -5459,6 +5499,7 @@ export const meta = {
         features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx', 'ibc-go'],
         explorerUrlToTx: 'https://www.mintscan.io/lum/txs/{txHash}',
         gasPriceStep: null,
+        tokenUrl: null,
       },
     },
     BOBA: {
@@ -5481,6 +5522,7 @@ export const meta = {
         blockExplorerUrls: ['https://bobascan.com/'],
         addressUrl: 'https://bobascan.com//address/{wallet}',
         transactionUrl: 'https://bobascan.com//tx/{txHash}',
+        tokenUrl: null,
       },
     },
   },
@@ -5945,6 +5987,7 @@ export const meta = {
         blockExplorerUrls: ['https://bscscan.com'],
         addressUrl: 'https://bscscan.com/address/{wallet}',
         transactionUrl: 'https://bscscan.com/tx/{txHash}',
+        tokenUrl: 'https://bscscan.com/token/{address}',
       },
     },
     {
@@ -5967,6 +6010,7 @@ export const meta = {
         blockExplorerUrls: ['https://polygonscan.com'],
         addressUrl: 'https://polygonscan.com/address/{wallet}',
         transactionUrl: 'https://polygonscan.com/tx/{txHash}',
+        tokenUrl: 'https://polygonscan.com/token/{address}',
       },
     },
     {
@@ -5989,6 +6033,7 @@ export const meta = {
         blockExplorerUrls: ['https://etherscan.io'],
         addressUrl: 'https://etherscan.io/address/{wallet}',
         transactionUrl: 'https://etherscan.io/tx/{txHash}',
+        tokenUrl: 'https://etherscan.io/token/{address}',
       },
     },
     {
@@ -6011,6 +6056,7 @@ export const meta = {
         blockExplorerUrls: ['https://snowtrace.io'],
         addressUrl: 'https://snowtrace.io/address/{wallet}',
         transactionUrl: 'https://snowtrace.io/tx/{txHash}',
+        tokenUrl: 'https://snowtrace.dev/token/{address}',
       },
     },
     {
@@ -6033,6 +6079,7 @@ export const meta = {
         blockExplorerUrls: ['https://arbiscan.io'],
         addressUrl: 'https://arbiscan.io/address/{wallet}',
         transactionUrl: 'https://arbiscan.io/tx/{txHash}',
+        tokenUrl: 'https://arbiscan.io/token/{address}',
       },
     },
     {
@@ -6055,6 +6102,7 @@ export const meta = {
         blockExplorerUrls: ['https://ftmscan.com'],
         addressUrl: 'https://ftmscan.com/address/{wallet}',
         transactionUrl: 'https://ftmscan.com/tx/{txHash}',
+        tokenUrl: 'https://explorer.fantom.network/token/{address}',
       },
     },
     {
@@ -6077,6 +6125,7 @@ export const meta = {
         blockExplorerUrls: ['https://optimistic.etherscan.io'],
         addressUrl: 'https://optimistic.etherscan.io/address/{wallet}',
         transactionUrl: 'https://optimistic.etherscan.io/tx/{txHash}',
+        tokenUrl: 'https://optimistic.etherscan.io/token/{address}',
       },
     },
     {
@@ -6099,6 +6148,7 @@ export const meta = {
         blockExplorerUrls: ['https://www.oklink.com/en/okc'],
         addressUrl: 'https://www.oklink.com/en/okc/address/{wallet}',
         transactionUrl: 'https://www.oklink.com/en/okc/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     {
@@ -6121,6 +6171,7 @@ export const meta = {
         blockExplorerUrls: ['https://cronoscan.com'],
         addressUrl: 'https://cronoscan.com/address/{wallet}',
         transactionUrl: 'https://cronoscan.com/tx/{txHash}',
+        tokenUrl: 'https://cronoscan.com/token/{address}',
       },
     },
     {
@@ -6143,6 +6194,7 @@ export const meta = {
         blockExplorerUrls: ['https://moonriver.moonscan.io'],
         addressUrl: 'https://moonriver.moonscan.io/address/{wallet}',
         transactionUrl: 'https://moonriver.moonscan.io/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     {
@@ -6165,6 +6217,7 @@ export const meta = {
         blockExplorerUrls: ['https://moonbeam.moonscan.io'],
         addressUrl: 'https://moonbeam.moonscan.io/address/{wallet}',
         transactionUrl: 'https://moonbeam.moonscan.io/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     {
@@ -6187,6 +6240,7 @@ export const meta = {
         blockExplorerUrls: ['https://hecoinfo.com'],
         addressUrl: 'https://hecoinfo.com/address/{wallet}',
         transactionUrl: 'https://hecoinfo.com/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     {
@@ -6209,6 +6263,7 @@ export const meta = {
         blockExplorerUrls: ['https://explorer.mainnet.aurora.dev'],
         addressUrl: 'https://explorer.mainnet.aurora.dev/address/{wallet}',
         transactionUrl: 'https://explorer.mainnet.aurora.dev/tx/{txHash}',
+        tokenUrl: 'https://explorer.mainnet.aurora.dev/token/{address}',
       },
     },
     {
@@ -6231,6 +6286,7 @@ export const meta = {
         blockExplorerUrls: ['https://explorer.harmony.one'],
         addressUrl: 'https://explorer.harmony.one/address/{wallet}',
         transactionUrl: 'https://explorer.harmony.one/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     {
@@ -6253,6 +6309,7 @@ export const meta = {
         blockExplorerUrls: ['https://evm.evmos.org'],
         addressUrl: 'https://evm.evmos.org/address/{wallet}',
         transactionUrl: 'https://evm.evmos.org/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     {
@@ -6275,6 +6332,7 @@ export const meta = {
         blockExplorerUrls: ['https://blockscout.com/xdai/mainnet'],
         addressUrl: 'https://blockscout.com/xdai/mainnet/address/{wallet}',
         transactionUrl: 'https://blockscout.com/xdai/mainnet/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     {
@@ -6297,6 +6355,7 @@ export const meta = {
         blockExplorerUrls: ['https://explorer.fuse.io'],
         addressUrl: 'https://explorer.fuse.io/address/{wallet}',
         transactionUrl: 'https://explorer.fuse.io/tx/{txHash}',
+        tokenUrl: null,
       },
     },
     {
@@ -6319,6 +6378,7 @@ export const meta = {
         blockExplorerUrls: ['https://bobascan.com/'],
         addressUrl: 'https://bobascan.com//address/{wallet}',
         transactionUrl: 'https://bobascan.com//tx/{txHash}',
+        tokenUrl: null,
       },
     },
   ],

--- a/queue-manager/rango-preset/package.json
+++ b/queue-manager/rango-preset/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@rango-dev/logging-core": "^0.12.1",
-    "rango-types": "^0.1.98",
+    "rango-types": "^0.3.0",
     "ts-results": "^3.3.0",
     "uuid": "^9.0.0"
   },

--- a/signers/signer-cosmos/package.json
+++ b/signers/signer-cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rango-dev/signer-cosmos",
-  "version": "0.39.2-next.0",
+  "version": "0.39.1",
   "license": "MIT",
   "type": "module",
   "source": "./src/index.ts",
@@ -26,7 +26,7 @@
     "@keplr-wallet/proto-types": "^0.13.26",
     "cosmjs-types": "^0.5.2",
     "long": "^4.0.0",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "devDependencies": {
     "@keplr-wallet/types": "^0.13.26",

--- a/signers/signer-evm/package.json
+++ b/signers/signer-evm/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "ethers": "^6.13.2",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/signers/signer-solana/package.json
+++ b/signers/signer-solana/package.json
@@ -24,7 +24,7 @@
     "@solana/web3.js": "^1.91.4",
     "bs58": "^5.0.0",
     "promise-retry": "^2.0.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "devDependencies": {
     "@types/promise-retry": "^1.1.6"

--- a/signers/signer-starknet/package.json
+++ b/signers/signer-starknet/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/signers/signer-sui/package.json
+++ b/signers/signer-sui/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "devDependencies": {
     "@mysten/sui": "^1.21.2",

--- a/signers/signer-ton/package.json
+++ b/signers/signer-ton/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "peerDependencies": {
     "@ton/core": ">=0.59.0",

--- a/signers/signer-tron/package.json
+++ b/signers/signer-tron/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/core/package.json
+++ b/wallets/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rango-dev/wallets-core",
-  "version": "0.58.2-next.0",
+  "version": "0.58.1",
   "license": "MIT",
   "type": "module",
   "source": "./src/mod.ts",
@@ -85,7 +85,7 @@
     "@chain-registry/types": "2.0.110",
     "caip": "^1.1.1",
     "immer": "^10.0.4",
-    "rango-types": "^0.1.98",
+    "rango-types": "^0.3.0",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/wallets/provider-binance/package.json
+++ b/wallets/provider-binance/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.41.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-bitget/package.json
+++ b/wallets/provider-bitget/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-tron": "^0.40.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-braavos/package.json
+++ b/wallets/provider-braavos/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-starknet": "^0.41.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-brave/package.json
+++ b/wallets/provider-brave/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-solana": "^0.47.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-coin98/package.json
+++ b/wallets/provider-coin98/package.json
@@ -27,7 +27,7 @@
     "@rango-dev/wallets-shared": "^0.59.1",
     "@solana/web3.js": "^1.91.4",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-coinbase/package.json
+++ b/wallets/provider-coinbase/package.json
@@ -26,7 +26,7 @@
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-cosmostation/package.json
+++ b/wallets/provider-cosmostation/package.json
@@ -26,7 +26,7 @@
     "@rango-dev/signer-evm": "^0.41.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-default/package.json
+++ b/wallets/provider-default/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.41.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-enkrypt/package.json
+++ b/wallets/provider-enkrypt/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.41.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-exodus/package.json
+++ b/wallets/provider-exodus/package.json
@@ -26,7 +26,7 @@
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-gemwallet/package.json
+++ b/wallets/provider-gemwallet/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@gemwallet/api": "^3.8.0",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98",
+    "rango-types": "^0.3.0",
     "xrpl": "^4.2.0"
   },
   "publishConfig": {

--- a/wallets/provider-keplr/package.json
+++ b/wallets/provider-keplr/package.json
@@ -32,7 +32,7 @@
     "@rango-dev/signer-cosmos": "^0.39.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "devDependencies": {
     "@keplr-wallet/types": "^0.11.21"

--- a/wallets/provider-leap-cosmos/package.json
+++ b/wallets/provider-leap-cosmos/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-cosmos": "^0.39.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-ledger/package.json
+++ b/wallets/provider-ledger/package.json
@@ -34,7 +34,7 @@
     "@types/w3c-web-hid": "^1.0.2",
     "bs58": "^5.0.0",
     "ethers": "^6.13.2",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-math-wallet/package.json
+++ b/wallets/provider-math-wallet/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-solana": "^0.47.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-metamask/package.json
+++ b/wallets/provider-metamask/package.json
@@ -27,7 +27,7 @@
     "@rango-dev/wallets-shared": "^0.59.1",
     "@wallet-standard/app": "^1.1.0",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "devDependencies": {
     "@solana/wallet-standard-features": "^1.3.0",

--- a/wallets/provider-okx/package.json
+++ b/wallets/provider-okx/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-solana": "^0.47.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-phantom/package.json
+++ b/wallets/provider-phantom/package.json
@@ -29,7 +29,7 @@
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
     "bitcoinjs-lib": "^6.1.7",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-rabby/package.json
+++ b/wallets/provider-rabby/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.41.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-ready/package.json
+++ b/wallets/provider-ready/package.json
@@ -20,7 +20,7 @@
     "@rango-dev/signer-starknet": "^0.41.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-safe/package.json
+++ b/wallets/provider-safe/package.json
@@ -27,7 +27,7 @@
     "@safe-global/safe-apps-provider": "^0.17.0",
     "@safe-global/safe-apps-sdk": "^9.1.0",
     "ethers": "^6.13.2",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-safepal/package.json
+++ b/wallets/provider-safepal/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/signer-solana": "^0.47.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-slush/package.json
+++ b/wallets/provider-slush/package.json
@@ -26,7 +26,7 @@
     "@rango-dev/signer-sui": "^0.9.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-solflare/package.json
+++ b/wallets/provider-solflare/package.json
@@ -26,7 +26,7 @@
     "@rango-dev/wallets-shared": "^0.59.1",
     "@solana/web3.js": "^1.91.4",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-taho/package.json
+++ b/wallets/provider-taho/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.41.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-tokenpocket/package.json
+++ b/wallets/provider-tokenpocket/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.41.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-tomo/package.json
+++ b/wallets/provider-tomo/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-evm": "^0.41.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-tonconnect/package.json
+++ b/wallets/provider-tonconnect/package.json
@@ -28,7 +28,7 @@
     "@ton/core": "^0.59.0",
     "@ton/crypto": "^3.3.0",
     "@tonconnect/ui": "^2.0.9",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-trezor/package.json
+++ b/wallets/provider-trezor/package.json
@@ -28,7 +28,7 @@
     "@rango-dev/wallets-shared": "^0.59.1",
     "@trezor/connect-web": "^9.5.0",
     "ethers": "^6.13.2",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-tron-link/package.json
+++ b/wallets/provider-tron-link/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/signer-tron": "^0.40.1",
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-trustwallet/package.json
+++ b/wallets/provider-trustwallet/package.json
@@ -25,7 +25,7 @@
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-unisat/package.json
+++ b/wallets/provider-unisat/package.json
@@ -24,7 +24,7 @@
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
     "bitcoinjs-lib": "^6.1.7",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-vultisig/package.json
+++ b/wallets/provider-vultisig/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-walletconnect-2/package.json
+++ b/wallets/provider-walletconnect-2/package.json
@@ -36,7 +36,7 @@
     "bs58": "^5.0.0",
     "caip": "^1.1.1",
     "cosmos-wallet": "^1.2.0",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "devDependencies": {
     "@walletconnect/modal": "^2.6.2",

--- a/wallets/provider-walletconnect-2/src/signers/mock.ts
+++ b/wallets/provider-walletconnect-2/src/signers/mock.ts
@@ -35,6 +35,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://bscscan.com/address/{wallet}',
       transactionUrl: 'https://bscscan.com/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://bscscan.com/token/{address}',
     },
   },
   {
@@ -71,6 +72,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://polygonscan.com/address/{wallet}',
       transactionUrl: 'https://polygonscan.com/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://polygonscan.com/token/{address}',
     },
   },
   {
@@ -107,6 +109,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://etherscan.io/address/{wallet}',
       transactionUrl: 'https://etherscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://etherscan.io/token/{address}',
     },
   },
   {
@@ -193,6 +196,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.04,
       },
+      tokenUrl: 'https://www.mintscan.io/osmosis/assets/{address}',
     },
   },
   {
@@ -272,6 +276,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.0025,
         high: 0.004,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -308,6 +313,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://snowtrace.io/address/{wallet}',
       transactionUrl: 'https://snowtrace.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://snowtrace.dev/token/{address}',
     },
   },
   {
@@ -344,6 +350,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://arbiscan.io/address/{wallet}',
       transactionUrl: 'https://arbiscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://arbiscan.io/token/{address}',
     },
   },
   {
@@ -423,6 +430,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.04,
       },
+      tokenUrl: 'https://www.mintscan.io/cosmos/assets/{address}',
     },
   },
   {
@@ -531,6 +539,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.0075,
         high: 0.0075,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -567,6 +576,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://ftmscan.com/address/{wallet}',
       transactionUrl: 'https://ftmscan.com/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://explorer.fantom.network/token/{address}',
     },
   },
   {
@@ -603,6 +613,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://optimistic.etherscan.io/address/{wallet}',
       transactionUrl: 'https://optimistic.etherscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://optimistic.etherscan.io/token/{address}',
     },
   },
   {
@@ -639,6 +650,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://www.oklink.com/en/okc/address/{wallet}',
       transactionUrl: 'https://www.oklink.com/en/okc/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -674,6 +686,7 @@ export const supportedChains: BlockchainMeta[] = [
       blockExplorerUrls: ['https://starkscan.co'],
       addressUrl: 'https://starkscan.co/contract/{wallet}',
       transactionUrl: 'https://starkscan.co/tx/{txHash}',
+      tokenUrl: 'https://voyager.online/token/{address}',
     },
   },
   {
@@ -733,6 +746,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://cronoscan.com/address/{wallet}',
       transactionUrl: 'https://cronoscan.com/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://cronoscan.com/token/{address}',
     },
   },
   {
@@ -769,6 +783,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://moonriver.moonscan.io/address/{wallet}',
       transactionUrl: 'https://moonriver.moonscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -805,6 +820,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://explorer.zksync.io/address/{wallet}',
       transactionUrl: 'https://explorer.zksync.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://explorer.zksync.io/token/{address}',
     },
   },
   {
@@ -841,6 +857,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://moonbeam.moonscan.io/address/{wallet}',
       transactionUrl: 'https://moonbeam.moonscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -894,6 +911,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://explorer.mainnet.aurora.dev/address/{wallet}',
       transactionUrl: 'https://explorer.mainnet.aurora.dev/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://explorer.mainnet.aurora.dev/token/{address}',
     },
   },
   {
@@ -953,6 +971,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://explorer.harmony.one/address/{wallet}',
       transactionUrl: 'https://explorer.harmony.one/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -989,6 +1008,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://evm.evmos.org/address/{wallet}',
       transactionUrl: 'https://evm.evmos.org/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -1025,6 +1045,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://zkevm.polygonscan.com/address/{wallet}',
       transactionUrl: 'https://zkevm.polygonscan.com/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://zkevm.polygonscan.com/token/{address}',
     },
   },
   {
@@ -1061,6 +1082,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://hecoinfo.com/address/{wallet}',
       transactionUrl: 'https://hecoinfo.com/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -1097,6 +1119,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://tronscan.org/#/address/{wallet}',
       transactionUrl: 'https://tronscan.org/#/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://tronscan.org/#/token20/{address}',
     },
   },
   {
@@ -1176,6 +1199,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 1500000000000,
         high: 2000000000000,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1258,6 +1282,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://brisescan.com//address/{wallet}',
       transactionUrl: 'https://brisescan.com//tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -1360,6 +1385,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 1,
         high: 1,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1464,6 +1490,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.03,
         high: 0.04,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1543,6 +1570,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.03,
         high: 0.035,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1618,6 +1646,7 @@ export const supportedChains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
       explorerUrlToTx: 'https://cosmoscan.io/tx/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -1693,6 +1722,7 @@ export const supportedChains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
       explorerUrlToTx: 'https://www.mintscan.io/comdex/txs/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -1772,6 +1802,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.04,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1851,6 +1882,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.3,
         high: 0.4,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1938,6 +1970,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 1,
         high: 1,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1974,6 +2007,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://blockscout.com/xdai/mainnet/address/{wallet}',
       transactionUrl: 'https://blockscout.com/xdai/mainnet/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -2056,6 +2090,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://explorer.fuse.io/address/{wallet}',
       transactionUrl: 'https://explorer.fuse.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -2131,6 +2166,7 @@ export const supportedChains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx', 'ibc-go'],
       explorerUrlToTx: 'https://explorebitsong.com/transactions/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -2210,6 +2246,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.0025,
         high: 0.004,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2285,6 +2322,7 @@ export const supportedChains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer'],
       explorerUrlToTx: 'https://www.mintscan.io/ki-chain/txs/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -2364,6 +2402,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.04,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2443,6 +2482,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 7,
         high: 9,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2522,6 +2562,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.03,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2601,6 +2642,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.25,
         high: 0.4,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2680,6 +2722,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 500000000,
         high: 500000000,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2759,6 +2802,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.25,
         high: 0.3,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2834,6 +2878,7 @@ export const supportedChains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
       explorerUrlToTx: 'https://www.mintscan.io/konstellation/txs/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -2913,6 +2958,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 2,
         high: 3,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2988,6 +3034,7 @@ export const supportedChains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
       explorerUrlToTx: 'https://www.mintscan.io/bitcanna/txs/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -3067,6 +3114,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.06,
         high: 0.1,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -3142,6 +3190,7 @@ export const supportedChains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx', 'ibc-go'],
       explorerUrlToTx: 'https://explorer.desmos.network/transactions/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -3217,6 +3266,7 @@ export const supportedChains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx', 'ibc-go'],
       explorerUrlToTx: 'https://www.mintscan.io/lum/txs/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -3253,6 +3303,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://bobascan.com//address/{wallet}',
       transactionUrl: 'https://bobascan.com//tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -3333,6 +3384,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.007,
         high: 0.01,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -3454,6 +3506,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.0025,
         high: 0.04,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -3490,6 +3543,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://explorer.kcc.io/en/address/{wallet}',
       transactionUrl: 'https://explorer.kcc.io/en/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -3569,6 +3623,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.0025,
         high: 0.01,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -3648,6 +3703,7 @@ export const supportedChains: BlockchainMeta[] = [
         average: 0.015,
         high: 0.15,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -3684,6 +3740,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://www.teloscan.io/address/{wallet}',
       transactionUrl: 'https://www.teloscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -3720,6 +3777,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://blockexplorer.bnb.boba.network/address/{wallet}',
       transactionUrl: 'https://blockexplorer.bnb.boba.network/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -3757,6 +3815,7 @@ export const supportedChains: BlockchainMeta[] = [
         'https://blockexplorer.bobabeam.boba.network/address/{wallet}',
       transactionUrl: 'https://blockexplorer.bobabeam.boba.network/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -3793,6 +3852,7 @@ export const supportedChains: BlockchainMeta[] = [
       addressUrl: 'https://blockexplorer.avax.boba.network/address/{wallet}',
       transactionUrl: 'https://blockexplorer.avax.boba.network/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
 ];

--- a/wallets/provider-xdefi/package.json
+++ b/wallets/provider-xdefi/package.json
@@ -27,7 +27,7 @@
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
     "bs58": "^5.0.0",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/provider-xverse/package.json
+++ b/wallets/provider-xverse/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/wallets/react/package.json
+++ b/wallets/react/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@rango-dev/wallets-core": "^0.58.1",
     "@rango-dev/wallets-shared": "^0.59.1",
-    "rango-types": "^0.1.98",
+    "rango-types": "^0.3.0",
     "ts-results": "^3.3.0"
   },
   "devDependencies": {

--- a/wallets/react/src/test-utils/fixtures.ts
+++ b/wallets/react/src/test-utils/fixtures.ts
@@ -18,7 +18,7 @@ export class MockEvmSigner implements GenericSigner<EvmTransaction> {
     _tx: EvmTransaction,
     _address: string,
     _chainId: string | null
-  ): Promise<{ hash: string; response?: any }> {
+  ): Promise<{ hash: string; response?: unknown }> {
     return {
       hash: '0x',
     };
@@ -96,6 +96,7 @@ export const blockchainsMeta: BlockchainMeta[] = [
       blockExplorerUrls: ['https://www.blockchain.com/btc/'],
       addressUrl: 'https://www.blockchain.com/btc/address/{wallet}',
       transactionUrl: 'https://www.blockchain.com/btc/tx/{txHash}',
+      tokenUrl: null,
     },
   },
   {
@@ -130,6 +131,7 @@ export const blockchainsMeta: BlockchainMeta[] = [
       addressUrl: 'https://etherscan.io/address/{wallet}',
       transactionUrl: 'https://etherscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://etherscan.io/token/{address}',
     },
   },
   {
@@ -156,6 +158,7 @@ export const blockchainsMeta: BlockchainMeta[] = [
       blockExplorerUrls: ['https://solscan.io/'],
       addressUrl: 'https://solscan.io/account/{wallet}',
       transactionUrl: 'https://solscan.io/tx/{txHash}',
+      tokenUrl: 'https://solscan.io/token/{address}',
     },
   },
   {
@@ -233,6 +236,7 @@ export const blockchainsMeta: BlockchainMeta[] = [
       blockExplorerUrls: ['https://www.mintscan.io/cosmos/'],
       addressUrl: 'https://www.mintscan.io/cosmos/account/{wallet}',
       transactionUrl: 'https://www.mintscan.io/cosmos/txs/{txHash}',
+      tokenUrl: 'https://www.mintscan.io/cosmos/assets/{address}',
     },
   },
 ];

--- a/wallets/shared/package.json
+++ b/wallets/shared/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@rango-dev/wallets-core": "^0.58.1",
     "ethers": "^6.13.2",
-    "rango-types": "^0.1.98"
+    "rango-types": "^0.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/widget/embedded/package.json
+++ b/widget/embedded/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rango-dev/widget-embedded",
-  "version": "0.59.2-next.0",
+  "version": "0.59.1",
   "license": "MIT",
   "type": "module",
   "source": "./src/index.ts",
@@ -40,8 +40,8 @@
     "ethers": "^6.13.2",
     "immer": "^9.0.19",
     "mitt": "^3.0.0",
-    "rango-sdk": "^0.1.77",
-    "rango-types": "^0.1.98",
+    "rango-sdk": "^0.3.0",
+    "rango-types": "^0.3.0",
     "react-i18next": "^12.2.0",
     "react-router-dom": "^6.8.0",
     "values.js": "2.1.1",

--- a/widget/embedded/src/hooks/usePrepareBlockchainList/usePrepareBlockchainList.mock.ts
+++ b/widget/embedded/src/hooks/usePrepareBlockchainList/usePrepareBlockchainList.mock.ts
@@ -95,6 +95,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://etherscan.io/address/{wallet}',
       transactionUrl: 'https://etherscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://etherscan.io/token/{address}',
     },
   },
   {
@@ -129,6 +130,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://bscscan.com/address/{wallet}',
       transactionUrl: 'https://bscscan.com/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://bscscan.com/token/{address}',
     },
   },
   {
@@ -163,6 +165,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://arbiscan.io/address/{wallet}',
       transactionUrl: 'https://arbiscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://arbiscan.io/token/{address}',
     },
   },
   {
@@ -197,6 +200,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://polygonscan.com/address/{wallet}',
       transactionUrl: 'https://polygonscan.com/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://polygonscan.com/token/{address}',
     },
   },
   {
@@ -231,6 +235,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://explorer.zksync.io/address/{wallet}',
       transactionUrl: 'https://explorer.zksync.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://explorer.zksync.io/token/{address}',
     },
   },
   {
@@ -264,6 +269,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       blockExplorerUrls: ['https://starkscan.co'],
       addressUrl: 'https://starkscan.co/contract/{wallet}',
       transactionUrl: 'https://starkscan.co/tx/{txHash}',
+      tokenUrl: 'https://voyager.online/token/{address}',
     },
   },
   {
@@ -298,6 +304,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://optimistic.etherscan.io/address/{wallet}',
       transactionUrl: 'https://optimistic.etherscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://optimistic.etherscan.io/token/{address}',
     },
   },
   {
@@ -332,6 +339,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://snowtrace.io/address/{wallet}',
       transactionUrl: 'https://snowtrace.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://snowtrace.dev/token/{address}',
     },
   },
   {
@@ -366,6 +374,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://zkevm.polygonscan.com/address/{wallet}',
       transactionUrl: 'https://zkevm.polygonscan.com/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://zkevm.polygonscan.com/token/{address}',
     },
   },
   {
@@ -400,6 +409,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://explorer.linea.build/address/{wallet}',
       transactionUrl: 'https://explorer.linea.build/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://lineascan.build/token/{address}',
     },
   },
   {
@@ -434,6 +444,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://tronscan.org/#/address/{wallet}',
       transactionUrl: 'https://tronscan.org/#/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://tronscan.org/#/token20/{address}',
     },
   },
   {
@@ -462,6 +473,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       blockExplorerUrls: ['https://www.blockchain.com/btc/'],
       addressUrl: 'https://www.blockchain.com/btc/address/{wallet}',
       transactionUrl: 'https://www.blockchain.com/btc/tx/{txHash}',
+      tokenUrl: null,
     },
   },
   {
@@ -539,6 +551,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.04,
       },
+      tokenUrl: 'https://www.mintscan.io/cosmos/assets/{address}',
     },
   },
   {
@@ -623,6 +636,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.04,
       },
+      tokenUrl: 'https://www.mintscan.io/osmosis/assets/{address}',
     },
   },
   {
@@ -700,6 +714,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.05,
       },
+      tokenUrl: 'https://www.mintscan.io/neutron/assets/{address}',
     },
   },
   {
@@ -777,6 +792,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.03,
       },
+      tokenUrl: 'https://www.mintscan.io/noble/assets/{address}',
     },
   },
   {
@@ -803,6 +819,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       blockExplorerUrls: ['https://www.blockchain.com/btc/'],
       addressUrl: 'https://www.blockchain.com/btc/address/{wallet}',
       transactionUrl: 'https://www.blockchain.com/btc/tx/{txHash}',
+      tokenUrl: 'https://solscan.io/token/{address}',
     },
   },
   {
@@ -837,6 +854,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://cronoscan.com/address/{wallet}',
       transactionUrl: 'https://cronoscan.com/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://cronoscan.com/token/{address}',
     },
   },
   {
@@ -892,6 +910,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://explorer.mainnet.aurora.dev/address/{wallet}',
       transactionUrl: 'https://explorer.mainnet.aurora.dev/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: 'https://explorer.mainnet.aurora.dev/token/{address}',
     },
   },
   {
@@ -968,6 +987,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://bobascan.com//address/{wallet}',
       transactionUrl: 'https://bobascan.com//tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -1002,6 +1022,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://moonbeam.moonscan.io/address/{wallet}',
       transactionUrl: 'https://moonbeam.moonscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -1036,6 +1057,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://moonriver.moonscan.io/address/{wallet}',
       transactionUrl: 'https://moonriver.moonscan.io/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -1070,6 +1092,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://www.oklink.com/en/okc/address/{wallet}',
       transactionUrl: 'https://www.oklink.com/en/okc/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -1104,6 +1127,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://blockexplorer.avax.boba.network/address/{wallet}',
       transactionUrl: 'https://blockexplorer.avax.boba.network/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -1130,6 +1154,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       blockExplorerUrls: ['https://www.blockchain.com/btc/'],
       addressUrl: 'https://www.blockchain.com/btc/address/{wallet}',
       transactionUrl: 'https://www.blockchain.com/btc/tx/{txHash}',
+      tokenUrl: null,
     },
   },
   {
@@ -1156,6 +1181,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       blockExplorerUrls: ['https://www.blockchain.com/btc/'],
       addressUrl: 'https://www.blockchain.com/btc/address/{wallet}',
       transactionUrl: 'https://www.blockchain.com/btc/tx/{txHash}',
+      tokenUrl: null,
     },
   },
   {
@@ -1190,6 +1216,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       addressUrl: 'https://hecoinfo.com/address/{wallet}',
       transactionUrl: 'https://hecoinfo.com/tx/{txHash}',
       enableGasV2: true,
+      tokenUrl: null,
     },
   },
   {
@@ -1267,6 +1294,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 1,
         high: 1,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1344,6 +1372,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.03,
         high: 0.04,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1421,6 +1450,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.03,
         high: 0.035,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1494,6 +1524,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
       explorerUrlToTx: 'https://cosmoscan.io/tx/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -1567,6 +1598,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
       explorerUrlToTx: 'https://www.mintscan.io/comdex/txs/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -1644,6 +1676,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.04,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1721,6 +1754,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.3,
         high: 0.4,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1806,6 +1840,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 1,
         high: 1,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -1883,6 +1918,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.0025,
         high: 0.004,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2002,6 +2038,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.0025,
         high: 0.04,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2079,6 +2116,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.0025,
         high: 0.01,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2156,6 +2194,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.015,
         high: 0.15,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2229,6 +2268,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx', 'ibc-go'],
       explorerUrlToTx: 'https://explorebitsong.com/transactions/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -2306,6 +2346,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.0025,
         high: 0.004,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2379,6 +2420,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer'],
       explorerUrlToTx: 'https://www.mintscan.io/ki-chain/txs/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -2456,6 +2498,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.04,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2533,6 +2576,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 7,
         high: 9,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2610,6 +2654,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.025,
         high: 0.03,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2687,6 +2732,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.25,
         high: 0.4,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2764,6 +2810,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 500000000,
         high: 500000000,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2841,6 +2888,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.25,
         high: 0.3,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -2914,6 +2962,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
       explorerUrlToTx: 'https://www.mintscan.io/konstellation/txs/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -2991,6 +3040,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 2,
         high: 3,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -3064,6 +3114,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx'],
       explorerUrlToTx: 'https://www.mintscan.io/bitcanna/txs/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -3141,6 +3192,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
         average: 0.06,
         high: 0.1,
       },
+      tokenUrl: null,
     },
   },
   {
@@ -3214,6 +3266,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx', 'ibc-go'],
       explorerUrlToTx: 'https://explorer.desmos.network/transactions/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
   {
@@ -3287,6 +3340,7 @@ export const sampleBlockchains: BlockchainMeta[] = [
       features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx', 'ibc-go'],
       explorerUrlToTx: 'https://www.mintscan.io/lum/txs/{txHash}',
       gasPriceStep: null,
+      tokenUrl: null,
     },
   },
 ];

--- a/widget/embedded/src/test-utils/fixtures.ts
+++ b/widget/embedded/src/test-utils/fixtures.ts
@@ -216,6 +216,7 @@ export function createEvmBlockchain(): EvmBlockchainMeta {
       addressUrl: faker.internet.url(),
       transactionUrl: faker.internet.url(),
       enableGasV2: faker.datatype.boolean(),
+      tokenUrl: faker.internet.url(),
     },
   };
 }

--- a/widget/playground/package.json
+++ b/widget/playground/package.json
@@ -27,7 +27,7 @@
     "@rango-dev/wallets-react": "^0.45.1",
     "@rango-dev/wallets-shared": "^0.59.1",
     "@rango-dev/widget-embedded": "^0.59.1",
-    "rango-sdk": "^0.1.77",
+    "rango-sdk": "^0.3.0",
     "react": "^18.2.0",
     "react-color": "^2.19.3",
     "react-dom": "^18.2.0",

--- a/widget/ui/package.json
+++ b/widget/ui/package.json
@@ -56,7 +56,7 @@
     "@rango-dev/wallets-shared": "^0.59.1",
     "@stitches/react": "^1.2.8",
     "copy-to-clipboard": "^3.3.3",
-    "rango-types": "^0.1.98",
+    "rango-types": "^0.3.0",
     "react-virtuoso": "^4.6.2"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5048,48 +5048,6 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@rango-dev/signer-cosmos@^0.39.1":
-  version "0.39.1"
-  resolved "https://registry.yarnpkg.com/@rango-dev/signer-cosmos/-/signer-cosmos-0.39.1.tgz#209b501a787c9893857e22a6f5718c930e317d31"
-  integrity sha512-l8lP65gO0p7gJuTvJIly95A6/WcVZj3l2RZ4EjpiFd5+7eUoVT39YE2yJzTFgkRmfjg7dTANLY9XzLI0zz/HXA==
-  dependencies:
-    "@cosmjs/launchpad" "^0.27.1"
-    "@cosmjs/stargate" "^0.31.0"
-    "@keplr-wallet/cosmos" "^0.9.12"
-    cosmjs-types "^0.5.2"
-    long "^5.2.3"
-    rango-types "^0.1.98"
-
-"@rango-dev/widget-embedded@^0.59.1":
-  version "0.59.1"
-  resolved "https://registry.yarnpkg.com/@rango-dev/widget-embedded/-/widget-embedded-0.59.1.tgz#d319ff0fcb2b0c97f9d3fe25cb7427c1dbdbcf98"
-  integrity sha512-4m7wt/PaGL8MgzamQcv6i3rSlQe+uK29YGcEkVOcULH9N3F1VCsYJAA60HfsSLcRqPQJj75Oe7T07qi4ReYByQ==
-  dependencies:
-    "@lingui/core" "4.2.1"
-    "@lingui/react" "4.2.1"
-    "@rango-dev/logging-core" "^0.12.1"
-    "@rango-dev/provider-all" "^0.61.1"
-    "@rango-dev/queue-manager-core" "^0.33.0"
-    "@rango-dev/queue-manager-rango-preset" "^0.61.1"
-    "@rango-dev/queue-manager-react" "^0.33.0"
-    "@rango-dev/signer-solana" "^0.47.1"
-    "@rango-dev/ui" "^0.62.1"
-    "@rango-dev/wallets-core" "^0.58.1"
-    "@rango-dev/wallets-react" "^0.45.1"
-    "@rango-dev/wallets-shared" "^0.59.1"
-    bignumber.js "^9.1.1"
-    copy-to-clipboard "^3.3.3"
-    dayjs "^1.11.7"
-    ethers "^6.13.2"
-    immer "^9.0.19"
-    mitt "^3.0.0"
-    rango-sdk "^0.1.77"
-    rango-types "^0.1.98"
-    react-i18next "^12.2.0"
-    react-router-dom "^6.8.0"
-    values.js "2.1.1"
-    zustand "^4.3.2"
-
 "@remix-run/router@1.13.0":
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.13.0.tgz#7e29c4ee85176d9c08cb0f4456bff74d092c5065"
@@ -12430,11 +12388,6 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
-long@^5.2.3:
-  version "5.3.2"
-  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
-  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
-
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -13992,19 +13945,24 @@ rango-sdk-basic@^0.1.77:
     rango-types "^0.1.98"
     uuid-random "^1.3.2"
 
-rango-sdk@^0.1.77:
-  version "0.1.77"
-  resolved "https://registry.yarnpkg.com/rango-sdk/-/rango-sdk-0.1.77.tgz#46dcf58af265df405a6d94b32d9d4beec904ab40"
-  integrity sha512-Iwx8VVgezb3HZRXMyIbn5NEijCO11rgsHIOlUMB+UB4VKvcpBrTCRG2rmR6axXCdJUrln+8/itRRnSQIuhE5+g==
+rango-sdk@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/rango-sdk/-/rango-sdk-0.3.0.tgz#1c6883dea02dcbd9747649212c90637ead1afd91"
+  integrity sha512-TEeEQAcpuMGJcjxFxeWmgEEZQoT1p7yX/Gh9G6SurVp0E49AbpT1qZ+/euqjHI2R/L7AB2RJq5gOSvRx4OS8KQ==
   dependencies:
     axios "^1.7.4"
-    rango-types "^0.1.98"
+    rango-types "^0.3.0"
     uuid-random "^1.3.2"
 
 rango-types@^0.1.98:
   version "0.1.98"
   resolved "https://registry.yarnpkg.com/rango-types/-/rango-types-0.1.98.tgz#d8d6f2f552a933212d80f53b89b66ab0fd15fbd7"
   integrity sha512-6oD3QOK9jeHYNRQ7LAPKYDKf4THZ4QtsrfqLcKPQUF82AwBmXFGtod0ff+4TtNR1H/ygzM24MbPLk4MYCkRwag==
+
+rango-types@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/rango-types/-/rango-types-0.3.0.tgz#bf77815d5e4a6d7996a4e1128141d2fa869157a2"
+  integrity sha512-aUyGx8gnA5jG2KgAwxUPvfBFPedpZ9qimCz0xKsgh2x3DwgWEKfzjo1F/janhXUx8/e+UviYWmsthptY8lafiQ==
 
 react-color@^2.19.3:
   version "2.19.3"


### PR DESCRIPTION

# Summary

* Bump `rango-types` and `rango-sdk` to `v0.3.0`
* Fix incorrect package versions in:

  * `wallet-core`
  * `signer-cosmos`
  * `widget-embedded`

The versions in these packages were pointing to unpublished releases. As a result, dependent packages resolved the `npm` versions instead of the local workspace packages, which caused the app to break.

Fixes # (issue)


# How did you test this change?

* Run the build command and verify the build completes successfully without errors.

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
