### PR TITLE
fix: display target wallet title in detached modal

### DIFF
--- a/widget/embedded/src/components/WalletStatefulConnect/Detached.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/Detached.tsx
@@ -161,7 +161,7 @@ export function Detached(props: PropTypes) {
       <MessageBox
         type="info"
         title={i18n.t(`Connect {wallet}`, {
-          wallet: targetWallet.type,
+          wallet: targetWallet.title,
         })}
         description={i18n.t(
           'This wallet supports multiple chains. Choose which chains you’d like to connect or disconnect.'


### PR DESCRIPTION
# Summary

Right now, in detached modal,  type of target wallet is being displayed instead of its title. In this PR it is changed to `title` to match the initial modal.


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
