### PR TITLE
fix: fixed ton signer data

### DIFF
--- a/signers/signer-ton/src/signer.ts
+++ b/signers/signer-ton/src/signer.ts
@@ -1,6 +1,6 @@
 import type { GenericSigner, TonTransaction } from 'rango-types';
 
-import { Cell } from '@ton/core';
+import { Address, Cell } from '@ton/core';
 import { SignerError } from 'rango-types';
 
 export class DefaultTonSigner implements GenericSigner<TonTransaction> {
@@ -14,7 +14,17 @@ export class DefaultTonSigner implements GenericSigner<TonTransaction> {
   }
 
   async signAndSendTx(tx: TonTransaction): Promise<{ hash: string }> {
-    const { type, blockChain, ...transactionObjectForSign } = tx;
+    const { type, blockChain, from, messages, ...rest } = tx;
+
+    const transactionObjectForSign = {
+      ...rest,
+      ...(from && { from: Address.parse(from).toRawString() }),
+      messages: messages.map(({ stateInit, payload, ...msg }) => ({
+        ...msg,
+        ...(stateInit != null && { stateInit }),
+        ...(payload != null && { payload }),
+      })),
+    };
 
     const { result } = await this.provider.send({
       method: 'sendTransaction',

--- a/wallets/provider-tonconnect/src/signers/ton.ts
+++ b/wallets/provider-tonconnect/src/signers/ton.ts
@@ -1,7 +1,7 @@
 import type { TonConnectUI } from '@tonconnect/ui';
 import type { GenericSigner, TonTransaction } from 'rango-types';
 
-import { Cell } from '@ton/core';
+import { Address, Cell } from '@ton/core';
 import { CHAIN } from '@tonconnect/ui';
 import { SignerError } from 'rango-types';
 
@@ -17,9 +17,15 @@ export class CustomTonSigner implements GenericSigner<TonTransaction> {
   }
 
   async signAndSendTx(tx: TonTransaction): Promise<{ hash: string }> {
-    const { blockChain, type, ...txObjectForSign } = tx;
+    const { blockChain, type, from, messages, ...rest } = tx;
     const result = await this.provider.sendTransaction({
-      ...txObjectForSign,
+      ...rest,
+      ...(from && { from: Address.parse(from).toRawString() }),
+      messages: messages.map(({ stateInit, payload, ...msg }) => ({
+        ...msg,
+        ...(stateInit != null && { stateInit }),
+        ...(payload != null && { payload }),
+      })),
       network: CHAIN.MAINNET,
     });
 


### PR DESCRIPTION
# Summary

Tonkeeper wallet checks the schema of the transaction we are passing to it before running it. The transaction should have raw address format and shouldn't contain null values

Fixes # (issue)
Fixed siging ton transacitons


# How did you test this change?

- [x] Tested with both Tonkeeper and MyTonWallet wallets in localhost


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
