### PR TITLE
ci(publish): upgrade dependents before Nx build and rollback on failure

### DIFF
--- a/scripts/publish/command.mjs
+++ b/scripts/publish/command.mjs
@@ -17,6 +17,11 @@ import { update } from './package.mjs';
 import { build } from './build.mjs';
 import { should } from '../common/features.mjs';
 import { bumpClientAndRootVersionsAndGenerateRootChangelog } from './version-log.mjs';
+import {
+  upgradeAllDependents,
+  snapshotOriginalVersions,
+  revertDependentsForFailedPackages,
+} from './upgrade.mjs';
 
 async function run() {
   logAsSection('::group::🔍 Checking environments...');
@@ -52,16 +57,13 @@ async function run() {
 
   console.log('Next state:');
   console.table(
-    pkgs.map((pkg) => {
-      return {
-        name: pkg.name,
-        ...state.getState(pkg.name),
-      };
-    })
+    pkgs.map((pkg) => ({
+      name: pkg.name,
+      ...state.getState(pkg.name),
+    }))
   );
 
   throwIfUnableToProceed(pkgStates);
-
   console.log('::endgroup::');
 
   // 2. Generate root changelog and bump widget, app and root versions.
@@ -69,20 +71,37 @@ async function run() {
   await bumpClientAndRootVersionsAndGenerateRootChangelog();
   console.log('::endgroup::');
 
-  // 3. Build all packacges
-  /**
-   * IMPORTANT NOTE:
-   * We are all the libs in parallel, parcel has a limitation on running `parcel` instances.
-   * So if you are trying to build multiple parcel apps it goes through some erros. here, for publishing libs
-   * We are using esbuild so don't need to do anything.
-   * but if we need, the potential solution is filtering parcel apps and run them secquentially.
-   */
+  // 3. Upgrade dependents BEFORE building.
+  //
+  // Critical ordering fix: Nx must see the bumped dependency versions in
+  // package.json files before it starts resolving the build graph. Previously,
+  // upgradeDependents ran inside publishTask (after the build), so Nx was
+  // resolving stale versions and failing.
+  //
+  // We snapshot the *original* (pre-bump) version of each package so that if
+  // a publish fails later, we can surgically revert only the entries for the
+  // failed packages inside each dependent's package.json — without touching
+  // the entries that belong to packages that published successfully.
+  logAsSection('::group::⬆️  Upgrading dependents before build...');
 
+  // Snapshot original versions BEFORE the upgrade rewrites package.json files.
+  // `pkgs` here already has the bumped version from state.list(), so we read
+  // from `libPkgs` which still holds the original version strings.
+  const originalVersions = snapshotOriginalVersions(libPkgs);
+
+  await upgradeAllDependents(pkgs);
+  console.log('::endgroup::');
+
+  // 4. Build all packages (Nx now sees the correct, up-to-date versions).
+  //
+  // NOTE: We build all libs in parallel. Parcel has a limitation on concurrent
+  // instances, but for publishing we use esbuild, so this is not a concern.
+  // If a Parcel app is added later, filter it out and run it sequentially.
   logAsSection(`::group::🔨 Start building...`);
   await build(pkgs);
   console.log('::endgroup::');
 
-  // 4. Publish
+  // 5. Publish
   logAsSection(`::group::🚀 Start publishing...`);
   try {
     await tryPublish(pkgs, {
@@ -92,30 +111,49 @@ async function run() {
     console.error(e);
 
     /** @type {import('../common/typedefs.mjs').Package | undefined} */
-    const pkg = e.cause.pkg;
-    if (!pkg) {
+    const failedPkg = e.cause?.pkg;
+
+    if (!failedPkg) {
       console.error(
         "🚨 The error hasn't thrown `pkg`. Here is more information to debug"
       );
       console.log(state.toJSON());
     } else {
-      // Ignoring error since it's possible to file hasn't changed yet.
-      await addPkgFileChangesToStage(pkg).catch(console.warn);
+      // Stage whatever partial file changes exist for the failed package.
+      await addPkgFileChangesToStage(failedPkg).catch(console.warn);
+
+      // Determine which packages did NOT make it to npm.
+      // A package with npmVersion in state was published successfully.
+      const failedPkgs = pkgs.filter(
+        (pkg) => !state.getState(pkg.name, 'npmVersion')
+      );
+
+      // Surgically revert dependency entries for failed packages across the
+      // entire workspace. Dependents that reference multiple packages from this
+      // publish run will only have the failed packages' entries reverted —
+      // entries for successfully published packages are left at their new version.
+      if (failedPkgs.length > 0) {
+        console.warn(
+          `⏪ Reverting ${failedPkgs.length} failed package(s) from dependents: ` +
+            failedPkgs.map((p) => p.name).join(', ')
+        );
+        await revertDependentsForFailedPackages(
+          failedPkgs,
+          originalVersions
+        ).catch(console.warn);
+      }
     }
   }
 
   console.log('::endgroup::');
 
-  // 5. Tag and Push
-
-  /**
-   * Our final list will includes only packages that published on NPM.
-   * If a package failed on making changelog, github release, ...
-   * We are considering it's published and should handle those cases manually.
-   */
+  // 6. Tag and Push.
+  //
+  // Only include packages that were successfully published to npm.
+  // If a package failed mid-way (changelog, github release, etc.) we still
+  // treat it as published and handle those edge cases manually.
   const listPkgsForTag = state.list().filter((pkg) => {
-    const isPublishedOnNpm = !!state.getState(pkg.name, 'npmVersion');
-    return isPublishedOnNpm;
+    return !!state.getState(pkg.name, 'npmVersion');
   });
 
   logAsSection(
@@ -125,11 +163,8 @@ async function run() {
   if (listPkgsForTag.length > 0) {
     performance.mark(`start-publish-tagging`);
 
-    /**
-     * We don't need to tag and mention them while publishing, they have a separate github action.
-     * But we updated their package json to use the latest version of published libs
-     * So we should includes them in our commit.
-     */
+    // Client packages had their package.json updated to reference the new
+    // lib versions — include them in the commit even though they're not tagged.
     await sequentiallyRun(
       clientPkgs.map(
         (pkg) => () => addFileToStage(`${pkg.location}`).catch(console.warn)
@@ -139,20 +174,20 @@ async function run() {
     await publishCommitAndTags(listPkgsForTag);
     await push();
     performance.mark(`end-publish-tagging`);
-    const duration_build = performance.measure(
+    const duration_tagging = performance.measure(
       `publish-tagging`,
       `start-publish-tagging`,
       `end-publish-tagging`
     ).duration;
-    console.log(`Tagged. ${duration_build}ms`);
+    console.log(`Tagged. ${duration_tagging}ms`);
   } else {
     console.log('Skipped.');
   }
 
   console.log('::endgroup::');
 
-  // 6. Making github release
-  // NOTE: If any error happens in this step we are don't bail out the process and will continue. A warning will be shown.
+  // 7. Making github release.
+  // NOTE: Errors here are non-fatal — we log a warning and continue.
   console.log('::group::🐙 Github release');
   if (should('generateChangelog')) {
     if (listPkgsForTag.length > 0) {
@@ -169,12 +204,12 @@ async function run() {
       await Promise.all(tasks);
 
       performance.mark(`end-publish-gh-release`);
-      const duration_build = performance.measure(
+      const duration_release = performance.measure(
         `publish-gh-release`,
         `start-publish-gh-release`,
         `end-publish-gh-release`
       ).duration;
-      console.log(`Finished. ${duration_build}ms`);
+      console.log(`Finished. ${duration_release}ms`);
     } else {
       console.log('Skipped.');
     }
@@ -183,7 +218,7 @@ async function run() {
   }
   console.log('::endgroup::');
 
-  // 6. Report
+  // 8. Report
   console.log('::group::📊 Report');
   console.table(
     pkgs.map((pkg) => ({

--- a/scripts/publish/publish.mjs
+++ b/scripts/publish/publish.mjs
@@ -2,23 +2,22 @@ import chalk from 'chalk';
 import { generateChangelogAndSave } from '../common/changelog.mjs';
 import { should } from '../common/features.mjs';
 import { publishOnNpm } from '../common/npm.mjs';
-import { upgradeDependents } from './upgrade.mjs';
 import { addPkgFileChangesToStage, sequentiallyRun } from './utils.mjs';
 
 /**
- *
- * By giving a list of packages, we will try to publish all of them.
- * Publishing includes some steps to be done.
+ * By giving a list of packages, we will try to publish all of them sequentially.
+ * Dependent upgrades are expected to have already been applied before calling this
+ * (see `upgradeAllDependents` in upgrade.mjs), so this function only handles
+ * npm publish → changelog → git staging.
  *
  * @param {import("../common/utils.mjs").Package[]} pkgs
+ * @param {{ onUpdateState: (name: string, key: string, value: string) => void }} options
  */
 export async function tryPublish(pkgs, { onUpdateState }) {
   const tasks = pkgs.map(
     (pkg) => () =>
       publishTask(pkg, { onUpdateState }).catch((e) => {
-        e.cause = {
-          pkg,
-        };
+        e.cause = { pkg };
         throw e;
       })
   );
@@ -28,31 +27,31 @@ export async function tryPublish(pkgs, { onUpdateState }) {
 }
 
 /**
+ * Executes all steps required to publish a single package:
+ *   1. Publish to npm
+ *   2. Generate changelog (if enabled)
+ *   3. Stage changed files for git commit
  *
- * There are some few steps to be finshed to publish a package.
- * This function contains these steps.
+ * Note: dependent package.json upgrades are intentionally excluded here.
+ * They are performed in bulk via `upgradeAllDependents` in command.mjs
+ * *before* the Nx build step so that Nx picks up the correct versions.
  *
  * @param {import('../common/typedefs.mjs').Package} pkg
+ * @param {{ onUpdateState: (name: string, key: string, value: string) => void }} options
  */
 async function publishTask(pkg, { onUpdateState }) {
-  console.log(chalk.green('[1/4]'), `Publish ${pkg.name} to npm`);
+  console.log(chalk.green('[1/3]'), `Publish ${pkg.name} to npm`);
   await publishOnNpm(pkg);
   onUpdateState(pkg.name, 'npmVersion', pkg.version);
 
   if (should('generateChangelog')) {
-    console.log(chalk.green('[2/4]'), `Making changelog`);
+    console.log(chalk.green('[2/3]'), `Making changelog`);
     await generateChangelogAndSave(pkg);
   } else {
-    console.log(chalk.green('[2/4]'), `Skipping changelog and github release.`);
+    console.log(chalk.green('[2/3]'), `Skipping changelog and github release.`);
   }
 
-  console.log(
-    chalk.green('[3/4]'),
-    `Upgrade all the dependent packages to latest version`
-  );
-  await upgradeDependents(pkg);
-
-  console.log(chalk.green('[4/4]'), `Adding files to staging area`);
+  console.log(chalk.green('[3/3]'), `Adding files to staging area`);
   await addPkgFileChangesToStage(pkg);
 
   console.log(`🚀 ${pkg.name} published.`);

--- a/scripts/publish/upgrade.mjs
+++ b/scripts/publish/upgrade.mjs
@@ -1,11 +1,14 @@
 import { execa } from 'execa';
+import { readFile, writeFile } from 'node:fs/promises';
 import { CustomScriptError } from '../common/errors.mjs';
+import { packageJsonPath } from '../common/path.mjs';
+import { workspacePackages } from '../common/utils.mjs';
 
 /**
+ * Upgrades all dependents of a given package to use its new version.
+ * Internally calls the `yarn upgrade-all` workspace script.
  *
- * Update all the packages that use a specific package to a specific package
- *
- * @param {import("../common/typedefs.mjs").Package} pkgs
+ * @param {import("../common/typedefs.mjs").Package} pkg
  */
 export async function upgradeDependents(pkg) {
   await execa('yarn', [
@@ -18,4 +21,112 @@ export async function upgradeDependents(pkg) {
   ]).catch((e) => {
     throw new CustomScriptError(e.stderr);
   });
+}
+
+/**
+ * Upgrades dependents for every package in the list, in sequence.
+ * Must be called after versions have been bumped but **before** the Nx build,
+ * so that Nx resolves the correct (new) peer/dep versions from package.json files.
+ *
+ * @param {import("../common/typedefs.mjs").Package[]} pkgs
+ */
+export async function upgradeAllDependents(pkgs) {
+  for (const pkg of pkgs) {
+    await upgradeDependents(pkg);
+  }
+}
+
+/**
+ * Records the version each published package was at *before* the upgrade step,
+ * keyed by package name. This is the version that dependents' package.json files
+ * referenced before `upgradeAllDependents` was called — i.e. the value we revert
+ * to for failed publishers.
+ *
+ * @param {import("../common/typedefs.mjs").Package[]} pkgs
+ * Packages as they exist before version bumping (original versions).
+ * @returns {Map<string, string>} pkg.name → original version string
+ */
+export function snapshotOriginalVersions(pkgs) {
+  return new Map(pkgs.map((pkg) => [pkg.name, pkg.version]));
+}
+
+/**
+ * Reverts dependency version entries inside every workspace package.json that
+ * referenced a package that failed to publish.
+ *
+ * A dependent may depend on several packages from the same publish run.
+ * Some of those may have published successfully and some may not. This function
+ * only touches the entries for the failed packages — it leaves entries for
+ * successfully published packages at their new (bumped) version.
+ *
+ * @param {import("../common/typedefs.mjs").Package[]} failedPkgs
+ *   Packages that did NOT publish successfully.
+ * @param {Map<string, string>} originalVersions
+ *   The version map produced by `snapshotOriginalVersions` — what each package's
+ *   version was before the upgrade step ran.
+ */
+export async function revertDependentsForFailedPackages(
+  failedPkgs,
+  originalVersions
+) {
+  if (failedPkgs.length === 0) return;
+
+  // Collect package.json paths for every package registered in the workspace.
+  // `workspacePackages()` is the same source used elsewhere in this pipeline
+  // (e.g. version-log.mjs) so we stay within the known monorepo boundary
+  // instead of crawling the filesystem with a glob.
+  const allWorkspacePkgs = await workspacePackages();
+  const packageJsonFiles = allWorkspacePkgs.map((pkg) =>
+    packageJsonPath(pkg.location)
+  );
+
+  for (const filePath of packageJsonFiles) {
+    const raw = await readFile(filePath, 'utf-8');
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      // Skip malformed files — shouldn't happen in a healthy repo.
+      continue;
+    }
+
+    let dirty = false;
+
+    // All dependency field types that can hold version references.
+    const depFields = [
+      'dependencies',
+      'devDependencies',
+      'peerDependencies',
+      'optionalDependencies',
+    ];
+
+    for (const failedPkg of failedPkgs) {
+      const originalVersion = originalVersions.get(failedPkg.name);
+      if (!originalVersion) continue;
+
+      for (const field of depFields) {
+        if (parsed[field]?.[failedPkg.name] !== undefined) {
+          const currentValue = parsed[field][failedPkg.name];
+          // Preserve range prefixes (^, ~, >=, etc.) that were already there.
+          // We replace only the version number portion, keeping the prefix intact.
+          const prefix = currentValue.match(/^[^0-9]*/)?.[0] ?? '';
+          const reverted = `${prefix}${originalVersion}`;
+
+          if (currentValue !== reverted) {
+            parsed[field][failedPkg.name] = reverted;
+            dirty = true;
+            console.warn(
+              `  ↩ ${filePath}: reverted ${failedPkg.name} from "${currentValue}" → "${reverted}"`
+            );
+          }
+        }
+      }
+    }
+
+    if (dirty) {
+      // Write back with the same indentation style as the original file.
+      const indent = raw.match(/^{\n(\s+)/)?.[1] ?? '  ';
+      await writeFile(filePath, JSON.stringify(parsed, null, indent) + '\n', 'utf-8');
+    }
+  }
 }


### PR DESCRIPTION
# Summary

After upgrading Nx to the latest version, the publish pipeline started failing at the build step. The root cause was a ordering bug: `upgradeDependents` was called inside `publishTask` — i.e. **after** the Nx build had already finished. Nx was resolving dependency versions from `package.json` files that still referenced the old versions, causing it to fail to find the freshly-bumped packages.

This PR fixes the ordering and adds a rollback mechanism for dependents when a publish fails.

Fixes # (issue)




# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.