### PR TITLE
chore: migrating from wallet-core to @hub3js/*

### DIFF
--- a/queue-manager/rango-preset/package.json
+++ b/queue-manager/rango-preset/package.json
@@ -34,6 +34,8 @@
     "@types/uuid": "^8.3.4"
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/namespaces": "^0.1.1",
     "@rango-dev/logging-core": "^0.12.1",
     "@stellar/stellar-sdk": "^15.0.1",
     "rango-types": "^0.5.0",

--- a/queue-manager/rango-preset/src/actions/checkStellarTrustline/types.ts
+++ b/queue-manager/rango-preset/src/actions/checkStellarTrustline/types.ts
@@ -1,4 +1,4 @@
-import type { ProxiedNamespace } from '@rango-dev/wallets-core';
+import type { ProxiedNamespace } from '@hub3js/core';
 import type { StellarActions } from '@rango-dev/wallets-core/namespaces/stellar';
 
 export type StellarNamespace = ProxiedNamespace<StellarActions>;

--- a/queue-manager/rango-preset/src/actions/checkXrplTrustline/types.ts
+++ b/queue-manager/rango-preset/src/actions/checkXrplTrustline/types.ts
@@ -1,4 +1,4 @@
-import type { ProxiedNamespace } from '@rango-dev/wallets-core';
+import type { ProxiedNamespace } from '@hub3js/core';
 import type { XRPLActions } from '@rango-dev/wallets-core/namespaces/xrpl';
 
 export type XrplNamespace = ProxiedNamespace<XRPLActions>;

--- a/queue-manager/rango-preset/src/helpers.ts
+++ b/queue-manager/rango-preset/src/helpers.ts
@@ -12,6 +12,8 @@ import type {
   SwapStorage,
   UseQueueManagerParams,
 } from './types';
+import type { Provider } from '@hub3js/core';
+import type { DefaultNamespaces } from '@hub3js/namespaces';
 import type {
   ExecuterActions,
   Manager,
@@ -20,7 +22,6 @@ import type {
   QueueType,
   SetStorage,
 } from '@rango-dev/queue-manager-core';
-import type { Provider } from '@rango-dev/wallets-core';
 import type {
   Meta,
   Network,
@@ -689,7 +690,7 @@ async function getChainId(provider: any): Promise<string | number | null> {
 
 export async function getProviderChainId(
   providers: Providers,
-  hubProvider: (type: WalletType) => Provider,
+  hubProvider: (type: WalletType) => Provider<DefaultNamespaces>,
   walletType: string
 ) {
   const legacyProvider = getEvmProvider(providers, walletType);
@@ -718,7 +719,7 @@ export async function isNetworkMatchedForTransaction(
   wallet: Wallet | null,
   meta: Meta,
   providers: Providers,
-  hubProvider: (type: WalletType) => Provider
+  hubProvider: (type: WalletType) => Provider<DefaultNamespaces>
 ): Promise<boolean> {
   if (isWalletNull(wallet)) {
     return false;

--- a/queue-manager/rango-preset/src/types.ts
+++ b/queue-manager/rango-preset/src/types.ts
@@ -1,10 +1,11 @@
 import type { TargetNamespace, Wallet } from './shared';
+import type { Provider } from '@hub3js/core';
+import type { DefaultNamespaces } from '@hub3js/namespaces';
 import type {
   QueueContext,
   QueueDef,
   QueueStorage,
 } from '@rango-dev/queue-manager-core';
-import type { Provider } from '@rango-dev/wallets-core';
 import type { LegacyConnectResult as ConnectResult } from '@rango-dev/wallets-core/legacy';
 import type {
   Meta,
@@ -77,7 +78,7 @@ export interface SwapQueueContext extends QueueContext {
   meta: Meta;
   wallets: Wallet | null;
   providers: Providers;
-  hubProvider: (type: WalletType) => Provider;
+  hubProvider: (type: WalletType) => Provider<DefaultNamespaces>;
   getSigners: (type: WalletType) => Promise<SignerFactory>;
   switchNetwork: (
     wallet: WalletType,

--- a/wallets/provider-all/package.json
+++ b/wallets/provider-all/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
     "@rango-dev/provider-binance": "^0.3.1-next.0",
     "@rango-dev/provider-bitget": "^0.57.1-next.0",
     "@rango-dev/provider-braavos": "^0.54.1-next.0",

--- a/wallets/provider-all/src/helpers.ts
+++ b/wallets/provider-all/src/helpers.ts
@@ -1,8 +1,8 @@
-import type { VersionedProviders } from '@rango-dev/wallets-core/utils';
+import type { VersionedProviders } from '@hub3js/core/utils';
 import type { ProviderInterface } from '@rango-dev/wallets-react';
 import type { WalletType, WalletTypes } from '@rango-dev/wallets-shared';
 
-import { Provider } from '@rango-dev/wallets-core';
+import { Provider } from '@hub3js/core';
 
 export const isWalletExcluded = (
   providers: (WalletType | ProviderInterface | Provider)[],

--- a/wallets/provider-all/src/index.ts
+++ b/wallets/provider-all/src/index.ts
@@ -1,7 +1,8 @@
+import type { Provider } from '@hub3js/core';
+import type { VersionedProviders } from '@hub3js/core/utils';
 import type { Environments as TonConnectEnvironments } from '@rango-dev/provider-tonconnect';
 import type { Environments as TrezorEnvironments } from '@rango-dev/provider-trezor';
 import type { Environments as WalletConnectEnvironments } from '@rango-dev/provider-walletconnect-2';
-import type { Provider } from '@rango-dev/wallets-core';
 import type { ProviderInterface } from '@rango-dev/wallets-react';
 
 import { versions as binance } from '@rango-dev/provider-binance';
@@ -38,10 +39,7 @@ import { versions as vultisig } from '@rango-dev/provider-vultisig';
 import * as walletconnect2 from '@rango-dev/provider-walletconnect-2';
 import * as xdefi from '@rango-dev/provider-xdefi';
 import { versions as xverse } from '@rango-dev/provider-xverse';
-import {
-  legacyProviderImportsToVersionsInterface,
-  type VersionedProviders,
-} from '@rango-dev/wallets-core/utils';
+import { legacyProviderImportsToVersionsInterface } from '@rango-dev/wallets-core/utils';
 import { type WalletType, WalletTypes } from '@rango-dev/wallets-shared';
 
 import { isWalletExcluded, lazyProvider } from './helpers.js';

--- a/wallets/provider-binance/package.json
+++ b/wallets/provider-binance/package.json
@@ -21,6 +21,9 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",

--- a/wallets/provider-binance/src/constants.ts
+++ b/wallets/provider-binance/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { type BlockchainMeta } from 'rango-types';
 

--- a/wallets/provider-binance/src/mod.ts
+++ b/wallets/provider-binance/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-binance/src/namespaces/evm.ts
+++ b/wallets/provider-binance/src/namespaces/evm.ts
@@ -1,15 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  utils,
-} from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, utils } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmBinance, getEvmAccounts } from '../utils.js';

--- a/wallets/provider-binance/src/provider.ts
+++ b/wallets/provider-binance/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-binance/src/types.ts
+++ b/wallets/provider-binance/src/types.ts
@@ -1,5 +1,5 @@
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
 
 export type ProviderObject = {
   [LegacyNetworks.ETHEREUM]: EvmProviderApi;

--- a/wallets/provider-binance/src/utils.ts
+++ b/wallets/provider-binance/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 
+import { type ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import { type ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
 
 export function binance(): Provider | null {
   const { binancew3w } = window;

--- a/wallets/provider-bitget/package.json
+++ b/wallets/provider-bitget/package.json
@@ -21,6 +21,9 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/signer-tron": "^0.41.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",

--- a/wallets/provider-bitget/src/actions/utxo.ts
+++ b/wallets/provider-bitget/src/actions/utxo.ts
@@ -1,7 +1,5 @@
-import {
-  type Context,
-  type FunctionWithContext,
-} from '@rango-dev/wallets-core';
+import type { Context, FunctionWithContext } from '@hub3js/core';
+
 import {
   CAIP_BITCOIN_CHAIN_ID,
   type ProviderAPI,

--- a/wallets/provider-bitget/src/builders/tron.ts
+++ b/wallets/provider-bitget/src/builders/tron.ts
@@ -1,6 +1,6 @@
 import type { TronChangeAccountEvent } from '../types.js';
 
-import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 import {
   type ProviderAPI,
   type TronActions,

--- a/wallets/provider-bitget/src/builders/utxo.ts
+++ b/wallets/provider-bitget/src/builders/utxo.ts
@@ -1,5 +1,5 @@
-import { ActionBuilder } from '@rango-dev/wallets-core';
-import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
+import { ActionBuilder } from '@hub3js/core';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 import {
   CAIP_BITCOIN_CHAIN_ID,
   type ProviderAPI,

--- a/wallets/provider-bitget/src/constants.ts
+++ b/wallets/provider-bitget/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import {
   type BlockchainMeta,

--- a/wallets/provider-bitget/src/hooks/utxo.ts
+++ b/wallets/provider-bitget/src/hooks/utxo.ts
@@ -1,8 +1,4 @@
-import type {
-  AnyFunction,
-  Subscriber,
-  SubscriberCleanUp,
-} from '@rango-dev/wallets-core';
+import type { AnyFunction, Subscriber, SubscriberCleanUp } from '@hub3js/core';
 import type {
   ProviderAPI,
   UtxoActions,

--- a/wallets/provider-bitget/src/mod.ts
+++ b/wallets/provider-bitget/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-bitget/src/namespaces/evm.ts
+++ b/wallets/provider-bitget/src/namespaces/evm.ts
@@ -1,15 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  hooks,
-} from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, hooks } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmBitget } from '../utils.js';

--- a/wallets/provider-bitget/src/namespaces/tron.ts
+++ b/wallets/provider-bitget/src/namespaces/tron.ts
@@ -1,8 +1,6 @@
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import {
   type TronActions,
   utils,

--- a/wallets/provider-bitget/src/namespaces/utxo.ts
+++ b/wallets/provider-bitget/src/namespaces/utxo.ts
@@ -1,10 +1,8 @@
 import type { UtxoActions } from '@rango-dev/wallets-core/namespaces/utxo';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import { builders } from '@rango-dev/wallets-core/namespaces/utxo';
 
 import { utxoActions } from '../actions/utxo.js';

--- a/wallets/provider-bitget/src/provider.ts
+++ b/wallets/provider-bitget/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-bitget/src/types.ts
+++ b/wallets/provider-bitget/src/types.ts
@@ -1,5 +1,5 @@
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
 import type { ProviderAPI as TronProviderApi } from '@rango-dev/wallets-core/namespaces/tron';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 

--- a/wallets/provider-bitget/src/utils.ts
+++ b/wallets/provider-bitget/src/utils.ts
@@ -1,5 +1,5 @@
 import type { Provider } from './types.js';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as TronProviderApi } from '@rango-dev/wallets-core/namespaces/tron';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 

--- a/wallets/provider-braavos/package.json
+++ b/wallets/provider-braavos/package.json
@@ -21,6 +21,8 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-starknet": "^0.42.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",

--- a/wallets/provider-braavos/src/actions/starknet.ts
+++ b/wallets/provider-braavos/src/actions/starknet.ts
@@ -1,4 +1,4 @@
-import type { Context, FunctionWithContext } from '@rango-dev/wallets-core';
+import type { Context, FunctionWithContext } from '@hub3js/core';
 
 import {
   CAIP_STARKNET_CHAIN_ID,

--- a/wallets/provider-braavos/src/builders/starknet.ts
+++ b/wallets/provider-braavos/src/builders/starknet.ts
@@ -3,7 +3,7 @@ import type {
   StarknetActions,
 } from '@rango-dev/wallets-core/namespaces/starknet';
 
-import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 import { utils } from '@rango-dev/wallets-core/namespaces/starknet';
 // Hooks
 export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>

--- a/wallets/provider-braavos/src/constants.ts
+++ b/wallets/provider-braavos/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { type BlockchainMeta, starknetBlockchain } from 'rango-types';
 
 import getSigners from './signer.js';

--- a/wallets/provider-braavos/src/mod.ts
+++ b/wallets/provider-braavos/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-braavos/src/namespaces/starknet.ts
+++ b/wallets/provider-braavos/src/namespaces/starknet.ts
@@ -1,10 +1,8 @@
 import type { StarknetActions } from '@rango-dev/wallets-core/namespaces/starknet';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import { actions, builders } from '@rango-dev/wallets-core/namespaces/starknet';
 
 import { starknetActions } from '../actions/starknet.js';

--- a/wallets/provider-braavos/src/provider.ts
+++ b/wallets/provider-braavos/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { starknet } from './namespaces/starknet.js';

--- a/wallets/provider-brave/package.json
+++ b/wallets/provider-brave/package.json
@@ -21,6 +21,10 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/signer-solana": "^0.48.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",

--- a/wallets/provider-brave/src/constants.ts
+++ b/wallets/provider-brave/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import {
   type BlockchainMeta,
   evmBlockchains,

--- a/wallets/provider-brave/src/mod.ts
+++ b/wallets/provider-brave/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-brave/src/namespaces/evm.ts
+++ b/wallets/provider-brave/src/namespaces/evm.ts
@@ -1,15 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  hooks,
-} from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, hooks } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmBrave } from '../utils.js';

--- a/wallets/provider-brave/src/namespaces/solana.ts
+++ b/wallets/provider-brave/src/namespaces/solana.ts
@@ -1,15 +1,9 @@
-import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
+import type { SolanaActions } from '@hub3js/solana';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  hooks,
-} from '@rango-dev/wallets-core/namespaces/solana';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, hooks } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { solanaBrave } from '../utils.js';

--- a/wallets/provider-brave/src/provider.ts
+++ b/wallets/provider-brave/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-brave/src/types.ts
+++ b/wallets/provider-brave/src/types.ts
@@ -1,6 +1,6 @@
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
 
 export type ProviderObject = {
   [LegacyNetworks.ETHEREUM]: EvmProviderApi;

--- a/wallets/provider-brave/src/utils.ts
+++ b/wallets/provider-brave/src/utils.ts
@@ -1,6 +1,6 @@
 import type { Provider } from './types.js';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 
@@ -54,5 +54,5 @@ export function solanaBrave(): SolanaProviderApi {
     );
   }
 
-  return solanaInstance as SolanaProviderApi;
+  return solanaInstance;
 }

--- a/wallets/provider-coin98/package.json
+++ b/wallets/provider-coin98/package.json
@@ -21,6 +21,10 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/signer-solana": "^0.48.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",

--- a/wallets/provider-coin98/src/actions/solana.ts
+++ b/wallets/provider-coin98/src/actions/solana.ts
@@ -1,10 +1,10 @@
-import type { Context, FunctionWithContext } from '@rango-dev/wallets-core';
+import type { Context, FunctionWithContext } from '@hub3js/core';
 
 import {
   type SolanaActions,
   type ProviderAPI as SolanaProviderApi,
   utils,
-} from '@rango-dev/wallets-core/namespaces/solana';
+} from '@hub3js/solana';
 
 function connect(
   getInstance: () => SolanaProviderApi

--- a/wallets/provider-coin98/src/constants.ts
+++ b/wallets/provider-coin98/src/constants.ts
@@ -1,4 +1,4 @@
-import type { ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
 
 import { WalletTypes } from '@rango-dev/wallets-shared';
 import {

--- a/wallets/provider-coin98/src/mod.ts
+++ b/wallets/provider-coin98/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-coin98/src/namespaces/evm.ts
+++ b/wallets/provider-coin98/src/namespaces/evm.ts
@@ -1,11 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmCoin98 } from '../utils.js';

--- a/wallets/provider-coin98/src/namespaces/solana.ts
+++ b/wallets/provider-coin98/src/namespaces/solana.ts
@@ -1,12 +1,7 @@
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  builders,
-  type SolanaActions,
-} from '@rango-dev/wallets-core/namespaces/solana';
+import { NamespaceBuilder } from '@hub3js/core';
+import { builders, type SolanaActions } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { solanaActions } from '../actions/solana.js';
 import { WALLET_ID } from '../constants.js';

--- a/wallets/provider-coin98/src/provider.ts
+++ b/wallets/provider-coin98/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { COIN98_INJECTION_DELAY, metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-coin98/src/types.ts
+++ b/wallets/provider-coin98/src/types.ts
@@ -1,6 +1,6 @@
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
 
 type ProviderObject = {
   [LegacyNetworks.ETHEREUM]: EvmProviderApi;

--- a/wallets/provider-coin98/src/utils.ts
+++ b/wallets/provider-coin98/src/utils.ts
@@ -1,6 +1,6 @@
 import type { Provider } from './types.js';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
 import { Networks } from '@rango-dev/wallets-shared';
 

--- a/wallets/provider-coinbase/package.json
+++ b/wallets/provider-coinbase/package.json
@@ -21,6 +21,10 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/signer-solana": "^0.48.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",

--- a/wallets/provider-coinbase/src/constants.ts
+++ b/wallets/provider-coinbase/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import {
   type BlockchainMeta,
   evmBlockchains,

--- a/wallets/provider-coinbase/src/mod.ts
+++ b/wallets/provider-coinbase/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildLegacyProvider } from './legacy/index.js';
 import { buildProvider } from './provider.js';

--- a/wallets/provider-coinbase/src/namespaces/evm.ts
+++ b/wallets/provider-coinbase/src/namespaces/evm.ts
@@ -1,18 +1,14 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, utils } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
 import {
-  builders as commonBuilders,
   connectAndUpdateStateForMultiNetworks,
   intoConnecting,
   intoConnectionFinished,
   standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  utils,
-} from '@rango-dev/wallets-core/namespaces/evm';
+} from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmCoinbase } from '../utils.js';

--- a/wallets/provider-coinbase/src/namespaces/solana.ts
+++ b/wallets/provider-coinbase/src/namespaces/solana.ts
@@ -1,14 +1,14 @@
-import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
+import type { SolanaActions } from '@hub3js/solana';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import { actions, builders } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
 import {
-  builders as commonBuilders,
   connectAndUpdateStateForSingleNetwork,
   intoConnecting,
   intoConnectionFinished,
   standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/solana';
+} from '@hub3js/std/operators';
 
 import { solanaActions } from '../actions/solana.js';
 import { WALLET_ID } from '../constants.js';

--- a/wallets/provider-coinbase/src/provider.ts
+++ b/wallets/provider-coinbase/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-coinbase/src/utils.ts
+++ b/wallets/provider-coinbase/src/utils.ts
@@ -1,5 +1,5 @@
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { ProviderConnectResult } from '@rango-dev/wallets-shared';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';

--- a/wallets/provider-default/package.json
+++ b/wallets/provider-default/package.json
@@ -21,8 +21,8 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/evm": "^0.2.1",
     "@rango-dev/signer-evm": "^0.42.0",
-    "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",
     "rango-types": "^0.5.0"
   },

--- a/wallets/provider-default/src/signer.ts
+++ b/wallets/provider-default/src/signer.ts
@@ -1,4 +1,4 @@
-import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/evm';
+import type { ProviderAPI } from '@hub3js/evm';
 import type { SignerFactory } from 'rango-types';
 
 import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';

--- a/wallets/provider-enkrypt/package.json
+++ b/wallets/provider-enkrypt/package.json
@@ -21,6 +21,9 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",

--- a/wallets/provider-enkrypt/src/constants.ts
+++ b/wallets/provider-enkrypt/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { type BlockchainMeta, evmBlockchains } from 'rango-types';
 
 import getSigners from './signer.js';

--- a/wallets/provider-enkrypt/src/mod.ts
+++ b/wallets/provider-enkrypt/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-enkrypt/src/namespaces/evm.ts
+++ b/wallets/provider-enkrypt/src/namespaces/evm.ts
@@ -1,15 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  hooks,
-} from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, hooks } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmEnkrypt } from '../utils.js';

--- a/wallets/provider-enkrypt/src/provider.ts
+++ b/wallets/provider-enkrypt/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-enkrypt/src/types.ts
+++ b/wallets/provider-enkrypt/src/types.ts
@@ -1,5 +1,5 @@
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
 
 export type EnkryptEvmProvider = EvmProviderApi & {
   selectedAddress: string;

--- a/wallets/provider-exodus/package.json
+++ b/wallets/provider-exodus/package.json
@@ -21,6 +21,10 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/signer-solana": "^0.48.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",

--- a/wallets/provider-exodus/src/constants.ts
+++ b/wallets/provider-exodus/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { type BlockchainMeta, solanaBlockchain } from 'rango-types';
 

--- a/wallets/provider-exodus/src/mod.ts
+++ b/wallets/provider-exodus/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildLegacyProvider } from './legacy/index.js';
 import { buildProvider } from './provider.js';

--- a/wallets/provider-exodus/src/namespaces/evm.ts
+++ b/wallets/provider-exodus/src/namespaces/evm.ts
@@ -1,11 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmExodus } from '../utils.js';

--- a/wallets/provider-exodus/src/namespaces/solana.ts
+++ b/wallets/provider-exodus/src/namespaces/solana.ts
@@ -1,11 +1,9 @@
-import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
+import type { SolanaActions } from '@hub3js/solana';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/solana';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import { actions, builders } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { solanaActions } from '../actions/solana.js';
 import { WALLET_ID } from '../constants.js';

--- a/wallets/provider-exodus/src/provider.ts
+++ b/wallets/provider-exodus/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-exodus/src/types.ts
+++ b/wallets/provider-exodus/src/types.ts
@@ -1,6 +1,6 @@
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
 
 export type ProviderObject = {
   [LegacyNetworks.ETHEREUM]: EvmProviderApi;

--- a/wallets/provider-exodus/src/utils.ts
+++ b/wallets/provider-exodus/src/utils.ts
@@ -1,6 +1,6 @@
 import type { Provider } from './types.js';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 
@@ -54,5 +54,5 @@ export function solanaExodus(): SolanaProviderApi {
     );
   }
 
-  return solanaInstance as SolanaProviderApi;
+  return solanaInstance;
 }

--- a/wallets/provider-freighter/package.json
+++ b/wallets/provider-freighter/package.json
@@ -21,7 +21,8 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
-    "@rango-dev/wallets-core": "^0.59.1-next.0",
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^15.0.1",

--- a/wallets/provider-freighter/src/constants.ts
+++ b/wallets/provider-freighter/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { type BlockchainMeta } from 'rango-types';
 

--- a/wallets/provider-freighter/src/mod.ts
+++ b/wallets/provider-freighter/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-freighter/src/namespaces/stellar/hooks.ts
+++ b/wallets/provider-freighter/src/namespaces/stellar/hooks.ts
@@ -1,6 +1,6 @@
 import type { StellarActions } from '@rango-dev/wallets-core/namespaces/stellar';
 
-import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 import { utils } from '@rango-dev/wallets-core/namespaces/stellar';
 import { WatchWalletChanges } from '@stellar/freighter-api';
 

--- a/wallets/provider-freighter/src/namespaces/stellar/namespace.ts
+++ b/wallets/provider-freighter/src/namespaces/stellar/namespace.ts
@@ -1,10 +1,8 @@
 import type { StellarActions } from '@rango-dev/wallets-core/namespaces/stellar';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import { builders, utils } from '@rango-dev/wallets-core/namespaces/stellar';
 import * as freighterApi from '@stellar/freighter-api';
 

--- a/wallets/provider-freighter/src/provider.ts
+++ b/wallets/provider-freighter/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { namespace as stellar } from './namespaces/stellar/namespace.js';

--- a/wallets/provider-gemwallet/package.json
+++ b/wallets/provider-gemwallet/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "@gemwallet/api": "^3.8.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/std": "^0.1.1",
     "rango-types": "^0.5.0",
     "xrpl": "^4.2.0"
   },

--- a/wallets/provider-gemwallet/src/constants.ts
+++ b/wallets/provider-gemwallet/src/constants.ts
@@ -1,4 +1,4 @@
-import type { ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
 import type { BlockchainMeta } from 'rango-types';
 
 import { xrplBlockchain } from 'rango-types';

--- a/wallets/provider-gemwallet/src/mod.ts
+++ b/wallets/provider-gemwallet/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-gemwallet/src/namespaces/xrpl/hooks.ts
+++ b/wallets/provider-gemwallet/src/namespaces/xrpl/hooks.ts
@@ -1,7 +1,7 @@
 import type { XRPLActions } from '@rango-dev/wallets-core/namespaces/xrpl';
 
 import { on } from '@gemwallet/api';
-import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 import { utils } from '@rango-dev/wallets-core/namespaces/xrpl';
 
 type WalletChangedEventPayload = {

--- a/wallets/provider-gemwallet/src/namespaces/xrpl/namespace.ts
+++ b/wallets/provider-gemwallet/src/namespaces/xrpl/namespace.ts
@@ -1,11 +1,9 @@
 import type { XRPLActions } from '@rango-dev/wallets-core/namespaces/xrpl';
 
 import { getAddress } from '@gemwallet/api';
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import { builders, utils } from '@rango-dev/wallets-core/namespaces/xrpl';
 import { Client } from 'xrpl';
 

--- a/wallets/provider-gemwallet/src/provider.ts
+++ b/wallets/provider-gemwallet/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { info, WALLET_ID } from './constants.js';
 import { namespace as xrpl } from './namespaces/xrpl/mod.js';

--- a/wallets/provider-ledger/package.json
+++ b/wallets/provider-ledger/package.json
@@ -21,6 +21,10 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@ledgerhq/errors": "^6.16.4",
     "@ledgerhq/hw-app-eth": "^6.36.0",
     "@ledgerhq/hw-app-solana": "^7.1.6",
@@ -33,6 +37,7 @@
     "@solana/web3.js": "^1.91.4",
     "@types/w3c-web-hid": "^1.0.2",
     "bs58": "^5.0.0",
+    "caip": "^1.1.1",
     "ethers": "^6.13.2",
     "rango-types": "^0.5.0"
   },

--- a/wallets/provider-ledger/src/constants.ts
+++ b/wallets/provider-ledger/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { Networks } from '@rango-dev/wallets-shared';
 import { type BlockchainMeta } from 'rango-types';

--- a/wallets/provider-ledger/src/mod.ts
+++ b/wallets/provider-ledger/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildLegacyProvider } from './legacy/index.js';
 import { buildProvider } from './provider.js';

--- a/wallets/provider-ledger/src/namespaces/evm.ts
+++ b/wallets/provider-ledger/src/namespaces/evm.ts
@@ -1,16 +1,11 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
+import type { CaipAccount } from '@hub3js/std/types';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  type CaipAccount,
-  builders as commonBuilders,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  builders,
-  CAIP_NAMESPACE,
-} from '@rango-dev/wallets-core/namespaces/evm';
-import { CAIP } from '@rango-dev/wallets-core/utils';
+import { NamespaceBuilder } from '@hub3js/core';
+import { builders, CAIP_NAMESPACE } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
 import { ETHEREUM_CHAIN_ID } from '@rango-dev/wallets-shared';
+import { AccountId } from 'caip';
 
 import { WALLET_ID } from '../constants.js';
 import { setDerivationPath } from '../state.js';
@@ -32,7 +27,7 @@ const connect = builders
 
     const formatAccounts = result.accounts.map(
       (account) =>
-        CAIP.AccountId.format({
+        AccountId.format({
           address: account,
           chainId: {
             namespace: CAIP_NAMESPACE,

--- a/wallets/provider-ledger/src/namespaces/solana.ts
+++ b/wallets/provider-ledger/src/namespaces/solana.ts
@@ -1,13 +1,10 @@
-import type { CaipAccount } from '@rango-dev/wallets-core/namespaces/common';
-import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
+import type { SolanaActions } from '@hub3js/solana';
+import type { CaipAccount } from '@hub3js/std/types';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import { builders as commonBuilders } from '@rango-dev/wallets-core/namespaces/common';
-import {
-  builders,
-  CAIP_NAMESPACE,
-} from '@rango-dev/wallets-core/namespaces/solana';
-import { CAIP } from '@rango-dev/wallets-core/utils';
+import { NamespaceBuilder } from '@hub3js/core';
+import { builders, CAIP_NAMESPACE } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { AccountId } from 'caip';
 
 import { WALLET_ID } from '../constants.js';
 import { setDerivationPath } from '../state.js';
@@ -26,7 +23,7 @@ const connect = builders
 
     const formatAccounts = result.accounts.map(
       (account) =>
-        CAIP.AccountId.format({
+        AccountId.format({
           address: account,
           chainId: {
             namespace: CAIP_NAMESPACE,

--- a/wallets/provider-ledger/src/provider.ts
+++ b/wallets/provider-ledger/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-ledger/src/utils.ts
+++ b/wallets/provider-ledger/src/utils.ts
@@ -1,8 +1,8 @@
 import type Transport from '@ledgerhq/hw-transport';
 
+import { CAIP_SOLANA_CHAIN_ID } from '@hub3js/solana';
 import { getAltStatusMessage } from '@ledgerhq/errors';
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import { CAIP_SOLANA_CHAIN_ID } from '@rango-dev/wallets-core/namespaces/solana';
 import {
   dynamicImportWithRefinedError,
   ETHEREUM_CHAIN_ID,

--- a/wallets/provider-math-wallet/package.json
+++ b/wallets/provider-math-wallet/package.json
@@ -21,6 +21,10 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/signer-solana": "^0.48.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",

--- a/wallets/provider-math-wallet/src/constants.ts
+++ b/wallets/provider-math-wallet/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import {
   type BlockchainMeta,
   evmBlockchains,

--- a/wallets/provider-math-wallet/src/mod.ts
+++ b/wallets/provider-math-wallet/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-math-wallet/src/namespaces/evm.ts
+++ b/wallets/provider-math-wallet/src/namespaces/evm.ts
@@ -1,11 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmMathWallet } from '../utils.js';

--- a/wallets/provider-math-wallet/src/namespaces/solana.ts
+++ b/wallets/provider-math-wallet/src/namespaces/solana.ts
@@ -1,13 +1,7 @@
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  type SolanaActions,
-} from '@rango-dev/wallets-core/namespaces/solana';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, type SolanaActions } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { solanaMathWallet } from '../utils.js';

--- a/wallets/provider-math-wallet/src/provider.ts
+++ b/wallets/provider-math-wallet/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import {
   MATH_WALLET_INJECTION_DELAY,

--- a/wallets/provider-math-wallet/src/types.ts
+++ b/wallets/provider-math-wallet/src/types.ts
@@ -1,6 +1,6 @@
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
 
 export type OkxBtcAddress = {
   address: string;

--- a/wallets/provider-math-wallet/src/utils.ts
+++ b/wallets/provider-math-wallet/src/utils.ts
@@ -1,6 +1,6 @@
 import type { Provider } from './types.js';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 
@@ -53,5 +53,5 @@ export function solanaMathWallet(): SolanaProviderApi {
     );
   }
 
-  return solanaInstance as SolanaProviderApi;
+  return solanaInstance;
 }

--- a/wallets/provider-metamask/package.json
+++ b/wallets/provider-metamask/package.json
@@ -21,6 +21,10 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/signer-solana": "^0.48.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",

--- a/wallets/provider-metamask/src/actions/solana.ts
+++ b/wallets/provider-metamask/src/actions/solana.ts
@@ -1,10 +1,7 @@
 import type { WalletStandardSolanaInstance } from '../types.js';
-import type { Context, FunctionWithContext } from '@rango-dev/wallets-core';
+import type { Context, FunctionWithContext } from '@hub3js/core';
 
-import {
-  type SolanaActions,
-  utils,
-} from '@rango-dev/wallets-core/namespaces/solana';
+import { type SolanaActions, utils } from '@hub3js/solana';
 
 function connect(
   getInstance: () => WalletStandardSolanaInstance

--- a/wallets/provider-metamask/src/builders/solana.ts
+++ b/wallets/provider-metamask/src/builders/solana.ts
@@ -1,11 +1,8 @@
 import type { WalletStandardSolanaInstance } from '../types.js';
 import type { StandardEventsChangeProperties } from '@wallet-standard/features';
 
-import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
-import {
-  type SolanaActions,
-  utils,
-} from '@rango-dev/wallets-core/namespaces/solana';
+import { type SolanaActions, utils } from '@hub3js/solana';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 
 // Hooks
 const changeAccountSubscriber = (

--- a/wallets/provider-metamask/src/constants.ts
+++ b/wallets/provider-metamask/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import {
   type BlockchainMeta,
   evmBlockchains,

--- a/wallets/provider-metamask/src/mod.ts
+++ b/wallets/provider-metamask/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildLegacyProvider } from './legacy/index.js';
 import { buildProvider } from './provider.js';

--- a/wallets/provider-metamask/src/namespaces/evm.ts
+++ b/wallets/provider-metamask/src/namespaces/evm.ts
@@ -1,18 +1,14 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, utils } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
 import {
-  builders as commonBuilders,
   connectAndUpdateStateForMultiNetworks,
   intoConnecting,
   intoConnectionFinished,
   standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  utils,
-} from '@rango-dev/wallets-core/namespaces/evm';
+} from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmMetamask } from '../utils.js';

--- a/wallets/provider-metamask/src/namespaces/solana.ts
+++ b/wallets/provider-metamask/src/namespaces/solana.ts
@@ -1,12 +1,7 @@
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  builders,
-  type SolanaActions,
-} from '@rango-dev/wallets-core/namespaces/solana';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import { builders, type SolanaActions } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { solanaActions } from '../actions/solana.js';
 import { solanaBuilders } from '../builders/solana.js';

--- a/wallets/provider-metamask/src/provider.ts
+++ b/wallets/provider-metamask/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-metamask/src/types.ts
+++ b/wallets/provider-metamask/src/types.ts
@@ -1,5 +1,5 @@
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
 import type { WalletWithFeatures as StandardWalletWithFeatures } from '@wallet-standard/base';
 
 import {

--- a/wallets/provider-metamask/src/utils.ts
+++ b/wallets/provider-metamask/src/utils.ts
@@ -3,7 +3,7 @@ import type {
   Provider,
   WalletStandardSolanaInstance,
 } from './types.js';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { getWallets } from '@wallet-standard/app';

--- a/wallets/provider-okx/package.json
+++ b/wallets/provider-okx/package.json
@@ -21,6 +21,10 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/signer-solana": "^0.48.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",

--- a/wallets/provider-okx/src/builders/utxo.ts
+++ b/wallets/provider-okx/src/builders/utxo.ts
@@ -1,7 +1,7 @@
 import type { OkxBtcAddress } from '../types.js';
 
-import { ActionBuilder } from '@rango-dev/wallets-core';
-import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
+import { ActionBuilder } from '@hub3js/core';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 import {
   CAIP_BITCOIN_CHAIN_ID,
   type ProviderAPI,

--- a/wallets/provider-okx/src/constants.ts
+++ b/wallets/provider-okx/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { Networks } from '@rango-dev/wallets-shared';
 import {

--- a/wallets/provider-okx/src/mod.ts
+++ b/wallets/provider-okx/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildLegacyProvider } from './legacy/index.js';
 import { buildProvider } from './provider.js';

--- a/wallets/provider-okx/src/namespaces/evm.ts
+++ b/wallets/provider-okx/src/namespaces/evm.ts
@@ -1,15 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  utils,
-} from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, utils } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmOKX } from '../utils.js';

--- a/wallets/provider-okx/src/namespaces/solana.ts
+++ b/wallets/provider-okx/src/namespaces/solana.ts
@@ -1,15 +1,9 @@
-import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
+import type { SolanaActions } from '@hub3js/solana';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  utils,
-} from '@rango-dev/wallets-core/namespaces/solana';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, utils } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { solanaOKX } from '../utils.js';

--- a/wallets/provider-okx/src/namespaces/utxo.ts
+++ b/wallets/provider-okx/src/namespaces/utxo.ts
@@ -1,8 +1,6 @@
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import {
   CAIP_BITCOIN_CHAIN_ID,
   utils,

--- a/wallets/provider-okx/src/provider.ts
+++ b/wallets/provider-okx/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-okx/src/types.ts
+++ b/wallets/provider-okx/src/types.ts
@@ -1,6 +1,6 @@
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 
 export type OkxBtcAddress = {

--- a/wallets/provider-okx/src/utils.ts
+++ b/wallets/provider-okx/src/utils.ts
@@ -1,6 +1,6 @@
 import type { OkxBtcAddress, Provider } from './types.js';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
@@ -57,7 +57,7 @@ export function solanaOKX(): SolanaProviderApi {
     );
   }
 
-  return solanaInstance as SolanaProviderApi;
+  return solanaInstance;
 }
 export function bitcoinOKX(): UtxoProviderApi {
   const instance = okx();
@@ -69,7 +69,7 @@ export function bitcoinOKX(): UtxoProviderApi {
     );
   }
 
-  return bitcoinInstance as UtxoProviderApi;
+  return bitcoinInstance;
 }
 export async function getBitcoinAccounts(): Promise<OkxBtcAddress> {
   const instance = bitcoinOKX();

--- a/wallets/provider-phantom/package.json
+++ b/wallets/provider-phantom/package.json
@@ -22,6 +22,10 @@
   },
   "dependencies": {
     "@bitcoinerlab/secp256k1": "^1.2.0",
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@mysten/sui": "^1.21.2",
     "@mysten/wallet-standard": "^0.13.26",
     "@rango-dev/signer-solana": "^0.48.0",
@@ -29,6 +33,7 @@
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",
     "bitcoinjs-lib": "^6.1.7",
+    "caip": "^1.1.1",
     "rango-types": "^0.5.0"
   },
   "publishConfig": {

--- a/wallets/provider-phantom/src/constants.ts
+++ b/wallets/provider-phantom/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { Networks } from '@rango-dev/wallets-shared';
 import {

--- a/wallets/provider-phantom/src/mod.ts
+++ b/wallets/provider-phantom/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildLegacyProvider } from './legacy/index.js';
 import { buildProvider } from './provider.js';

--- a/wallets/provider-phantom/src/namespaces/evm.ts
+++ b/wallets/provider-phantom/src/namespaces/evm.ts
@@ -1,15 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  hooks,
-} from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, hooks } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmPhantom } from '../utils.js';

--- a/wallets/provider-phantom/src/namespaces/solana.ts
+++ b/wallets/provider-phantom/src/namespaces/solana.ts
@@ -1,20 +1,18 @@
-import type { CaipAccount } from '@rango-dev/wallets-core/namespaces/common';
-import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
+import type { SolanaActions } from '@hub3js/solana';
+import type { CaipAccount } from '@hub3js/std/types';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
 import {
   actions,
   builders,
   CAIP_NAMESPACE,
   CAIP_SOLANA_CHAIN_ID,
   hooks,
-} from '@rango-dev/wallets-core/namespaces/solana';
-import { CAIP } from '@rango-dev/wallets-core/utils';
+} from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import { getSolanaAccounts } from '@rango-dev/wallets-shared';
+import { AccountId } from 'caip';
 
 import { WALLET_ID } from '../constants.js';
 import { solanaPhantom } from '../utils.js';
@@ -44,7 +42,7 @@ const connect = builders
 
     const formatAccounts = result.accounts.map(
       (account) =>
-        CAIP.AccountId.format({
+        AccountId.format({
           address: account,
           chainId: {
             namespace: CAIP_NAMESPACE,

--- a/wallets/provider-phantom/src/namespaces/sui.ts
+++ b/wallets/provider-phantom/src/namespaces/sui.ts
@@ -1,12 +1,10 @@
-import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
+import type { SolanaActions } from '@hub3js/solana';
 import type { SuiActions } from '@rango-dev/wallets-core/namespaces/sui';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import { actions as solanaActions } from '@rango-dev/wallets-core/namespaces/solana';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import { actions as solanaActions } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import { builders, hooks } from '@rango-dev/wallets-core/namespaces/sui';
 
 import { WALLET_ID, WALLET_NAME_IN_WALLET_STANDARD } from '../constants.js';

--- a/wallets/provider-phantom/src/namespaces/utxo.ts
+++ b/wallets/provider-phantom/src/namespaces/utxo.ts
@@ -1,3 +1,4 @@
+import type { CaipAccount } from '@hub3js/std/types';
 import type {
   ProviderAPI,
   UtxoActions,
@@ -8,26 +9,20 @@ import {
   NamespaceBuilder,
   type Subscriber,
   type SubscriberCleanUp,
-} from '@rango-dev/wallets-core';
-import {
-  type CaipAccount,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import { builders as commonBuilders } from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions as solanaActions,
-  type SolanaActions,
-} from '@rango-dev/wallets-core/namespaces/solana';
+} from '@hub3js/core';
+import { actions as solanaActions, type SolanaActions } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import {
   builders,
   CAIP_BITCOIN_CHAIN_ID,
   CAIP_NAMESPACE,
 } from '@rango-dev/wallets-core/namespaces/utxo';
-import { CAIP } from '@rango-dev/wallets-core/utils';
 import {
   Networks,
   type ProviderConnectResult,
 } from '@rango-dev/wallets-shared';
+import { AccountId } from 'caip';
 
 import { WALLET_ID } from '../constants.js';
 import { bitcoinPhantom, solanaPhantom } from '../utils.js';
@@ -86,7 +81,7 @@ function getChangeAccountSubscriber(
           .filter((account) => account.purpose === 'payment')
           .map(
             (account: BtcAccount) =>
-              CAIP.AccountId.format({
+              AccountId.format({
                 address: account.address,
                 chainId: {
                   namespace: CAIP_NAMESPACE,
@@ -130,7 +125,7 @@ const connect = builders
 
     const formatAccounts = result.accounts.map(
       (account) =>
-        CAIP.AccountId.format({
+        AccountId.format({
           address: account,
           chainId: {
             namespace: CAIP_NAMESPACE,

--- a/wallets/provider-phantom/src/provider.ts
+++ b/wallets/provider-phantom/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-phantom/src/utils.ts
+++ b/wallets/provider-phantom/src/utils.ts
@@ -1,5 +1,5 @@
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { ProviderAPI as SuiProviderApi } from '@rango-dev/wallets-core/namespaces/sui';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';

--- a/wallets/provider-rabby/package.json
+++ b/wallets/provider-rabby/package.json
@@ -21,6 +21,9 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",

--- a/wallets/provider-rabby/src/constants.ts
+++ b/wallets/provider-rabby/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { type BlockchainMeta, evmBlockchains } from 'rango-types';
 
 import getSigners from './signer.js';

--- a/wallets/provider-rabby/src/mod.ts
+++ b/wallets/provider-rabby/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildLegacyProvider } from './legacy/index.js';
 import { buildProvider } from './provider.js';

--- a/wallets/provider-rabby/src/namespaces/evm.ts
+++ b/wallets/provider-rabby/src/namespaces/evm.ts
@@ -1,15 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  hooks,
-} from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, hooks } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmRabby, switchOrAddNetwork } from '../utils.js';

--- a/wallets/provider-rabby/src/provider.ts
+++ b/wallets/provider-rabby/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-rabby/src/utils.ts
+++ b/wallets/provider-rabby/src/utils.ts
@@ -1,11 +1,11 @@
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import {
   type Chain,
   type ChainId,
   type ProviderAPI as EvmProviderApi,
   type ProviderAPI,
   utils,
-} from '@rango-dev/wallets-core/namespaces/evm';
+} from '@hub3js/evm';
+import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Provider = Record<string, any>;

--- a/wallets/provider-ready/package.json
+++ b/wallets/provider-ready/package.json
@@ -17,6 +17,8 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-starknet": "^0.42.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",

--- a/wallets/provider-ready/src/actions/starknet.ts
+++ b/wallets/provider-ready/src/actions/starknet.ts
@@ -1,4 +1,4 @@
-import type { Context, FunctionWithContext } from '@rango-dev/wallets-core';
+import type { Context, FunctionWithContext } from '@hub3js/core';
 
 import {
   CAIP_STARKNET_CHAIN_ID,

--- a/wallets/provider-ready/src/builders/starknet.ts
+++ b/wallets/provider-ready/src/builders/starknet.ts
@@ -3,7 +3,7 @@ import type {
   StarknetActions,
 } from '@rango-dev/wallets-core/namespaces/starknet';
 
-import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 import { utils } from '@rango-dev/wallets-core/namespaces/starknet';
 // Hooks
 export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>

--- a/wallets/provider-ready/src/constants.ts
+++ b/wallets/provider-ready/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { type BlockchainMeta, starknetBlockchain } from 'rango-types';
 
 import getSigners from './signer.js';

--- a/wallets/provider-ready/src/mod.ts
+++ b/wallets/provider-ready/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-ready/src/namespaces/starknet.ts
+++ b/wallets/provider-ready/src/namespaces/starknet.ts
@@ -1,10 +1,8 @@
 import type { StarknetActions } from '@rango-dev/wallets-core/namespaces/starknet';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import { actions, builders } from '@rango-dev/wallets-core/namespaces/starknet';
 
 import { starknetActions } from '../actions/starknet.js';

--- a/wallets/provider-ready/src/provider.ts
+++ b/wallets/provider-ready/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { starknet } from './namespaces/starknet.js';

--- a/wallets/provider-safe/package.json
+++ b/wallets/provider-safe/package.json
@@ -21,8 +21,8 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/evm": "^0.2.1",
     "@rango-dev/signer-evm": "^0.42.0",
-    "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",
     "@safe-global/safe-apps-provider": "^0.17.0",
     "@safe-global/safe-apps-sdk": "^9.1.0",

--- a/wallets/provider-safe/src/signer.ts
+++ b/wallets/provider-safe/src/signer.ts
@@ -1,4 +1,4 @@
-import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/evm';
+import type { ProviderAPI } from '@hub3js/evm';
 import type { SignerFactory } from 'rango-types';
 
 import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';

--- a/wallets/provider-safepal/package.json
+++ b/wallets/provider-safepal/package.json
@@ -21,6 +21,9 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/signer-solana": "^0.48.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",

--- a/wallets/provider-safepal/src/constants.ts
+++ b/wallets/provider-safepal/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { type BlockchainMeta, evmBlockchains } from 'rango-types';
 
 import getSigners from './signer.js';

--- a/wallets/provider-safepal/src/mod.ts
+++ b/wallets/provider-safepal/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildLegacyProvider } from './legacy/index.js';
 import { buildProvider } from './provider.js';

--- a/wallets/provider-safepal/src/namespaces/evm.ts
+++ b/wallets/provider-safepal/src/namespaces/evm.ts
@@ -1,14 +1,14 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import { actions, builders } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
 import {
-  builders as commonBuilders,
   connectAndUpdateStateForMultiNetworks,
   intoConnecting,
   intoConnectionFinished,
   standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/evm';
+} from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmSafepal, isValidEvmAddress } from '../utils.js';

--- a/wallets/provider-safepal/src/provider.ts
+++ b/wallets/provider-safepal/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-safepal/src/utils.ts
+++ b/wallets/provider-safepal/src/utils.ts
@@ -1,4 +1,4 @@
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { isEvmAddress } from '@rango-dev/wallets-shared';

--- a/wallets/provider-slush/package.json
+++ b/wallets/provider-slush/package.json
@@ -21,6 +21,8 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/std": "^0.1.1",
     "@mysten/sui": "^1.21.2",
     "@mysten/wallet-standard": "^0.13.26",
     "@rango-dev/signer-sui": "^0.10.0",

--- a/wallets/provider-slush/src/constants.ts
+++ b/wallets/provider-slush/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import {
   type BlockchainMeta,
   type SuiBlockchainMeta,

--- a/wallets/provider-slush/src/mod.ts
+++ b/wallets/provider-slush/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildLegacyProvider } from './legacy/index.js';
 import { buildProvider } from './provider.js';

--- a/wallets/provider-slush/src/namespaces/sui.ts
+++ b/wallets/provider-slush/src/namespaces/sui.ts
@@ -1,7 +1,7 @@
 import type { SuiActions } from '@rango-dev/wallets-core/namespaces/sui';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import { builders as commonBuilders } from '@rango-dev/wallets-core/namespaces/common';
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
 import { actions, builders } from '@rango-dev/wallets-core/namespaces/sui';
 
 import { WALLET_ID, WALLET_NAME_IN_WALLET_STANDARD } from '../constants.js';

--- a/wallets/provider-slush/src/provider.ts
+++ b/wallets/provider-slush/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { sui } from './namespaces/sui.js';

--- a/wallets/provider-solflare/package.json
+++ b/wallets/provider-solflare/package.json
@@ -21,6 +21,9 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-solana": "^0.48.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",

--- a/wallets/provider-solflare/src/actions/solana.ts
+++ b/wallets/provider-solflare/src/actions/solana.ts
@@ -1,10 +1,6 @@
-import type { Context, FunctionWithContext } from '@rango-dev/wallets-core';
+import type { Context, FunctionWithContext } from '@hub3js/core';
 
-import {
-  type ProviderAPI,
-  type SolanaActions,
-  utils,
-} from '@rango-dev/wallets-core/namespaces/solana';
+import { type ProviderAPI, type SolanaActions, utils } from '@hub3js/solana';
 
 function connect(
   instance: () => ProviderAPI

--- a/wallets/provider-solflare/src/constants.ts
+++ b/wallets/provider-solflare/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { type BlockchainMeta, solanaBlockchain } from 'rango-types';
 
 import getSigners from './signer.js';

--- a/wallets/provider-solflare/src/hooks/solana.ts
+++ b/wallets/provider-solflare/src/hooks/solana.ts
@@ -1,12 +1,5 @@
-import type {
-  AnyFunction,
-  Subscriber,
-  SubscriberCleanUp,
-} from '@rango-dev/wallets-core';
-import type {
-  ProviderAPI,
-  SolanaActions,
-} from '@rango-dev/wallets-core/namespaces/solana';
+import type { AnyFunction, Subscriber, SubscriberCleanUp } from '@hub3js/core';
+import type { ProviderAPI, SolanaActions } from '@hub3js/solana';
 
 function getDisconnectSubscriber(
   instance: () => ProviderAPI

--- a/wallets/provider-solflare/src/mod.ts
+++ b/wallets/provider-solflare/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-solflare/src/namespaces/solana.ts
+++ b/wallets/provider-solflare/src/namespaces/solana.ts
@@ -1,11 +1,9 @@
-import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
+import type { SolanaActions } from '@hub3js/solana';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import { builders, hooks } from '@rango-dev/wallets-core/namespaces/solana';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import { builders, hooks } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { solanaActions } from '../actions/solana.js';
 import { WALLET_ID } from '../constants.js';

--- a/wallets/provider-solflare/src/provider.ts
+++ b/wallets/provider-solflare/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, SOLFLARE_INJECTION_DELAY, WALLET_ID } from './constants.js';
 import { solana } from './namespaces/solana.js';

--- a/wallets/provider-solflare/src/types.ts
+++ b/wallets/provider-solflare/src/types.ts
@@ -1,5 +1,5 @@
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
 
 export type ProviderObject = {
   [LegacyNetworks.SOLANA]: SolanaProviderApi;

--- a/wallets/provider-solflare/src/utils.ts
+++ b/wallets/provider-solflare/src/utils.ts
@@ -1,5 +1,5 @@
 import type { Provider } from './types.js';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 

--- a/wallets/provider-taho/package.json
+++ b/wallets/provider-taho/package.json
@@ -21,6 +21,9 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",

--- a/wallets/provider-taho/src/constants.ts
+++ b/wallets/provider-taho/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { type BlockchainMeta } from 'rango-types';
 

--- a/wallets/provider-taho/src/mod.ts
+++ b/wallets/provider-taho/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-taho/src/namespaces/evm.ts
+++ b/wallets/provider-taho/src/namespaces/evm.ts
@@ -1,15 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  hooks,
-} from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, hooks } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmTaho } from '../utils.js';

--- a/wallets/provider-taho/src/provider.ts
+++ b/wallets/provider-taho/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-taho/src/types.ts
+++ b/wallets/provider-taho/src/types.ts
@@ -1,5 +1,5 @@
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
 
 export type ProviderObject = {
   [LegacyNetworks.ETHEREUM]: EvmProviderApi;

--- a/wallets/provider-taho/src/utils.ts
+++ b/wallets/provider-taho/src/utils.ts
@@ -1,5 +1,5 @@
 import type { Provider } from './types.js';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 

--- a/wallets/provider-tokenpocket/package.json
+++ b/wallets/provider-tokenpocket/package.json
@@ -21,6 +21,9 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",

--- a/wallets/provider-tokenpocket/src/constants.ts
+++ b/wallets/provider-tokenpocket/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { type BlockchainMeta, evmBlockchains } from 'rango-types';
 
 import getSigners from './signer.js';

--- a/wallets/provider-tokenpocket/src/mod.ts
+++ b/wallets/provider-tokenpocket/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-tokenpocket/src/namespaces/evm.ts
+++ b/wallets/provider-tokenpocket/src/namespaces/evm.ts
@@ -1,15 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  hooks,
-} from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, hooks } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmTokenPocket } from '../utils.js';

--- a/wallets/provider-tokenpocket/src/provider.ts
+++ b/wallets/provider-tokenpocket/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-tokenpocket/src/types.ts
+++ b/wallets/provider-tokenpocket/src/types.ts
@@ -1,5 +1,5 @@
+import type { ProviderAPI } from '@hub3js/evm';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/evm';
 
 export type ProviderObject = {
   [LegacyNetworks.ETHEREUM]: ProviderAPI;

--- a/wallets/provider-tokenpocket/src/utils.ts
+++ b/wallets/provider-tokenpocket/src/utils.ts
@@ -1,5 +1,5 @@
 import type { Provider } from './types.js';
-import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/evm';
+import type { ProviderAPI } from '@hub3js/evm';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 

--- a/wallets/provider-tomo/package.json
+++ b/wallets/provider-tomo/package.json
@@ -21,6 +21,9 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",

--- a/wallets/provider-tomo/src/constants.ts
+++ b/wallets/provider-tomo/src/constants.ts
@@ -1,4 +1,4 @@
-import type { ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
 
 import { WalletTypes } from '@rango-dev/wallets-shared';
 import { type BlockchainMeta, evmBlockchains } from 'rango-types';

--- a/wallets/provider-tomo/src/mod.ts
+++ b/wallets/provider-tomo/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-tomo/src/namespaces/evm.ts
+++ b/wallets/provider-tomo/src/namespaces/evm.ts
@@ -1,14 +1,14 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import { actions, builders } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
 import {
-  builders as commonBuilders,
   connectAndUpdateStateForMultiNetworks,
   intoConnecting,
   intoConnectionFinished,
   standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import { actions, builders } from '@rango-dev/wallets-core/namespaces/evm';
+} from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import { evmTomo } from '../utils.js';

--- a/wallets/provider-tomo/src/provider.ts
+++ b/wallets/provider-tomo/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, TOMO_INJECTION_DELAY, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-tomo/src/types.ts
+++ b/wallets/provider-tomo/src/types.ts
@@ -1,5 +1,5 @@
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
 
 type ProviderObject = {
   [LegacyNetworks.ETHEREUM]: EvmProviderApi;

--- a/wallets/provider-tomo/src/utils.ts
+++ b/wallets/provider-tomo/src/utils.ts
@@ -1,5 +1,5 @@
 import type { Provider } from './types.js';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 
 import { Networks } from '@rango-dev/wallets-shared';
 

--- a/wallets/provider-tonconnect/package.json
+++ b/wallets/provider-tonconnect/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "@rango-dev/wallets-shared": "^0.60.1-next.0",
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/std": "^0.1.1",
     "@ton/core": "^0.59.0",
     "@ton/crypto": "^3.3.0",
     "@tonconnect/ui": "^2.0.9",

--- a/wallets/provider-tonconnect/src/actions/ton.ts
+++ b/wallets/provider-tonconnect/src/actions/ton.ts
@@ -1,4 +1,4 @@
-import type { Context, FunctionWithContext } from '@rango-dev/wallets-core';
+import type { Context, FunctionWithContext } from '@hub3js/core';
 import type { TonConnectUI } from '@tonconnect/ui';
 
 import { type TonActions, utils } from '@rango-dev/wallets-core/namespaces/ton';

--- a/wallets/provider-tonconnect/src/constants.ts
+++ b/wallets/provider-tonconnect/src/constants.ts
@@ -1,4 +1,4 @@
-import type { ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
 
 import { WalletTypes } from '@rango-dev/wallets-shared';
 import { type BlockchainMeta, tonBlockchain } from 'rango-types';

--- a/wallets/provider-tonconnect/src/hooks/ton.ts
+++ b/wallets/provider-tonconnect/src/hooks/ton.ts
@@ -3,7 +3,7 @@ import type {
   Context,
   Subscriber,
   SubscriberCleanUp,
-} from '@rango-dev/wallets-core';
+} from '@hub3js/core';
 import type { TonActions } from '@rango-dev/wallets-core/namespaces/ton';
 import type {
   ConnectedWallet,

--- a/wallets/provider-tonconnect/src/mod.ts
+++ b/wallets/provider-tonconnect/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-tonconnect/src/namespaces/ton.ts
+++ b/wallets/provider-tonconnect/src/namespaces/ton.ts
@@ -1,10 +1,8 @@
 import type { TonActions } from '@rango-dev/wallets-core/namespaces/ton';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import { builders } from '@rango-dev/wallets-core/namespaces/ton';
 
 import { tonActions } from '../actions/ton.js';

--- a/wallets/provider-tonconnect/src/provider.ts
+++ b/wallets/provider-tonconnect/src/provider.ts
@@ -1,6 +1,6 @@
 import type { Environments } from './types.js';
 
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { ton } from './namespaces/ton.js';

--- a/wallets/provider-tron-link/package.json
+++ b/wallets/provider-tron-link/package.json
@@ -21,6 +21,8 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-tron": "^0.41.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",

--- a/wallets/provider-tron-link/src/builders/tron.ts
+++ b/wallets/provider-tron-link/src/builders/tron.ts
@@ -1,6 +1,6 @@
 import type { TronChangeAccountEvent } from '../types.js';
 
-import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 import {
   type ProviderAPI,
   type TronActions,

--- a/wallets/provider-tron-link/src/constants.ts
+++ b/wallets/provider-tron-link/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import { type BlockchainMeta, tronBlockchain } from 'rango-types';
 
 import getSigners from './signer.js';

--- a/wallets/provider-tron-link/src/mod.ts
+++ b/wallets/provider-tron-link/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-tron-link/src/namespaces/tron.ts
+++ b/wallets/provider-tron-link/src/namespaces/tron.ts
@@ -1,8 +1,6 @@
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import {
   type TronActions,
   utils,

--- a/wallets/provider-tron-link/src/provider.ts
+++ b/wallets/provider-tron-link/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, TRONLINK_INJECTION_DELAY, WALLET_ID } from './constants.js';
 import { tron } from './namespaces/tron.js';

--- a/wallets/provider-trustwallet/package.json
+++ b/wallets/provider-trustwallet/package.json
@@ -21,6 +21,10 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.42.0",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",

--- a/wallets/provider-trustwallet/src/constants.ts
+++ b/wallets/provider-trustwallet/src/constants.ts
@@ -1,4 +1,5 @@
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
+
 import {
   type BlockchainMeta,
   evmBlockchains,

--- a/wallets/provider-trustwallet/src/mod.ts
+++ b/wallets/provider-trustwallet/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildLegacyProvider } from './legacy/index.js';
 import { buildProvider } from './provider.js';

--- a/wallets/provider-trustwallet/src/namespaces/evm.ts
+++ b/wallets/provider-trustwallet/src/namespaces/evm.ts
@@ -1,15 +1,9 @@
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
+import type { EvmActions } from '@hub3js/evm';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  hooks,
-} from '@rango-dev/wallets-core/namespaces/evm';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, hooks } from '@hub3js/evm';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import {

--- a/wallets/provider-trustwallet/src/namespaces/solana.ts
+++ b/wallets/provider-trustwallet/src/namespaces/solana.ts
@@ -1,15 +1,9 @@
-import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
+import type { SolanaActions } from '@hub3js/solana';
 
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import {
-  actions,
-  builders,
-  hooks,
-} from '@rango-dev/wallets-core/namespaces/solana';
+import { NamespaceBuilder } from '@hub3js/core';
+import { actions, builders, hooks } from '@hub3js/solana';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 
 import { WALLET_ID } from '../constants.js';
 import {

--- a/wallets/provider-trustwallet/src/provider.ts
+++ b/wallets/provider-trustwallet/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';

--- a/wallets/provider-trustwallet/src/utils.ts
+++ b/wallets/provider-trustwallet/src/utils.ts
@@ -1,6 +1,6 @@
-import type { Context } from '@rango-dev/wallets-core';
-import type { ProviderAPI as EvmProviderApi } from '@rango-dev/wallets-core/namespaces/evm';
-import type { ProviderAPI as SolanaProviderApi } from '@rango-dev/wallets-core/namespaces/solana';
+import type { Context } from '@hub3js/core';
+import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/wallets/provider-unisat/package.json
+++ b/wallets/provider-unisat/package.json
@@ -23,7 +23,10 @@
   "dependencies": {
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/std": "^0.1.1",
     "bitcoinjs-lib": "^6.1.7",
+    "caip": "^1.1.1",
     "rango-types": "^0.5.0"
   },
   "publishConfig": {

--- a/wallets/provider-unisat/src/constants.ts
+++ b/wallets/provider-unisat/src/constants.ts
@@ -1,6 +1,6 @@
+import type { ProviderMetadata } from '@hub3js/core';
 import type { BlockchainMeta, TransferBlockchainMeta } from 'rango-types';
 
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
 import { Networks } from '@rango-dev/wallets-shared';
 
 import getSigners from './signer.js';

--- a/wallets/provider-unisat/src/mod.ts
+++ b/wallets/provider-unisat/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildLegacyProvider } from './legacy/index.js';
 import { buildProvider } from './provider.js';

--- a/wallets/provider-unisat/src/namespaces/utxo.ts
+++ b/wallets/provider-unisat/src/namespaces/utxo.ts
@@ -1,3 +1,4 @@
+import type { CaipAccount } from '@hub3js/std/types';
 import type {
   ProviderAPI,
   UtxoActions,
@@ -7,22 +8,19 @@ import {
   NamespaceBuilder,
   type Subscriber,
   type SubscriberCleanUp,
-} from '@rango-dev/wallets-core';
-import {
-  type CaipAccount,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
-import { builders as commonBuilders } from '@rango-dev/wallets-core/namespaces/common';
+} from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import {
   builders,
   CAIP_BITCOIN_CHAIN_ID,
   CAIP_NAMESPACE,
 } from '@rango-dev/wallets-core/namespaces/utxo';
-import { CAIP } from '@rango-dev/wallets-core/utils';
 import {
   Networks,
   type ProviderConnectResult,
 } from '@rango-dev/wallets-shared';
+import { AccountId } from 'caip';
 
 import { WALLET_ID } from '../constants.js';
 import { bitcoinUnisat } from '../utils.js';
@@ -66,7 +64,7 @@ function getChangeAccountSubscriber(
 
         const formatAccounts = accounts.map(
           (account) =>
-            CAIP.AccountId.format({
+            AccountId.format({
               address: account,
               chainId: {
                 namespace: CAIP_NAMESPACE,
@@ -110,7 +108,7 @@ const connect = builders
 
     const formatAccounts = result.accounts.map(
       (account) =>
-        CAIP.AccountId.format({
+        AccountId.format({
           address: account,
           chainId: {
             namespace: CAIP_NAMESPACE,

--- a/wallets/provider-unisat/src/provider.ts
+++ b/wallets/provider-unisat/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { utxo } from './namespaces/utxo.js';

--- a/wallets/provider-unisat/src/signers/utxoSigner.ts
+++ b/wallets/provider-unisat/src/signers/utxoSigner.ts
@@ -1,6 +1,6 @@
 import type { GenericSigner, Transfer } from 'rango-types';
 
-import { parseErrorAndThrowStandardizeError } from '@rango-dev/wallets-core/namespaces/common';
+import { parseErrorAndThrowStandardizeError } from '@hub3js/std/utils';
 import { Networks } from '@rango-dev/wallets-shared';
 import * as bitcoin from 'bitcoinjs-lib';
 import { SignerError } from 'rango-types';

--- a/wallets/provider-vultisig/package.json
+++ b/wallets/provider-vultisig/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "@rango-dev/wallets-shared": "^0.60.1-next.0",
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/std": "^0.1.1",
     "rango-types": "^0.5.0"
   },
   "publishConfig": {

--- a/wallets/provider-vultisig/src/constants.ts
+++ b/wallets/provider-vultisig/src/constants.ts
@@ -1,4 +1,4 @@
-import type { ProviderMetadata } from '@rango-dev/wallets-core';
+import type { ProviderMetadata } from '@hub3js/core';
 import type { BlockchainMeta } from 'rango-types';
 
 import getSigners from './signer.js';

--- a/wallets/provider-vultisig/src/mod.ts
+++ b/wallets/provider-vultisig/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-vultisig/src/namespaces/utxo/namespace.ts
+++ b/wallets/provider-vultisig/src/namespaces/utxo/namespace.ts
@@ -1,10 +1,8 @@
 import type { UtxoActions } from '@rango-dev/wallets-core/namespaces/utxo';
 
-import { ActionBuilder, NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import {
   builders,
   CAIP_ZCASH_CHAIN_ID,

--- a/wallets/provider-vultisig/src/provider.ts
+++ b/wallets/provider-vultisig/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { info, WALLET_ID } from './constants.js';
 import { namespace as utxo } from './namespaces/utxo/namespace.js';

--- a/wallets/provider-xverse/package.json
+++ b/wallets/provider-xverse/package.json
@@ -21,6 +21,8 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",
     "rango-types": "^0.5.0"

--- a/wallets/provider-xverse/src/builders/utxo.ts
+++ b/wallets/provider-xverse/src/builders/utxo.ts
@@ -1,7 +1,7 @@
 import type { XVerseEvent } from '../types.js';
 
-import { ActionBuilder } from '@rango-dev/wallets-core';
-import { ChangeAccountSubscriberBuilder } from '@rango-dev/wallets-core/namespaces/common';
+import { ActionBuilder } from '@hub3js/core';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 import {
   CAIP_BITCOIN_CHAIN_ID,
   type ProviderAPI,

--- a/wallets/provider-xverse/src/constants.ts
+++ b/wallets/provider-xverse/src/constants.ts
@@ -1,6 +1,6 @@
+import type { ProviderMetadata } from '@hub3js/core';
 import type { BlockchainMeta, TransferBlockchainMeta } from 'rango-types';
 
-import { type ProviderMetadata } from '@rango-dev/wallets-core';
 import { Networks } from '@rango-dev/wallets-shared';
 
 import getSigners from './signer.js';

--- a/wallets/provider-xverse/src/mod.ts
+++ b/wallets/provider-xverse/src/mod.ts
@@ -1,4 +1,4 @@
-import { defineVersions } from '@rango-dev/wallets-core/utils';
+import { defineVersions } from '@hub3js/core/utils';
 
 import { buildProvider } from './provider.js';
 

--- a/wallets/provider-xverse/src/namespaces/utxo.ts
+++ b/wallets/provider-xverse/src/namespaces/utxo.ts
@@ -1,8 +1,6 @@
-import { NamespaceBuilder } from '@rango-dev/wallets-core';
-import {
-  builders as commonBuilders,
-  standardizeAndThrowError,
-} from '@rango-dev/wallets-core/namespaces/common';
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
 import {
   CAIP_BITCOIN_CHAIN_ID,
   utils,

--- a/wallets/provider-xverse/src/provider.ts
+++ b/wallets/provider-xverse/src/provider.ts
@@ -1,4 +1,4 @@
-import { ProviderBuilder } from '@rango-dev/wallets-core';
+import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID, XVERSE_INJECTION_DELAY_MS } from './constants.js';
 import { utxo } from './namespaces/utxo.js';

--- a/wallets/react/package.json
+++ b/wallets/react/package.json
@@ -35,6 +35,12 @@
     "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/solana": "^0.2.1",
+    "@hub3js/namespaces": "^0.1.1",
+    "@hub3js/std": "^0.1.1",
+    "caip": "^1.1.1",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "@rango-dev/wallets-shared": "^0.60.1-next.0",
     "rango-types": "^0.5.0",

--- a/wallets/react/src/hub/autoConnect.ts
+++ b/wallets/react/src/hub/autoConnect.ts
@@ -1,18 +1,15 @@
 import type { AllProxiedNamespaces } from './types.js';
 import type { UseAdapterParams } from './useHubAdapter.js';
-import type { Hub } from '@rango-dev/wallets-core';
+import type { Hub } from '@hub3js/core';
+import type { DefaultNamespaces, Namespace } from '@hub3js/namespaces';
+import type { Accounts, AccountsWithActiveChain } from '@hub3js/std/types';
 import type {
   LegacyNamespaceInputForConnect,
   LegacyProviderInterface,
 } from '@rango-dev/wallets-core/legacy';
-import type {
-  Accounts,
-  AccountsWithActiveChain,
-  Namespace,
-} from '@rango-dev/wallets-core/namespaces/common';
 import type { WalletType } from '@rango-dev/wallets-shared';
 
-import { Provider } from '@rango-dev/wallets-core';
+import { Provider } from '@hub3js/core';
 import { legacyIsEvmNamespace } from '@rango-dev/wallets-core/legacy';
 import { Result } from 'ts-results';
 
@@ -140,7 +137,7 @@ async function eagerConnect(
  */
 async function tryRunCanEagerConnect(
   namespaces: LegacyNamespaceInputForConnect[],
-  wallet: Provider
+  wallet: Provider<DefaultNamespaces>
 ): Promise<{
   successNamespaces: LegacyNamespaceInputForConnect[];
   failedNamespaces: LegacyNamespaceInputForConnect[];

--- a/wallets/react/src/hub/helpers.ts
+++ b/wallets/react/src/hub/helpers.ts
@@ -1,8 +1,5 @@
 import type { AllProxiedNamespaces } from './types.js';
-import type {
-  Accounts,
-  AccountsWithActiveChain,
-} from '@rango-dev/wallets-core/namespaces/common';
+import type { Accounts, AccountsWithActiveChain } from '@hub3js/std/types';
 import type { Result } from 'ts-results';
 
 import { legacyFormatAddressWithNetwork as formatAddressWithNetwork } from '@rango-dev/wallets-core/legacy';
@@ -12,11 +9,11 @@ import {
   CAIP_BITCOIN_CHAIN_ID,
   CAIP_ZCASH_CHAIN_ID,
 } from '@rango-dev/wallets-core/namespaces/utxo';
-import { CAIP } from '@rango-dev/wallets-core/utils';
+import { AccountId, type ChainIdParams } from 'caip';
 import { Err, Ok } from 'ts-results';
 
 export function mapCaipNamespaceToLegacyNetworkName(
-  chainId: CAIP.ChainIdParams | string
+  chainId: ChainIdParams | string,
 ): string {
   if (typeof chainId === 'string') {
     return chainId;
@@ -55,8 +52,10 @@ export function mapCaipNamespaceToLegacyNetworkName(
  *
  * @see https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-10.md
  */
-export function fromAccountIdToLegacyAddressFormat(account: string): string {
-  const { chainId, address } = CAIP.AccountId.parse(account);
+export function fromAccountIdToLegacyAddressFormat(
+  account: string,
+): string {
+  const { chainId, address } = AccountId.parse(account);
   const network = mapCaipNamespaceToLegacyNetworkName(chainId);
   return formatAddressWithNetwork(address, network);
 }

--- a/wallets/react/src/hub/lastConnectedWallets.ts
+++ b/wallets/react/src/hub/lastConnectedWallets.ts
@@ -1,4 +1,4 @@
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { Namespace } from '@hub3js/namespaces';
 
 import { Persistor } from '@rango-dev/wallets-core/legacy';
 

--- a/wallets/react/src/hub/types.ts
+++ b/wallets/react/src/hub/types.ts
@@ -1,12 +1,9 @@
-import type {
-  CommonNamespaces,
-  FindProxiedNamespace,
-  ProviderMetadata,
-} from '@rango-dev/wallets-core';
+import type { FindProxiedNamespace, ProviderMetadata } from '@hub3js/core';
+import type { DefaultNamespaces } from '@hub3js/namespaces';
 
 export type AllProxiedNamespaces = FindProxiedNamespace<
-  keyof CommonNamespaces,
-  CommonNamespaces
+  keyof DefaultNamespaces,
+  DefaultNamespaces
 >;
 
 export type ExtensionLink = keyof ProviderMetadata['extensions'];

--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -1,14 +1,11 @@
 import type { AllProxiedNamespaces, ExtensionLink } from './types.js';
 import type { ProviderContext } from '../index.js';
-import type { Provider } from '@rango-dev/wallets-core';
+import type { Provider } from '@hub3js/core';
+import type { VersionedProviders } from '@hub3js/core/utils';
+import type { Accounts, AccountsWithActiveChain } from '@hub3js/std/types';
 import type { LegacyNamespaceInputForConnect } from '@rango-dev/wallets-core/legacy';
-import type {
-  Accounts,
-  AccountsWithActiveChain,
-} from '@rango-dev/wallets-core/namespaces/common';
-import type { VersionedProviders } from '@rango-dev/wallets-core/utils';
 
-import { utils } from '@rango-dev/wallets-core/namespaces/evm';
+import { utils } from '@hub3js/evm';
 import { type WalletInfo, type WalletType } from '@rango-dev/wallets-shared';
 import { useEffect, useRef, useState } from 'react';
 import { Ok, Result } from 'ts-results';

--- a/wallets/react/src/hub/useHubRefs.ts
+++ b/wallets/react/src/hub/useHubRefs.ts
@@ -1,6 +1,6 @@
-import type { Provider, Store } from '@rango-dev/wallets-core';
+import type { Provider, Store } from '@hub3js/core';
 
-import { createStore, Hub } from '@rango-dev/wallets-core';
+import { createStore, Hub } from '@hub3js/core';
 import { useRef } from 'react';
 
 import { synchronizeHubWithConfigProviders } from './utils.js';

--- a/wallets/react/src/hub/utils.ts
+++ b/wallets/react/src/hub/utils.ts
@@ -1,19 +1,18 @@
 import type { AllProxiedNamespaces } from './types.js';
-import type { Hub, Provider, ProxiedNamespace } from '@rango-dev/wallets-core';
+import type { Hub, Provider, ProxiedNamespace } from '@hub3js/core';
+import type { Event } from '@hub3js/core/store';
+import type { EvmActions } from '@hub3js/evm';
+import type { SolanaActions } from '@hub3js/solana';
 import type {
   LegacyNamespaceInputForConnect,
   LegacyProviderInterface,
   LegacyEventHandler as WalletEventHandler,
 } from '@rango-dev/wallets-core/legacy';
-import type { EvmActions } from '@rango-dev/wallets-core/namespaces/evm';
-import type { SolanaActions } from '@rango-dev/wallets-core/namespaces/solana';
 import type { SuiActions } from '@rango-dev/wallets-core/namespaces/sui';
 import type { UtxoActions } from '@rango-dev/wallets-core/namespaces/utxo';
-import type { Event } from '@rango-dev/wallets-core/store';
 
+import { pickVersion, type VersionedProviders } from '@hub3js/core/utils';
 import { LegacyEvents as Events } from '@rango-dev/wallets-core/legacy';
-import { type VersionedProviders } from '@rango-dev/wallets-core/utils';
-import { pickVersion } from '@rango-dev/wallets-core/utils';
 import {
   type AddEthereumChainParameter,
   convertEvmBlockchainMetaToEvmChainInfo,

--- a/wallets/react/src/legacy/types.ts
+++ b/wallets/react/src/legacy/types.ts
@@ -1,8 +1,7 @@
-import type {
-  Provider,
-  ProviderMetadata,
-  VersionedProviders,
-} from '@rango-dev/wallets-core';
+import type { Provider, ProviderMetadata } from '@hub3js/core';
+import type { NamespaceData } from '@hub3js/core/store';
+import type { VersionedProviders } from '@hub3js/core/utils';
+import type { Namespace } from '@hub3js/namespaces';
 import type {
   LegacyNamespaceInputForConnect,
   LegacyProviderInterface,
@@ -12,8 +11,6 @@ import type {
   LegacyState as WalletState,
   LegacyWalletType as WalletType,
 } from '@rango-dev/wallets-core/legacy';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
-import type { NamespaceData } from '@rango-dev/wallets-core/store';
 import type { BlockchainMeta, SignerFactory } from 'rango-types';
 import type { PropsWithChildren } from 'react';
 

--- a/wallets/shared/package.json
+++ b/wallets/shared/package.json
@@ -27,6 +27,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@hub3js/std": "^0.1.1",
+    "@hub3js/namespaces": "^0.1.1",
     "@rango-dev/wallets-core": "^0.59.1-next.0",
     "ethers": "^6.13.2",
     "rango-types": "^0.5.0"

--- a/wallets/shared/src/rango.ts
+++ b/wallets/shared/src/rango.ts
@@ -1,9 +1,9 @@
+import type { Namespace } from '@hub3js/namespaces';
 import type {
   LegacyNetwork as Network,
   LegacyWalletInfo as WalletInfo,
   LegacyWalletType as WalletType,
 } from '@rango-dev/wallets-core/legacy';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 import type { BlockchainMeta, EvmBlockchainMeta } from 'rango-types';
 
 import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';

--- a/widget/embedded/package.json
+++ b/widget/embedded/package.json
@@ -22,6 +22,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/std": "^0.1.1",
+    "@hub3js/namespaces": "^0.1.1",
     "@lingui/core": "4.2.1",
     "@lingui/react": "4.2.1",
     "@rango-dev/logging-core": "^0.12.1",

--- a/widget/embedded/src/components/StatefulConnectModal/StatefulConnectModal.tsx
+++ b/widget/embedded/src/components/StatefulConnectModal/StatefulConnectModal.tsx
@@ -1,6 +1,6 @@
 import type { Result } from '../../hooks/useStatefulConnect';
 import type { WalletInfoWithExtra } from '../../types';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { Namespace } from '@hub3js/namespaces';
 
 import { Divider } from '@rango-dev/ui';
 import React, { useEffect, useRef, useState } from 'react';

--- a/widget/embedded/src/components/WalletStatefulConnect/DerivationPath.helpers.ts
+++ b/widget/embedded/src/components/WalletStatefulConnect/DerivationPath.helpers.ts
@@ -1,4 +1,4 @@
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { Namespace } from '@hub3js/namespaces';
 import type { DerivationPath } from '@rango-dev/wallets-shared';
 
 import { namespaces } from '@rango-dev/wallets-shared';

--- a/widget/embedded/src/components/WalletStatefulConnect/Detached.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Detached.tsx
@@ -1,6 +1,6 @@
 import type { PropTypes } from './Detached.types';
+import type { Namespace } from '@hub3js/namespaces';
 import type { LegacyNamespaceMeta } from '@rango-dev/wallets-core/legacy';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
 
 import { i18n } from '@lingui/core';
 import {

--- a/widget/embedded/src/components/WalletStatefulConnect/Detached.types.ts
+++ b/widget/embedded/src/components/WalletStatefulConnect/Detached.types.ts
@@ -1,5 +1,5 @@
 import type { NeedsNamespacesState } from '../../hooks/useStatefulConnect';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { Namespace } from '@hub3js/namespaces';
 
 export interface PropTypes {
   value: NeedsNamespacesState;

--- a/widget/embedded/src/components/WalletStatefulConnect/Namespaces.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Namespaces.tsx
@@ -1,5 +1,5 @@
 import type { PropTypes } from './Namespaces.types';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { Namespace } from '@hub3js/namespaces';
 
 import { i18n } from '@lingui/core';
 import {

--- a/widget/embedded/src/components/WalletStatefulConnect/Namespaces.types.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Namespaces.types.tsx
@@ -1,7 +1,7 @@
 import type { NeedsNamespacesState } from '../../hooks/useStatefulConnect';
+import type { NamespaceData } from '@hub3js/core/store';
+import type { Namespace } from '@hub3js/namespaces';
 import type { LegacyNamespaceMeta } from '@rango-dev/wallets-core/legacy';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
-import type { NamespaceData } from '@rango-dev/wallets-core/store';
 
 export interface PropTypes {
   onConfirm: (namespaces: Namespace[]) => void;

--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.state.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.state.ts
@@ -3,7 +3,7 @@ import type {
   NeedsDerivationPathState,
   NeedsNamespacesState,
 } from './useStatefulConnect.types';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { Namespace } from '@hub3js/namespaces';
 
 export interface State {
   status: 'init' | 'namespace' | 'derivationPath' | 'detached';

--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
@@ -1,6 +1,6 @@
 import type { HandleConnectOptions, Result } from './useStatefulConnect.types';
 import type { WalletInfoWithExtra } from '../../types';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { Namespace } from '@hub3js/namespaces';
 import type { NamespaceData } from '@rango-dev/wallets-shared';
 
 import { WalletState } from '@rango-dev/ui';

--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.types.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.types.ts
@@ -1,5 +1,5 @@
 import type { ExtendedModalWalletInfo } from '../../utils/wallets';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { Namespace } from '@hub3js/namespaces';
 
 export interface HandleConnectOptions {
   // To have a switch between connect and disconnect when user is clicking on a button, this option can be helpful.

--- a/widget/embedded/src/hooks/useWalletProviders/useWalletProviders.helpers.ts
+++ b/widget/embedded/src/hooks/useWalletProviders/useWalletProviders.helpers.ts
@@ -1,6 +1,6 @@
 import type { ProviderInterface } from '@rango-dev/wallets-react';
 
-import { Provider } from '@rango-dev/wallets-core';
+import { Provider } from '@hub3js/core';
 
 export function hashProviders(
   providers: (string | ProviderInterface | Provider)[]

--- a/widget/embedded/src/store/slices/config.ts
+++ b/widget/embedded/src/store/slices/config.ts
@@ -2,9 +2,9 @@ import type { DataSlice } from './data';
 import type { SettingsSlice } from './settings';
 import type { WidgetConfig } from '../../types';
 import type { StateCreatorWithInitialData } from '../app';
+import type { VersionedProviders } from '@hub3js/core/utils';
 
 import { allProviders as getAllProviders } from '@rango-dev/provider-all';
-import { type VersionedProviders } from '@rango-dev/wallets-core';
 
 import { cacheService } from '../../services/cacheService';
 import {

--- a/widget/embedded/src/store/slices/wallets.ts
+++ b/widget/embedded/src/store/slices/wallets.ts
@@ -1,5 +1,5 @@
 import type { AppStoreState } from './types';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { Namespace } from '@hub3js/namespaces';
 import type { Asset, Token, WalletDetail } from 'rango-sdk';
 
 import BigNumber from 'bignumber.js';

--- a/widget/embedded/src/store/utils/wallets.ts
+++ b/widget/embedded/src/store/utils/wallets.ts
@@ -8,7 +8,7 @@ import type {
   BalanceState,
   ConnectedWallet,
 } from '../slices/wallets';
-import type { Namespace } from '@rango-dev/wallets-core/namespaces/common';
+import type { Namespace } from '@hub3js/namespaces';
 import type { Asset, WalletDetail } from 'rango-types';
 
 import BigNumber from 'bignumber.js';

--- a/widget/embedded/src/types/config.ts
+++ b/widget/embedded/src/types/config.ts
@@ -1,5 +1,5 @@
+import type { Provider } from '@hub3js/core';
 import type { Language, theme } from '@rango-dev/ui';
-import type { Provider } from '@rango-dev/wallets-core';
 import type { LegacyProviderInterface } from '@rango-dev/wallets-core/legacy';
 import type { WalletType } from '@rango-dev/wallets-shared';
 import type { Asset } from 'rango-sdk';

--- a/widget/embedded/src/utils/providers.ts
+++ b/widget/embedded/src/utils/providers.ts
@@ -1,12 +1,12 @@
 import type { WidgetConfig } from '../types';
 import type { LegacyProviderInterface } from '@rango-dev/wallets-core/legacy';
 
+import { Provider } from '@hub3js/core';
 import {
   defineVersions,
   pickVersion,
-  Provider,
   type VersionedProviders,
-} from '@rango-dev/wallets-core';
+} from '@hub3js/core/utils';
 
 export interface ProvidersOptions {
   walletConnectProjectId?: WidgetConfig['walletConnectProjectId'];

--- a/widget/playground/package.json
+++ b/widget/playground/package.json
@@ -26,6 +26,7 @@
     "vm-browserify": "^1.1.2"
   },
   "dependencies": {
+    "@hub3js/core": "^0.60.1",
     "@rango-dev/provider-all": "^0.62.2-next.0",
     "@rango-dev/ui": "^0.63.1-next.0",
     "@rango-dev/wallets-react": "^0.46.1-next.0",

--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.utils.ts
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.utils.ts
@@ -3,8 +3,8 @@ import type { WalletTypes } from '@rango-dev/wallets-shared';
 import type { WidgetConfig } from '@rango-dev/widget-embedded';
 import type { BlockchainMeta } from 'rango-sdk';
 
+import { pickVersion, type VersionedProviders } from '@hub3js/core/utils';
 import { allProviders as getAllProviders } from '@rango-dev/provider-all';
-import { pickVersion, type VersionedProviders } from '@rango-dev/wallets-core';
 
 import { getCategoryNetworks } from '../../utils/blockchains';
 import { excludedWallets } from '../../utils/common';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2657,6 +2657,48 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
+"@hub3js/core@^0.60.1":
+  version "0.60.1"
+  resolved "https://registry.yarnpkg.com/@hub3js/core/-/core-0.60.1.tgz#e4b4f190cbc383de34a255a474578d7177e59567"
+  integrity sha512-vHeJEW5e1SxmXpNckGreIZxWY90XMBr11CrD3RAfsGAVfqM4uJ0YFZxyuiQMxBdr88EGdj3pnU6ciEYPy9KBmg==
+  dependencies:
+    immer "^10.0.4"
+    rango-types "^0.5.0"
+    zustand "^4.5.2"
+
+"@hub3js/evm@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@hub3js/evm/-/evm-0.2.1.tgz#fcbec4a96b28cda87d750b7ab92bf89b84e4cf59"
+  integrity sha512-H/IWo43jRBGLcmsyBSdcAD7HsGxiWDH9l93scbC1/d1AnKOxmG0pVwCiFFR3l1NODx/NikXdMovfO0pXuBtERA==
+  dependencies:
+    "@hub3js/std" "^0.1.1"
+    caip "^1.1.1"
+    rango-types "^0.5.0"
+
+"@hub3js/namespaces@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@hub3js/namespaces/-/namespaces-0.1.1.tgz#b9b93f25702de4bb655ae5270fb9fcda8953d0e1"
+  integrity sha512-1SnIPV0snvYO0ZhExK1D+ssikSp2vjMZR8PaLspRdg/qbcFEAI9oZ5U/67e5u7ikynRcEIWSv0wR/zaOd5FKYg==
+  dependencies:
+    "@hub3js/evm" "^0.2.1"
+    "@hub3js/solana" "^0.2.1"
+
+"@hub3js/solana@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@hub3js/solana/-/solana-0.2.1.tgz#c41855832a72a5bf8a66a58997d914e0c7699f82"
+  integrity sha512-ss279okYhrN/omPwc1p0O/NaXmXe3aAdZAZyusepkWWOFqFjIbVb6j2yO+9f8Nb1uilCOghNS+QninAAGWb42g==
+  dependencies:
+    "@hub3js/std" "^0.1.1"
+    caip "^1.1.1"
+    rango-types "^0.5.0"
+
+"@hub3js/std@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@hub3js/std/-/std-0.1.1.tgz#440df6fe7e8ebf2b11d88f6ce339aa4a090b493e"
+  integrity sha512-of8ioIcP/obup0lqMe2wUbF6DXV38EdpNb4sAtj5W0epNCq3dfvpeBgPK1/1XOgqUpTb89ANgtvXGYDaS8GuUg==
+  dependencies:
+    caip "^1.1.1"
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"


### PR DESCRIPTION
## Summary

  Migrates `rango-client` source imports from `@rango-dev/wallets-core` (and its subpaths) to the newly published `@hub3js/*` packages, per the migration mapping. Only subpaths that were fully moved to `@hub3js/*` are migrated; everything else still points at `@rango-dev/wallets-core`.

  ## Import mapping applied

  | Old | New |
  | --- | --- |
  | `@rango-dev/wallets-core` | `@hub3js/core` |
  | `@rango-dev/wallets-core/store` | `@hub3js/core/store` |
  | `@rango-dev/wallets-core/utils` | `@hub3js/core/utils` |
  | `@rango-dev/wallets-core/namespaces/evm` | `@hub3js/evm` |
  | `@rango-dev/wallets-core/namespaces/solana` | `@hub3js/solana` |
  | `@rango-dev/wallets-core/namespaces/common` | `@hub3js/std/{types,operators,actions,builders,hooks,utils}` — per-symbol |


  ### Left untouched (not yet migrated)

  - `@rango-dev/wallets-core/legacy`
  - `@rango-dev/wallets-core/namespaces/{cosmos, starknet, stellar, sui, ton, tron, utxo, xrpl}`

  ## CAIP

  Import the functions we needed from the `caip` directly instead of importing them from `wallets-core`

  ## `@hub3js/std` per-symbol mapping

  `namespaces/common` was a flat re-export. `@hub3js/std` exposes the same surface area through subpaths, so each imported symbol was routed to its new home:

  | Symbol(s) | New subpath |
  | --- | --- |
  | `Namespace`, `CaipAccount`, `Accounts`, `AccountsWithActiveChain` | `@hub3js/std/types` |
  | `actions` (namespace) | `import * as actions from '@hub3js/std/actions'` |
  | `builders` (namespace, incl. aliases like `commonBuilders`) | `import * as ... from '@hub3js/std/builders'` |
  | `ChangeAccountSubscriberBuilder` | `@hub3js/std/hooks` |
  | `parseErrorAndThrowStandardizeError` | `@hub3js/std/utils` |
  | `standardizeAndThrowError`, `intoConnecting`, `beforeRecommended`, `intoConnectionFinished`, `afterRecommended`, `connectAndUpdateStateForMultiNetworks`, `connectAndUpdateStateForSingleNetwork`, `andRecommended` | `@hub3js/std/operators` |

  ## Symbols intentionally kept on `@rango-dev/wallets-core`

  These weren't found in the new `@hub3js/*` packages, so the imports were split rather than blindly replaced:

  - From `@rango-dev/wallets-core/utils`: `legacyProviderImportsToVersionsInterface`

  ## Package.json updates

  Added `@hub3js/*` deps to 40 `package.json` files based on what each package's source actually imports:

  `@rango-dev/wallets-core` was left in place wherever the package still imports an untouched subpath or a kept symbol.

  ## Scope

  - **431** new `@hub3js/*` import sites across the source tree
  - **235** `@rango-dev/wallets-core` import sites preserved (legacy + untouched namespaces + kept symbols)
  - **40** `package.json` files updated

  ## Test plan

  - [x] `yarn install` resolves cleanly with the new `@hub3js/*` deps
  - [x] `yarn build:all` succeeds
  - [x] `yarn test` is green
  - [x] Manually smoke-tested the widget transaction flow for ton and evm


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
