### PR TITLE
refactor(wallets): use standard ChangeAccountSubscriberBuilder for Phantom & Unisat UTXO

### DIFF
--- a/wallets/provider-phantom/src/namespaces/utxo.ts
+++ b/wallets/provider-phantom/src/namespaces/utxo.ts
@@ -4,19 +4,16 @@ import type {
   UtxoActions,
 } from '@rango-dev/wallets-core/namespaces/utxo';
 
-import {
-  ActionBuilder,
-  NamespaceBuilder,
-  type Subscriber,
-  type SubscriberCleanUp,
-} from '@hub3js/core';
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
 import { actions as solanaActions, type SolanaActions } from '@hub3js/solana';
 import * as commonBuilders from '@hub3js/std/builders';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 import { standardizeAndThrowError } from '@hub3js/std/operators';
 import {
   builders,
   CAIP_BITCOIN_CHAIN_ID,
   CAIP_NAMESPACE,
+  utils,
 } from '@rango-dev/wallets-core/namespaces/utxo';
 import {
   Networks,
@@ -26,9 +23,6 @@ import { AccountId } from 'caip';
 
 import { WALLET_ID } from '../constants.js';
 import { bitcoinPhantom, solanaPhantom } from '../utils.js';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyFunction = (...args: any[]) => any;
 
 type BtcAccount = {
   address: string;
@@ -49,69 +43,34 @@ const getBitcoinAccounts: () => Promise<ProviderConnectResult> = async () => {
   };
 };
 
-function getChangeAccountSubscriber(
-  instance: () => ProviderAPI | undefined
-): [Subscriber<UtxoActions>, SubscriberCleanUp<UtxoActions>] {
-  let eventCallback: AnyFunction;
-
-  // subscriber can be passed to `or`, it will get the error and should rethrow error to pass the error to next `or` or throw error.
-  return [
-    (context, err) => {
-      const bitcoinInstance = instance();
-
-      if (!bitcoinInstance) {
-        throw new Error(
-          'Trying to subscribe to your Solana wallet, but seems its instance is not available.'
-        );
-      }
-
-      const [, setState] = context.state();
-
-      eventCallback = (accounts: BtcAccount[]) => {
-        /*
-         * In Phantom, when user is switching to an account which is not connected to dApp yet, it returns an empty array on `accountsChanged`.
-         * So empty array means we don't have access to account and we need to disconnect and let the user connect the account.
-         */
-        if (!accounts.length) {
-          context.action('disconnect');
-          return;
-        }
-
-        const formatAccounts = accounts
-          .filter((account) => account.purpose === 'payment')
-          .map(
-            (account: BtcAccount) =>
-              AccountId.format({
-                address: account.address,
-                chainId: {
-                  namespace: CAIP_NAMESPACE,
-                  reference: CAIP_BITCOIN_CHAIN_ID,
-                },
-              }) as CaipAccount
-          );
-
-        setState('accounts', formatAccounts);
-      };
-      bitcoinInstance.on('accountsChanged', eventCallback);
-
-      if (err instanceof Error) {
-        throw err;
-      }
-    },
-    (_context, err) => {
-      const bitcoinInstance = instance();
-
-      if (eventCallback && bitcoinInstance) {
-        bitcoinInstance.off('accountsChanged', eventCallback);
-      }
-
-      return err;
-    },
-  ];
-}
-
 const [changeAccountSubscriber, changeAccountCleanup] =
-  getChangeAccountSubscriber(bitcoinPhantom);
+  new ChangeAccountSubscriberBuilder<BtcAccount[], ProviderAPI, UtxoActions>()
+    .getInstance(bitcoinPhantom)
+    /*
+     * In Phantom, when the user switches to an account which is not connected to the dApp yet, it returns an empty array on `accountsChanged`.
+     * So an empty array means we don't have access to the account and we need to disconnect and let the user connect the account.
+     */
+    .onSwitchAccount((event, context) => {
+      if (!event.payload.length) {
+        event.preventDefault();
+        context.action('disconnect');
+      }
+    })
+    .format(async (_, accounts) => {
+      return utils.formatAccountsToCAIP(
+        accounts
+          .filter((account) => account.purpose === 'payment')
+          .map((account) => account.address),
+        CAIP_BITCOIN_CHAIN_ID
+      );
+    })
+    .addEventListener((instance, callback) => {
+      return instance.on('accountsChanged', callback);
+    })
+    .removeEventListener((instance, callback) => {
+      return instance.off('accountsChanged', callback);
+    })
+    .build();
 
 const connect = builders
   .connect()

--- a/wallets/provider-unisat/src/namespaces/utxo.ts
+++ b/wallets/provider-unisat/src/namespaces/utxo.ts
@@ -4,17 +4,15 @@ import type {
   UtxoActions,
 } from '@rango-dev/wallets-core/namespaces/utxo';
 
-import {
-  NamespaceBuilder,
-  type Subscriber,
-  type SubscriberCleanUp,
-} from '@hub3js/core';
+import { NamespaceBuilder } from '@hub3js/core';
 import * as commonBuilders from '@hub3js/std/builders';
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
 import { standardizeAndThrowError } from '@hub3js/std/operators';
 import {
   builders,
   CAIP_BITCOIN_CHAIN_ID,
   CAIP_NAMESPACE,
+  utils,
 } from '@rango-dev/wallets-core/namespaces/utxo';
 import {
   Networks,
@@ -24,9 +22,6 @@ import { AccountId } from 'caip';
 
 import { WALLET_ID } from '../constants.js';
 import { bitcoinUnisat } from '../utils.js';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyFunction = (...args: any[]) => any;
 
 const getBitcoinAccounts: () => Promise<ProviderConnectResult> = async () => {
   const instance = bitcoinUnisat();
@@ -38,63 +33,25 @@ const getBitcoinAccounts: () => Promise<ProviderConnectResult> = async () => {
   };
 };
 
-function getChangeAccountSubscriber(
-  instance: () => ProviderAPI | undefined
-): [Subscriber<UtxoActions>, SubscriberCleanUp<UtxoActions>] {
-  let eventCallback: AnyFunction;
-
-  // subscriber can be passed to `or`, it will get the error and should rethrow error to pass the error to next `or` or throw error.
-  return [
-    (context, err) => {
-      const bitcoinInstance = instance();
-
-      if (!bitcoinInstance) {
-        throw new Error(
-          'Trying to subscribe to your Solana wallet, but seems its instance is not available.'
-        );
-      }
-
-      const [, setState] = context.state();
-
-      eventCallback = (accounts: string[]) => {
-        if (!accounts.length) {
-          context.action('disconnect');
-          return;
-        }
-
-        const formatAccounts = accounts.map(
-          (account) =>
-            AccountId.format({
-              address: account,
-              chainId: {
-                namespace: CAIP_NAMESPACE,
-                reference: CAIP_BITCOIN_CHAIN_ID,
-              },
-            }) as CaipAccount
-        );
-
-        setState('accounts', formatAccounts);
-      };
-      bitcoinInstance.on('accountsChanged', eventCallback);
-
-      if (err instanceof Error) {
-        throw err;
-      }
-    },
-    (_context, err) => {
-      const bitcoinInstance = instance();
-
-      if (eventCallback && bitcoinInstance) {
-        bitcoinInstance.removeListener('accountsChanged', eventCallback);
-      }
-
-      return err;
-    },
-  ];
-}
-
 const [changeAccountSubscriber, changeAccountCleanup] =
-  getChangeAccountSubscriber(bitcoinUnisat);
+  new ChangeAccountSubscriberBuilder<string[], ProviderAPI, UtxoActions>()
+    .getInstance(bitcoinUnisat)
+    .onSwitchAccount((event, context) => {
+      if (!event.payload.length) {
+        event.preventDefault();
+        context.action('disconnect');
+      }
+    })
+    .format(async (_, accounts) => {
+      return utils.formatAccountsToCAIP(accounts, CAIP_BITCOIN_CHAIN_ID);
+    })
+    .addEventListener((instance, callback) => {
+      return instance.on('accountsChanged', callback);
+    })
+    .removeEventListener((instance, callback) => {
+      return instance.removeListener('accountsChanged', callback);
+    })
+    .build();
 
 const connect = builders
   .connect()


### PR DESCRIPTION
## Summary

  The Phantom and Unisat UTXO `changeAccount` subscribers were hand-rolled in
  `wallets/provider-phantom/src/namespaces/utxo.ts` and
  `wallets/provider-unisat/src/namespaces/utxo.ts` instead of being built with the
  standard `ChangeAccountSubscriberBuilder` from `@rango-dev/wallets-core`
  (`@hub3js/std/hooks`). This duplicated the event attach/detach, account
  formatting, and state-update logic, and risked drifting from the shared, tested
  implementation already used by the OKX and Bitget providers.

  This PR migrates both subscribers to the standard builder.

  ## Changes

  - **provider-phantom** — replace `getChangeAccountSubscriber` with a
    `ChangeAccountSubscriberBuilder<BtcAccount[], ProviderAPI, UtxoActions>` chain
    (`getInstance` / `onSwitchAccount` / `format` / `addEventListener` /
    `removeEventListener`). Keeps the `purpose === 'payment'` filter and the
    `on`/`off` listener pair.
  - **provider-unisat** — same migration for
    `ChangeAccountSubscriberBuilder<string[], ProviderAPI, UtxoActions>`, keeping
    the `on`/`removeListener` pair.
  - Empty-array account events still trigger a `disconnect` (now via
    `onSwitchAccount` + `event.preventDefault()`), preserving the Phantom/Unisat
    behaviour where switching to an account not yet connected to the dApp emits an
    empty array.
  - Account formatting now goes through `utils.formatAccountsToCAIP`.
  - Removed the now-dead `Subscriber` / `SubscriberCleanUp` imports and the local
    `AnyFunction` type; pulled in `ChangeAccountSubscriberBuilder` and `utils`.
  - The `connect`/`disconnect` wiring
    (`.before(changeAccountSubscriber).or(changeAccountCleanup).or(standardizeAndThrowError)`
    and `.after(changeAccountCleanup)`) is unchanged.

  ## Note on the `return err` cleanup

  The `.or` operators run via a `reduce` that threads the error as the
  accumulator (`wallets/core/src/hub/namespaces/namespace.ts`), so a cleanup that
  `return err`s passes the error to the next `.or` (`standardizeAndThrowError`),
  which is what throws it — the error is **not** swallowed. The standard builder's
  cleanup uses the same `return err` contract. Throwing from cleanup would instead
  skip `standardizeAndThrowError` and bypass error standardization, so adopting the
  standard builder gives the correct propagation behaviour by construction.


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
