### PR TITLE
fix: align category list loading skeleton count with the 4 chips

### DIFF
--- a/widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx
+++ b/widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx
@@ -23,12 +23,12 @@ export function SelectableCategoryList(props: SelectableCategoryListPropTypes) {
   return (
     <Container>
       {isLoading &&
-        Array.from(Array(5), (_, index) => (
+        Array.from(Array(4), (_, index) => (
           <Skeleton
             key={index}
             variant="rounded"
             height={70}
-            width={index === 0 ? 45 : 65}
+            width={index === 0 ? 45 : '100%'}
           />
         ))}
       {!isLoading &&

--- a/widget/ui/src/components/Skeleton/Skeleton.types.ts
+++ b/widget/ui/src/components/Skeleton/Skeleton.types.ts
@@ -8,13 +8,13 @@ type BaseSizes = Exclude<BaseProps['size'], object>;
 type TextVariant = {
   variant: 'text';
   size: BaseSizes;
-  width?: number;
+  width?: string | number;
 };
 
 type OtherVariant = {
   variant: Exclude<BaseVariants, 'text'>;
-  width?: number;
-  height: number;
+  width?: string | number;
+  height: string | number;
 };
 
 export type SkeletonPropTypes = TextVariant | OtherVariant;


### PR DESCRIPTION
## What

After Cosmos support was removed in #1405, the blockchain category list renders **4** chips (`ALL`, `EVM`, `UTXO`, `OTHER`), but the loading skeleton was still hardcoded to render **5** skeletons. When `isLoading` flipped to `false`, the extra placeholder collapsed and caused a visible UI glitch / layout shift on load.

This reduces the skeleton count from 5 to 4 so the loading state matches the number of chips actually rendered.

## Why

Regression introduced by the Cosmos removal in #1405. Reported by users.

## Changes

- `widget/ui/src/components/SelectableCategoryList/SelectableCategoryList.tsx`: loading skeleton loop `Array(5)` → `Array(4)`.

