### PR TITLE
feat: add new events to widget embedded

### DIFF
--- a/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
+++ b/widget/embedded/src/components/ConfirmWalletsModal/ConfirmWalletsModal.tsx
@@ -19,6 +19,8 @@ import { WIDGET_UI_ID } from '../../constants';
 import { getQuoteErrorMessage } from '../../constants/errors';
 import { useAppStore } from '../../store/AppStore';
 import { useQuoteStore } from '../../store/quote';
+import { UiEventTypes } from '../../types';
+import { emitUiEvent } from '../../utils/events';
 import { getBlockchainShortNameFor } from '../../utils/meta';
 import { isConfirmSwapDisabled } from '../../utils/swap';
 import { getQuoteChains } from '../../utils/wallets';
@@ -211,6 +213,10 @@ export function ConfirmWalletsModal(props: PropTypes) {
     const lastSelectedWallets = selectableWallets.filter(
       (wallet) => wallet.selected
     );
+    emitUiEvent({
+      type: UiEventTypes.SWAP_WALLETS_CONFIRMED,
+      payload: { routeId: selectedQuote?.requestId ?? '' },
+    });
     setWalletsAsSelected(lastSelectedWallets);
     selectQuoteWallets(lastSelectedWallets);
     setQuoteWalletConfirmed(true);
@@ -301,6 +307,36 @@ export function ConfirmWalletsModal(props: PropTypes) {
     }
   }, [connectedWallets, nextSelectedWallets]);
 
+  const routeId = selectedQuote?.requestId ?? '';
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const pendingChains = requiredChains.filter(
+      (chain) =>
+        !connectedWallets.some(
+          (connectedWallet) => connectedWallet.chain === chain
+        )
+    );
+    emitUiEvent({
+      type: UiEventTypes.SWAP_WALLETS_MODAL_SHOWN,
+      payload: {
+        chainsRequired: requiredChains.length,
+        chainsPending: pendingChains.length,
+      },
+    });
+  }, [open]);
+
+  useEffect(() => {
+    if (isInsufficientBalanceModalOpen) {
+      emitUiEvent({
+        type: UiEventTypes.GAS_WARNING_SHOWN,
+        payload: { routeId },
+      });
+    }
+  }, [isInsufficientBalanceModalOpen, routeId]);
+
   const modalContainer = document.getElementById(
     WIDGET_UI_ID.SWAP_BOX_ID
   ) as HTMLDivElement;
@@ -383,7 +419,13 @@ export function ConfirmWalletsModal(props: PropTypes) {
             size="large"
             type="primary"
             fullWidth
-            onClick={onConfirmBalance}>
+            onClick={() => {
+              emitUiEvent({
+                type: UiEventTypes.GAS_WARNING_BYPASSED,
+                payload: { routeId },
+              });
+              onConfirmBalance();
+            }}>
             {i18n.t('Proceed anyway')}
           </Button>
         </MessageBox>

--- a/widget/embedded/src/components/CustomDestination/CustomDestination.tsx
+++ b/widget/embedded/src/components/CustomDestination/CustomDestination.tsx
@@ -16,6 +16,8 @@ import React, { useEffect, useRef } from 'react';
 
 import { useAppStore } from '../../store/AppStore';
 import { useQuoteStore } from '../../store/quote';
+import { UiEventTypes } from '../../types';
+import { emitUiEvent } from '../../utils/events';
 import {
   getBlockchainDisplayNameFor,
   isValidTokenAddress,
@@ -93,6 +95,22 @@ export function CustomDestination(props: PropTypes) {
       handleOpenChange(true);
     }
   }, [configDestination]);
+
+  const lastReportedDestination = useRef<string | null>(null);
+  useEffect(() => {
+    if (!customDestination) {
+      lastReportedDestination.current = null;
+      return;
+    }
+    const isValid = open && isValidTokenAddress(blockchain, customDestination);
+    if (isValid && lastReportedDestination.current !== customDestination) {
+      lastReportedDestination.current = customDestination;
+      emitUiEvent({
+        type: UiEventTypes.DESTINATION_ADDRESS_SET,
+        payload: { destinationChain: blockchain.name },
+      });
+    }
+  }, [customDestination, open, blockchain]);
 
   return (
     <Container>

--- a/widget/embedded/src/components/Quote/QuoteCostDetails.tsx
+++ b/widget/embedded/src/components/Quote/QuoteCostDetails.tsx
@@ -21,7 +21,9 @@ import {
   USD_VALUE_MAX_DECIMALS,
   USD_VALUE_MIN_DECIMALS,
 } from '../../constants/routing';
+import { UiEventTypes } from '../../types';
 import { getContainer, getExpanded } from '../../utils/common';
+import { emitUiEvent } from '../../utils/events';
 import { numberToString } from '../../utils/numbers';
 import { getFeesGroup, getTotalFeesInUsd, getUsdFee } from '../../utils/swap';
 import { WatermarkedModal } from '../common/WatermarkedModal';
@@ -84,6 +86,12 @@ export function QuoteCostDetails(props: QuoteCostDetailsProps) {
           showModalFee
             ? (e) => {
                 e.stopPropagation();
+                if (!open && quote) {
+                  emitUiEvent({
+                    type: UiEventTypes.ROUTE_FEE_VIEWED,
+                    payload: { routeId: quote.requestId },
+                  });
+                }
                 setOpen(!open);
               }
             : undefined

--- a/widget/embedded/src/components/Slippage/Slippage.tsx
+++ b/widget/embedded/src/components/Slippage/Slippage.tsx
@@ -12,7 +12,9 @@ import React from 'react';
 
 import { MAX_SLIPPAGE, SLIPPAGES } from '../../constants/swapSettings';
 import { useAppStore } from '../../store/AppStore';
+import { UiEventTypes } from '../../types';
 import { getContainer } from '../../utils/common';
+import { emitUiEvent } from '../../utils/events';
 import { getSlippageValidation } from '../../utils/settings';
 import { isValidCurrencyFormat } from '../../utils/validation';
 
@@ -31,6 +33,23 @@ export function Slippage() {
   const slippageValidation =
     customSlippage !== null ? getSlippageValidation(customSlippage) : null;
 
+  /** Effective slippage before a change, used as the previous value in events. */
+  const effectiveSlippage = customSlippage ?? slippage;
+
+  const emitSlippageChanged = (previousValue: number, newValue: number) => {
+    if (previousValue === newValue) {
+      return;
+    }
+    emitUiEvent({
+      type: UiEventTypes.SETTINGS_CHANGED,
+      payload: {
+        setting: 'slippage',
+        previousValue,
+        newValue,
+      },
+    });
+  };
+
   const onSlippageValueChange = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
@@ -43,10 +62,12 @@ export function Slippage() {
     if (parsedValue > MAX_SLIPPAGE) {
       slippage = MAX_SLIPPAGE;
     }
+    emitSlippageChanged(effectiveSlippage, slippage);
     setCustomSlippage(slippage);
   };
 
   const onClickSlippageChip = (slippageItem: number) => {
+    emitSlippageChanged(effectiveSlippage, slippageItem);
     if (customSlippage !== null) {
       setCustomSlippage(null);
     }

--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -34,7 +34,9 @@ import {
 import { useAppStore } from '../../store/AppStore';
 import { useNotificationStore } from '../../store/notification';
 import { useQuoteStore } from '../../store/quote';
+import { UiEventTypes } from '../../types';
 import { getContainer } from '../../utils/common';
+import { emitUiEvent } from '../../utils/events';
 import {
   numberToString,
   roundedSecondsToString,
@@ -404,6 +406,10 @@ export function SwapDetails(props: SwapDetailsProps) {
             type="primary"
             size="large"
             onClick={() => {
+              emitUiEvent({
+                type: UiEventTypes.SWAP_RETRIED,
+                payload: { routeId: swap.requestId },
+              });
               const swapInput = createRetryQuote(swap, blockchains, findToken);
               retry(swapInput);
               setTimeout(() => {

--- a/widget/embedded/src/containers/Settings/Lists.tsx
+++ b/widget/embedded/src/containers/Settings/Lists.tsx
@@ -32,7 +32,9 @@ import { navigationRoutes } from '../../constants/navigationRoutes';
 import { ThemeModeEnum } from '../../constants/settings';
 import { useLanguage } from '../../hooks/useLanguage';
 import { useAppStore } from '../../store/AppStore';
+import { UiEventTypes } from '../../types';
 import { getContainer } from '../../utils/common';
+import { emitUiEvent } from '../../utils/events';
 import { getUniqueSwappersGroups, isFeatureHidden } from '../../utils/settings';
 
 const ThemeSection = styled('div', {
@@ -257,7 +259,17 @@ export function SettingsLists() {
     ),
     start: <InfinityIcon color="gray" size={16} />,
     end: <Switch checked={infiniteApprove} />,
-    onClick: toggleInfiniteApprove,
+    onClick: () => {
+      emitUiEvent({
+        type: UiEventTypes.SETTINGS_CHANGED,
+        payload: {
+          setting: 'infiniteApproval',
+          previousValue: infiniteApprove,
+          newValue: !infiniteApprove,
+        },
+      });
+      toggleInfiniteApprove();
+    },
   };
 
   const themeItem = {

--- a/widget/embedded/src/containers/Wallets/useUpdates.ts
+++ b/widget/embedded/src/containers/Wallets/useUpdates.ts
@@ -77,7 +77,9 @@ export function useUpdates(params: UseUpdatesParams): UseUpdates {
     );
 
     if (data.length) {
-      void newWalletConnected(data, info.namespace, state.derivationPath);
+      void newWalletConnected(data, info.namespace, state.derivationPath, {
+        walletName: type,
+      });
     }
   };
 

--- a/widget/embedded/src/hooks/useSwapInput.ts
+++ b/widget/embedded/src/hooks/useSwapInput.ts
@@ -5,8 +5,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAppStore } from '../store/AppStore';
 import { useQuoteStore } from '../store/quote';
-import { QuoteErrorType } from '../types';
+import { QuoteErrorType, QuoteEventTypes } from '../types';
 import { debounce } from '../utils/common';
+import { buildSwapEstimatePayload } from '../utils/eventPayloads';
+import { emitQuoteEvent } from '../utils/events';
 import { isPositiveNumber } from '../utils/numbers';
 import {
   generateQuoteWarnings,
@@ -160,6 +162,16 @@ export function useSwapInput({
           updateQuotePartialState('quotes', res);
           setSelectedQuote(quote);
 
+          if (res.results?.length && quote) {
+            emitQuoteEvent({
+              type: QuoteEventTypes.ROUTE_REQUESTED,
+              payload: {
+                ...buildSwapEstimatePayload(quote),
+                routeCount: res.results.length,
+              },
+            });
+          }
+
           throwErrorIfResponseIsNotValid({
             diagnosisMessages: res.diagnosisMessages,
             requestId: quote?.requestId || '',
@@ -176,6 +188,30 @@ export function useSwapInput({
         })
         .catch((error) => {
           const quoteError = handleQuoteErrors(error);
+          if (quoteError.type === QuoteErrorType.NO_RESULT) {
+            emitQuoteEvent({
+              type: QuoteEventTypes.ROUTE_NOT_FOUND,
+              payload: {
+                sourceChain: fromToken.blockchain,
+                destinationChain: toToken.blockchain,
+                sourceTokenSymbol: fromToken.symbol,
+                sourceTokenAddress: fromToken.address,
+                destinationTokenSymbol: toToken.symbol,
+                destinationTokenAddress: toToken.address,
+                inputAmountUsd: inputUsdValue ? inputUsdValue.toNumber() : null,
+              },
+            });
+          } else if (quoteError.type === QuoteErrorType.REQUEST_FAILED) {
+            emitQuoteEvent({
+              type: QuoteEventTypes.ROUTE_FETCH_FAILED,
+              payload: {
+                sourceChain: fromToken.blockchain,
+                destinationChain: toToken.blockchain,
+
+                errorCode: String(error?.response?.status ?? ''),
+              },
+            });
+          }
           if (
             quoteError.type === QuoteErrorType.NO_RESULT ||
             quoteError.type === QuoteErrorType.REQUEST_FAILED

--- a/widget/embedded/src/hooks/useSyncNotifications/useSyncNotifications.ts
+++ b/widget/embedded/src/hooks/useSyncNotifications/useSyncNotifications.ts
@@ -2,6 +2,8 @@ import { useManager } from '@rango-dev/queue-manager-react';
 import { useEffect } from 'react';
 
 import { useNotificationStore } from '../../store/notification';
+import { UiEventTypes } from '../../types';
+import { emitUiEvent } from '../../utils/events';
 import { getPendingSwaps } from '../../utils/queue';
 
 export function useSyncNotifications() {
@@ -15,7 +17,37 @@ export function useSyncNotifications() {
       !isSynced;
 
     if (shouldSyncNotifications) {
-      syncNotifications(getPendingSwaps(manager));
+      const pendingSwaps = getPendingSwaps(manager);
+      syncNotifications(pendingSwaps);
+
+      pendingSwaps.forEach(({ swap }) => {
+        const isInProgressMultiStep =
+          swap.status === 'running' && swap.steps.length > 1;
+        if (!isInProgressMultiStep) {
+          return;
+        }
+        /*
+         * The current step is the first one that hasn't succeeded yet. A
+         * running swap should always have one; if not (all steps already
+         * succeeded), the state is inconsistent/transient, so skip it rather
+         * than report a misleading step.
+         */
+        const currentStepIndex = swap.steps.findIndex(
+          (step) => step.status !== 'success'
+        );
+        if (currentStepIndex === -1) {
+          return;
+        }
+
+        emitUiEvent({
+          type: UiEventTypes.SWAP_RESUMED,
+          payload: {
+            routeId: swap.requestId,
+            stepCount: swap.steps.length,
+            stepNumber: currentStepIndex + 1,
+          },
+        });
+      });
     }
   }, [
     useNotificationStore.persist.hasHydrated(),

--- a/widget/embedded/src/hooks/useWalletList.ts
+++ b/widget/embedded/src/hooks/useWalletList.ts
@@ -7,6 +7,7 @@ import { detectMobileScreens, WalletTypes } from '@rango-dev/wallets-shared';
 import { useCallback, useEffect } from 'react';
 
 import { useAppStore } from '../store/AppStore';
+import { emitWalletDetected } from '../utils/events';
 import { configWalletsToWalletName } from '../utils/providers';
 import {
   hashWalletsState,
@@ -15,6 +16,26 @@ import {
 } from '../utils/wallets';
 
 import { useStatefulConnect } from './useStatefulConnect/useStatefulConnect';
+
+/**
+ * Wallet types we've already reported as detected this session. Module-scoped so
+ * the `walletDetected` event fires at most once per provider regardless of how
+ * often the wallet list re-renders or remounts.
+ */
+const detectedWalletsReported = new Set<string>();
+
+/**
+ * Wallet types that aren't browser-injected extensions (hardware wallets,
+ * WalletConnect, TON Connect). Their presence doesn't indicate an installed
+ * wallet, so they're excluded from the `walletDetected` signal.
+ */
+const NON_INJECTED_WALLET_TYPES = new Set<string>([
+  WalletTypes.LEDGER,
+  WalletTypes.TREZOR,
+  WalletTypes.WALLET_CONNECT_2,
+  WalletTypes.TON_CONNECT,
+  WalletTypes.DEFAULT,
+]);
 
 interface Params {
   chain?: string;
@@ -58,6 +79,21 @@ export function useWalletList(params?: Params): API {
     : wallets;
 
   const sortedWallets = sortWalletsBasedOnConnectionState(wallets);
+
+  useEffect(() => {
+    wallets.forEach((wallet) => {
+      if (NON_INJECTED_WALLET_TYPES.has(wallet.type)) {
+        return;
+      }
+      const isDetected = wallet.state !== WalletState.NOT_INSTALLED;
+      if (isDetected && !detectedWalletsReported.has(wallet.type)) {
+        detectedWalletsReported.add(wallet.type);
+        emitWalletDetected({
+          walletName: wallet.title,
+        });
+      }
+    });
+  }, [hashWalletsState(wallets)]);
 
   const terminateConnectingWallets = useCallback(() => {
     const connectingWallets =

--- a/widget/embedded/src/pages/ConfirmSwapPage.tsx
+++ b/widget/embedded/src/pages/ConfirmSwapPage.tsx
@@ -28,7 +28,9 @@ import { useConfirmSwap } from '../hooks/useConfirmSwap';
 import { useAppStore } from '../store/AppStore';
 import { useQuoteStore } from '../store/quote';
 import { useUiStore } from '../store/ui';
-import { QuoteErrorType, QuoteWarningType } from '../types';
+import { QuoteErrorType, QuoteWarningType, UiEventTypes } from '../types';
+import { buildSwapEstimatePayload } from '../utils/eventPayloads';
+import { emitUiEvent } from '../utils/events';
 import { isQuoteWarningConfirmationRequired } from '../utils/quote';
 import { joinList } from '../utils/ui';
 
@@ -142,6 +144,15 @@ export function ConfirmSwapPage() {
     if (shouldShowWarningModal) {
       setShowQuoteWarningModal(true);
     } else {
+      if (selectedQuote) {
+        emitUiEvent({
+          type: UiEventTypes.SWAP_STARTED,
+          payload: {
+            ...buildSwapEstimatePayload(selectedQuote),
+            stepCount: selectedQuote.swaps.length,
+          },
+        });
+      }
       await onConfirm();
     }
   };

--- a/widget/embedded/src/pages/Home.tsx
+++ b/widget/embedded/src/pages/Home.tsx
@@ -23,9 +23,14 @@ import { useSwapMode } from '../hooks/useSwapMode';
 import { useAppStore } from '../store/AppStore';
 import { useQuoteStore } from '../store/quote';
 import { useUiStore } from '../store/ui';
-import { UiEventTypes } from '../types';
+import { QuoteEventTypes, UiEventTypes } from '../types';
 import { isVariantExpandable } from '../utils/configs';
-import { emitPreventableEvent } from '../utils/events';
+import { buildSwapEstimatePayload } from '../utils/eventPayloads';
+import {
+  emitPreventableEvent,
+  emitQuoteEvent,
+  emitUiEvent,
+} from '../utils/events';
 import { getSlippageValidation } from '../utils/settings';
 import { getSwapButtonState, isTokensIdentical } from '../utils/swap';
 
@@ -133,6 +138,18 @@ export function Home() {
   };
   const onClickOnQuote = (quote: SelectedQuote) => {
     if (selectedQuote?.requestId !== quote.requestId) {
+      if (selectedQuote) {
+        emitQuoteEvent({
+          type: QuoteEventTypes.ROUTE_CHANGED,
+          payload: {
+            sourceChain: quote.swaps[0]?.from.blockchain ?? '',
+            destinationChain:
+              quote.swaps[quote.swaps.length - 1]?.to.blockchain ?? '',
+            fromRouteId: selectedQuote.requestId,
+            toRouteId: quote.requestId,
+          },
+        });
+      }
       setShowQuoteWarningModal(false);
       setSelectedQuote(quote);
     }
@@ -171,6 +188,25 @@ export function Home() {
     setIsVisibleExpanded(hasInputs);
   }, [hasInputs]);
 
+  const handleSwapButtonClick = () => {
+    if (swapButtonState.action === 'connect-wallet') {
+      emitPreventableEvent({ type: UiEventTypes.CLICK_CONNECT_WALLET }, () => {
+        onHandleNavigation(navigationRoutes.wallets);
+      });
+    } else if (swapButtonState.action === 'confirm-warning') {
+      setShowQuoteWarningModal(true);
+    } else if (selectedQuote) {
+      emitUiEvent({
+        type: UiEventTypes.SWAP_INITIATED,
+        payload: {
+          ...buildSwapEstimatePayload(selectedQuote),
+          walletConnected: connectedWallets.length > 0,
+        },
+      });
+      onHandleNavigation(navigationRoutes.confirmSwap);
+    }
+  };
+
   return (
     <MainContainer>
       <Layout
@@ -186,18 +222,7 @@ export function Home() {
               swapButtonState.action === 'confirm-warning' && <WarningIcon />
             }
             fullWidth
-            onClick={() => {
-              if (swapButtonState.action === 'connect-wallet') {
-                emitPreventableEvent(
-                  { type: UiEventTypes.CLICK_CONNECT_WALLET },
-                  () => onHandleNavigation(navigationRoutes.wallets)
-                );
-              } else if (swapButtonState.action === 'confirm-warning') {
-                setShowQuoteWarningModal(true);
-              } else {
-                onHandleNavigation(navigationRoutes.confirmSwap);
-              }
-            }}>
+            onClick={handleSwapButtonClick}>
             {swapButtonState.title}
           </Button>
         }

--- a/widget/embedded/src/pages/LiquiditySourcePage.tsx
+++ b/widget/embedded/src/pages/LiquiditySourcePage.tsx
@@ -21,6 +21,8 @@ import {
   NotFoundContainer,
 } from '../components/SettingsContainer';
 import { useAppStore } from '../store/AppStore';
+import { type LiquiditySourceType, UiEventTypes } from '../types';
+import { emitUiEvent } from '../utils/events';
 import { containsText } from '../utils/numbers';
 import { replaceSpacesWithDash } from '../utils/sanitizers';
 import { getUniqueSwappersGroups } from '../utils/settings';
@@ -56,7 +58,24 @@ export function LiquiditySourcePage({ sourceType }: PropTypes) {
     liquiditySources.length ===
     liquiditySources.filter((sourceItem) => sourceItem.selected).length;
 
+  const liquiditySourceType: LiquiditySourceType =
+    sourceType === 'Exchanges' ? 'exchanges' : 'bridges';
+
   const toggleAllSources = () => {
+    // Selecting all enables every source; deselecting all disables them.
+    const enabled = !hasSelectAll;
+    emitUiEvent({
+      type: UiEventTypes.SETTINGS_CHANGED,
+      payload: {
+        setting: 'liquiditySource',
+        sourceType: liquiditySourceType,
+        changeType: enabled ? 'selectAll' : 'deselectAll',
+        previousSelectedCount: liquiditySources.filter(
+          (sourceItem) => sourceItem.selected
+        ).length,
+        totalCount: liquiditySources.length,
+      },
+    });
     liquiditySources.forEach((sourceItem) => {
       if (hasSelectAll) {
         toggleLiquiditySource(sourceItem.groupTitle);
@@ -79,6 +98,15 @@ export function LiquiditySourcePage({ sourceType }: PropTypes) {
       start: <Image src={logo} size={22} type="circular" />,
       onClick: () => {
         if (!campaignMode) {
+          emitUiEvent({
+            type: UiEventTypes.SETTINGS_CHANGED,
+            payload: {
+              setting: 'liquiditySource',
+              sourceType: liquiditySourceType,
+              changeType: 'individual',
+              sources: [{ id: groupTitle, enabled: !selected }],
+            },
+          });
           toggleLiquiditySource(groupTitle);
         }
       },

--- a/widget/embedded/src/pages/SelectBlockchainPage.tsx
+++ b/widget/embedded/src/pages/SelectBlockchainPage.tsx
@@ -16,7 +16,9 @@ import { useNavigateBack } from '../hooks/useNavigateBack';
 import { useSwapMode } from '../hooks/useSwapMode';
 import { useAppStore } from '../store/AppStore';
 import { useQuoteStore } from '../store/quote';
+import { UiEventTypes } from '../types';
 import { filterBlockchainsWithAtLeastOneToken } from '../utils/common';
+import { emitUiEvent } from '../utils/events';
 
 interface PropTypes {
   type: 'source' | 'destination' | 'custom-token';
@@ -51,6 +53,14 @@ export function SelectBlockchainPage(props: PropTypes) {
     if (type === 'custom-token') {
       navigate(`..?blockchain=${blockchain.name}`, { replace: true });
     } else {
+      emitUiEvent({
+        type: UiEventTypes.CHAIN_FILTER_APPLIED,
+        payload: {
+          side: type === 'source' ? 'from' : 'to',
+          chain: blockchain.name,
+          filterSource: 'expanded',
+        },
+      });
       if (type === 'source') {
         setFromBlockchain(blockchain);
       } else {

--- a/widget/embedded/src/pages/SelectSwapItemPage/SelectSwapItemPage.helpers.ts
+++ b/widget/embedded/src/pages/SelectSwapItemPage/SelectSwapItemPage.helpers.ts
@@ -7,6 +7,15 @@ import {
   MIN_SEARCH_LENGTH,
 } from './SelectSwapItemPage.constants';
 
+export function getTokenSelectionMethod(
+  searchedFor: string
+): 'search' | 'default ' {
+  if (searchedFor.trim()) {
+    return 'search';
+  }
+  return 'default ';
+}
+
 export function shouldSearchForCustomTokens(
   metaSearchResultTokens: Token[],
   query: string,

--- a/widget/embedded/src/pages/SelectSwapItemPage/SelectSwapItemsPage.tsx
+++ b/widget/embedded/src/pages/SelectSwapItemPage/SelectSwapItemsPage.tsx
@@ -14,8 +14,11 @@ import { useNavigateBack } from '../../hooks/useNavigateBack';
 import { useSearchCustomTokens } from '../../hooks/useSearchCustomTokens';
 import { useAppStore } from '../../store/AppStore';
 import { useQuoteStore } from '../../store/quote';
+import { UiEventTypes } from '../../types';
+import { emitUiEvent } from '../../utils/events';
 
 import {
+  getTokenSelectionMethod,
   prepareTokensList,
   shouldSearchForCustomTokens,
 } from './SelectSwapItemPage.helpers';
@@ -82,6 +85,31 @@ export function SelectSwapItemsPage(props: PropTypes) {
       setToToken({ token, meta: { blockchains } });
     }
   };
+
+  const side = type === 'source' ? 'from' : 'to';
+
+  const emitChainFilterApplied = (blockchain: BlockchainMeta) => {
+    emitUiEvent({
+      type: UiEventTypes.CHAIN_FILTER_APPLIED,
+      payload: { side, chain: blockchain.name, filterSource: 'featured' },
+    });
+  };
+
+  const emitTokenSelected = (token: Token) => {
+    emitUiEvent({
+      type: UiEventTypes.TOKEN_SELECTED,
+      payload: {
+        side,
+        tokenName: token.name,
+        tokenSymbol: token.symbol,
+        tokenAddress: token.address,
+        chain: token.blockchain,
+        selectionMethod: getTokenSelectionMethod(searchedFor),
+        activeChainFilter: selectedBlockchainName || 'all',
+      },
+    });
+  };
+
   const types = {
     source: i18n.t('Source'),
     destination: i18n.t('Destination'),
@@ -111,6 +139,7 @@ export function SelectSwapItemsPage(props: PropTypes) {
           blockchain={type === 'source' ? fromBlockchain : toBlockchain}
           onMoreClick={() => navigate(navigationRoutes.blockchains)}
           onChange={(blockchain) => {
+            emitChainFilterApplied(blockchain);
             updateBlockchain(blockchain);
           }}
         />
@@ -142,6 +171,7 @@ export function SelectSwapItemsPage(props: PropTypes) {
           searchedFor={searchedFor}
           type={type}
           onChange={(token) => {
+            emitTokenSelected(token);
             updateToken(token);
 
             const tokenBlockchain = blockchains.find(

--- a/widget/embedded/src/pages/SwapDetailsPage.tsx
+++ b/widget/embedded/src/pages/SwapDetailsPage.tsx
@@ -9,6 +9,8 @@ import { SwapDetails } from '../components/SwapDetails';
 import { SwapDetailsPlaceholder } from '../components/SwapDetails/SwapDetails.Placeholder';
 import { useNavigateBack } from '../hooks/useNavigateBack';
 import { useAppStore } from '../store/AppStore';
+import { UiEventTypes } from '../types';
+import { emitUiEvent } from '../utils/events';
 import { getPendingSwaps } from '../utils/queue';
 
 export function SwapDetailsPage() {
@@ -41,6 +43,10 @@ export function SwapDetailsPage() {
     if (selectedSwap?.id) {
       const swap = manager?.get(selectedSwap.id);
       if (swap) {
+        emitUiEvent({
+          type: UiEventTypes.SWAP_CANCELLED,
+          payload: { routeId: requestId },
+        });
         cancelSwap(swap);
       }
     }

--- a/widget/embedded/src/store/slices/wallets.ts
+++ b/widget/embedded/src/store/slices/wallets.ts
@@ -114,7 +114,8 @@ export interface WalletsSlice {
   newWalletConnected: (
     accounts: Wallet[],
     namespace?: Namespace,
-    derivationPath?: string
+    derivationPath?: string,
+    meta?: { walletName?: string }
   ) => Promise<void>;
   disconnectNamespaces: (walletType: string, namespaces: Namespace[]) => void;
   /**
@@ -443,14 +444,19 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
         connectedWallets: nextConnectedWalletsWithUpdatedSelectedStatus,
       });
     },
-    newWalletConnected: async (accounts, namespace, derivationPath) => {
+    newWalletConnected: async (accounts, namespace, derivationPath, meta) => {
       const newAccount = accounts[0];
       if (!newAccount) {
         return;
       }
       eventEmitter.emit(WidgetEvents.WalletEvent, {
         type: WalletEventTypes.CONNECT,
-        payload: { walletType: newAccount.walletType, accounts },
+        payload: {
+          walletType: newAccount.walletType,
+          accounts,
+          chain: newAccount.chain ?? null,
+          walletName: meta?.walletName ?? newAccount.walletType,
+        },
       });
 
       get().addConnectedWallet(accounts, namespace, derivationPath);
@@ -526,7 +532,7 @@ export const createWalletsSlice = keepLastUpdated<AppStoreState, WalletsSlice>(
        */
       eventEmitter.emit(WidgetEvents.WalletEvent, {
         type: WalletEventTypes.DISCONNECT,
-        payload: { walletType },
+        payload: { walletType, walletName: walletType },
       });
       if (isTargetWalletExistsInConnectedWallets) {
         // This should be called before updating connectedWallets since we need the old state to remove balances.

--- a/widget/embedded/src/types/event.ts
+++ b/widget/embedded/src/types/event.ts
@@ -5,8 +5,6 @@ import type {
   StepEventData,
 } from '@rango-dev/queue-manager-rango-preset';
 
-import { WidgetEvents as QueueManagerEvents } from '@rango-dev/queue-manager-rango-preset';
-
 type EventData<
   T extends QuoteEventTypes | WalletEventTypes | UiEventTypes,
   U extends Record<string, unknown> | null
@@ -23,11 +21,20 @@ type Account = Wallet;
 export enum QuoteEventTypes {
   QUOTE_INPUT_UPDATE = 'quoteInputUpdate',
   QUOTE_OUTPUT_UPDATE = 'quoteOutputUpdate',
+  /** A route/quote request was made with a valid source, destination and amount. */
+  ROUTE_REQUESTED = 'routeRequested',
+  /** The route API returned zero results for the requested pair. */
+  ROUTE_NOT_FOUND = 'routeNotFound',
+  /** The route API returned a 4xx/5xx error. */
+  ROUTE_FETCH_FAILED = 'routeFetchFailed',
+  /** The user overrode the auto-selected route. */
+  ROUTE_CHANGED = 'routeChanged',
 }
 
 export enum WalletEventTypes {
   CONNECT = 'connect',
   DISCONNECT = 'disconnect',
+  DETECTED = 'detected',
 }
 
 /**
@@ -36,6 +43,20 @@ export enum WalletEventTypes {
  */
 export enum UiEventTypes {
   CLICK_CONNECT_WALLET = 'clickConnectWallet',
+  TOKEN_SELECTED = 'tokenSelected',
+  CHAIN_FILTER_APPLIED = 'chainFilterApplied',
+  SETTINGS_CHANGED = 'settingsChanged',
+  ROUTE_FEE_VIEWED = 'routeFeeViewed',
+  DESTINATION_ADDRESS_SET = 'destinationAddressSet',
+  GAS_WARNING_SHOWN = 'gasWarningShown',
+  GAS_WARNING_BYPASSED = 'gasWarningBypassed',
+  SWAP_INITIATED = 'swapInitiated',
+  SWAP_WALLETS_MODAL_SHOWN = 'swapWalletsModalShown',
+  SWAP_WALLETS_CONFIRMED = 'swapWalletsConfirmed',
+  SWAP_STARTED = 'swapStarted',
+  SWAP_RESUMED = 'swapResumed',
+  SWAP_RETRIED = 'swapRetried',
+  SWAP_CANCELLED = 'swapCancelled',
 }
 
 export type QuoteInputUpdateEventPayload = {
@@ -54,30 +75,188 @@ export type QuoteUpdateEventPayload = Pick<
 export type ConnectWalletEventPayload = {
   walletType: string;
   accounts: Account[];
+  /** Blockchain of the first connected account. */
+  chain: string | null;
+  /** wallet type (e.g. "metamask"). */
+  walletName: string;
 };
 
 export type DisconnectWalletEventPayload = {
   walletType: string;
+  walletName: string;
+};
+
+export type WalletDetectedEventPayload = {
+  walletName: string;
 };
 
 export type ClickConnectWalletPayload = PreventableEventPayload;
 
+/** Shared shape describing a route/quote, used by several swap events. */
+export type SwapEstimateEventPayload = {
+  sourceChain: string;
+  destinationChain: string;
+  sourceTokenSymbol: string;
+  sourceTokenAddress: string | null;
+  destinationTokenSymbol: string;
+  destinationTokenAddress: string | null;
+  inputAmountUsd: number | null;
+  outputAmountUsd: number | null;
+  sourceTokenAmount: number | null;
+  destinationTokenAmount: number | null;
+  routeId: string;
+};
+
+export type RouteRequestedEventPayload = SwapEstimateEventPayload & {
+  routeCount: number;
+};
+
+export type RouteNotFoundEventPayload = {
+  sourceChain: string;
+  destinationChain: string;
+  sourceTokenSymbol: string;
+  sourceTokenAddress: string | null;
+  destinationTokenSymbol: string;
+  destinationTokenAddress: string | null;
+  inputAmountUsd: number | null;
+};
+
+export type RouteFetchFailedEventPayload = {
+  sourceChain: string;
+  destinationChain: string;
+  /** HTTP status code returned by the route API, as a string. */
+  errorCode: string;
+};
+
+export type RouteChangedEventPayload = {
+  sourceChain: string;
+  destinationChain: string;
+  fromRouteId: string;
+  toRouteId: string;
+};
+
+export type TokenSelectedEventPayload = {
+  side: 'from' | 'to';
+  tokenName: string | null;
+  tokenSymbol: string;
+  tokenAddress: string | null;
+  chain: string;
+  selectionMethod: 'search' | 'default ';
+  /** `all` when no chain filter is active, otherwise the filtered chain name. */
+  activeChainFilter: string;
+};
+
+export type ChainFilterAppliedEventPayload = {
+  side: 'from' | 'to';
+  chain: string;
+  filterSource: 'featured' | 'expanded';
+};
+
+export type LiquiditySourceType = 'exchanges' | 'bridges';
+
+export type SettingsChangedEventPayload =
+  | { setting: 'slippage'; previousValue: number; newValue: number }
+  | { setting: 'infiniteApproval'; previousValue: boolean; newValue: boolean }
+  | {
+      setting: 'liquiditySource';
+      sourceType: LiquiditySourceType;
+      /** A single source was toggled on/off from the list. */
+      changeType: 'individual';
+      /** The sources whose enabled state changed, with their new state. */
+      sources: { id: string; enabled: boolean }[];
+    }
+  | {
+      setting: 'liquiditySource';
+      sourceType: LiquiditySourceType;
+      /** Every source was enabled or disabled at once via the header button. */
+      changeType: 'selectAll' | 'deselectAll';
+      /**
+       * Selection state before the bulk action, so the consumer can summarise
+       * it as all/some/none.
+       */
+      previousSelectedCount: number;
+      totalCount: number;
+    };
+
+export type RouteFeeViewedEventPayload = { routeId: string };
+
+export type DestinationAddressSetEventPayload = { destinationChain: string };
+
+export type GasWarningEventPayload = { routeId: string };
+
+export type SwapInitiatedEventPayload = SwapEstimateEventPayload & {
+  walletConnected: boolean;
+};
+
+export type SwapStartedEventPayload = SwapEstimateEventPayload & {
+  stepCount: number;
+};
+
+export type SwapWalletsModalShownEventPayload = {
+  chainsRequired: number;
+  chainsPending: number;
+};
+
+export type SwapWalletsConfirmedEventPayload = { routeId: string };
+
+export type SwapResumedEventPayload = {
+  routeId: string;
+  stepCount: number;
+  stepNumber: number;
+};
+
+export type SwapRetriedEventPayload = { routeId: string };
+
+export type SwapCancelledEventPayload = { routeId: string };
+
 export type QuoteEventData =
   | EventData<QuoteEventTypes.QUOTE_INPUT_UPDATE, QuoteInputUpdateEventPayload>
-  | EventData<QuoteEventTypes.QUOTE_OUTPUT_UPDATE, QuoteUpdateEventPayload>;
+  | EventData<QuoteEventTypes.QUOTE_OUTPUT_UPDATE, QuoteUpdateEventPayload>
+  | EventData<QuoteEventTypes.ROUTE_REQUESTED, RouteRequestedEventPayload>
+  | EventData<QuoteEventTypes.ROUTE_NOT_FOUND, RouteNotFoundEventPayload>
+  | EventData<QuoteEventTypes.ROUTE_FETCH_FAILED, RouteFetchFailedEventPayload>
+  | EventData<QuoteEventTypes.ROUTE_CHANGED, RouteChangedEventPayload>;
 
 export type WalletEventData =
   | EventData<WalletEventTypes.CONNECT, ConnectWalletEventPayload>
-  | EventData<WalletEventTypes.DISCONNECT, DisconnectWalletEventPayload>;
+  | EventData<WalletEventTypes.DISCONNECT, DisconnectWalletEventPayload>
+  | EventData<WalletEventTypes.DETECTED, WalletDetectedEventPayload>;
 
-export type UiEventData = EventData<
-  UiEventTypes.CLICK_CONNECT_WALLET,
-  ClickConnectWalletPayload
->;
+export type UiEventData =
+  | EventData<UiEventTypes.CLICK_CONNECT_WALLET, ClickConnectWalletPayload>
+  | EventData<UiEventTypes.TOKEN_SELECTED, TokenSelectedEventPayload>
+  | EventData<UiEventTypes.CHAIN_FILTER_APPLIED, ChainFilterAppliedEventPayload>
+  | EventData<UiEventTypes.SETTINGS_CHANGED, SettingsChangedEventPayload>
+  | EventData<UiEventTypes.ROUTE_FEE_VIEWED, RouteFeeViewedEventPayload>
+  | EventData<
+      UiEventTypes.DESTINATION_ADDRESS_SET,
+      DestinationAddressSetEventPayload
+    >
+  | EventData<UiEventTypes.GAS_WARNING_SHOWN, GasWarningEventPayload>
+  | EventData<UiEventTypes.GAS_WARNING_BYPASSED, GasWarningEventPayload>
+  | EventData<UiEventTypes.SWAP_INITIATED, SwapInitiatedEventPayload>
+  | EventData<
+      UiEventTypes.SWAP_WALLETS_MODAL_SHOWN,
+      SwapWalletsModalShownEventPayload
+    >
+  | EventData<
+      UiEventTypes.SWAP_WALLETS_CONFIRMED,
+      SwapWalletsConfirmedEventPayload
+    >
+  | EventData<UiEventTypes.SWAP_STARTED, SwapStartedEventPayload>
+  | EventData<UiEventTypes.SWAP_RESUMED, SwapResumedEventPayload>
+  | EventData<UiEventTypes.SWAP_RETRIED, SwapRetriedEventPayload>
+  | EventData<UiEventTypes.SWAP_CANCELLED, SwapCancelledEventPayload>;
 
+/**
+ * RouteEvent/StepEvent must match the queue-manager's `WidgetEvents` string
+ * values (`QueueManagerEvents`) so events route correctly. They're inlined as
+ * literals rather than referencing the other enum to keep this a pure string
+ * enum (a cross-enum reference makes `no-mixed-enums` read them as numeric).
+ */
 export enum WidgetEvents {
-  RouteEvent = QueueManagerEvents.RouteEvent,
-  StepEvent = QueueManagerEvents.StepEvent,
+  RouteEvent = 'routeEvent',
+  StepEvent = 'stepEvent',
   QuoteEvent = 'quoteEvent',
   WalletEvent = 'walletEvent',
   UiEvent = 'uiEvent',

--- a/widget/embedded/src/utils/eventPayloads.ts
+++ b/widget/embedded/src/utils/eventPayloads.ts
@@ -1,0 +1,39 @@
+import type { SelectedQuote, SwapEstimateEventPayload } from '../types';
+
+import { getUsdInputFrom, getUsdOutputFrom } from './swap';
+
+function toNumberOrNull(value: string | null | undefined): number | null {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Derives the shared route/quote descriptor used by several swap
+ * events (swapInitiated, swapStarted, routeRequested, ...) from a quote.
+ * Amounts are estimates taken from the quote, not on-chain actuals.
+ */
+export function buildSwapEstimatePayload(
+  quote: SelectedQuote
+): SwapEstimateEventPayload {
+  const firstSwap = quote.swaps[0];
+  const lastSwap = quote.swaps[quote.swaps.length - 1];
+  const inputUsd = getUsdInputFrom(quote);
+  const outputUsd = getUsdOutputFrom(quote);
+
+  return {
+    routeId: quote.requestId,
+    sourceChain: firstSwap?.from.blockchain ?? '',
+    destinationChain: lastSwap?.to.blockchain ?? '',
+    sourceTokenSymbol: firstSwap?.from.symbol ?? '',
+    sourceTokenAddress: firstSwap?.from.address ?? null,
+    destinationTokenSymbol: lastSwap?.to.symbol ?? '',
+    destinationTokenAddress: lastSwap?.to.address ?? null,
+    sourceTokenAmount: toNumberOrNull(quote.requestAmount),
+    destinationTokenAmount: toNumberOrNull(quote.outputAmount),
+    inputAmountUsd: inputUsd ? inputUsd.toNumber() : null,
+    outputAmountUsd: outputUsd ? outputUsd.toNumber() : null,
+  };
+}

--- a/widget/embedded/src/utils/events.ts
+++ b/widget/embedded/src/utils/events.ts
@@ -1,27 +1,50 @@
 import { eventEmitter } from '../services/eventEmitter';
-import { type UiEventData, WidgetEvents } from '../types';
+import {
+  type ClickConnectWalletPayload,
+  type QuoteEventData,
+  type UiEventData,
+  type UiEventTypes,
+  type WalletDetectedEventPayload,
+  WalletEventTypes,
+  WidgetEvents,
+} from '../types';
 
-type UiEvent = {
-  type: UiEventData['type'];
-  payload?: Omit<UiEventData['payload'], 'preventDefault'>;
+type PreventableUiEvent = {
+  type: UiEventTypes.CLICK_CONNECT_WALLET;
+  payload?: Omit<ClickConnectWalletPayload, 'preventDefault'>;
 };
 
-export function emitPreventableEvent(event: UiEvent, action: () => void): void {
+export function emitUiEvent(event: UiEventData): void {
+  eventEmitter.emit(WidgetEvents.UiEvent, event);
+}
+
+export function emitPreventableEvent(
+  event: PreventableUiEvent,
+  action: () => void
+): void {
   let defaultPrevented = false;
 
   const extendedPayload = {
+    ...event.payload,
     preventDefault() {
       defaultPrevented = true;
     },
-    ...(event.payload === undefined && { payload: event.payload }),
   };
 
-  eventEmitter.emit(WidgetEvents.UiEvent, {
-    type: event.type,
-    payload: extendedPayload,
-  });
+  emitUiEvent({ type: event.type, payload: extendedPayload });
 
   if (!defaultPrevented) {
     action();
   }
+}
+
+export function emitQuoteEvent(event: QuoteEventData): void {
+  eventEmitter.emit(WidgetEvents.QuoteEvent, event);
+}
+
+export function emitWalletDetected(payload: WalletDetectedEventPayload): void {
+  eventEmitter.emit(WidgetEvents.WalletEvent, {
+    type: WalletEventTypes.DETECTED,
+    payload,
+  });
 }


### PR DESCRIPTION
## Summary
This PR significantly expands the events the widget emits through
`widgetEventEmitter`, so host applications can observe user interactions and the
swap / route / wallet lifecycle happening inside the widget. It adds new
UI-interaction events, quote/route lifecycle events, enriches the wallet events,
and ships the supporting types and emit helpers.

## What's included

### New event types & payloads (`types/event.ts`)
- **UI interaction events** (`UiEvent` channel): `tokenSelected`,
  `chainFilterApplied`, `settingsChanged`, `routeFeeViewed`,
  `destinationAddressSet`, `gasWarningShown`, `gasWarningBypassed`,
  `swapInitiated`, `swapWalletsModalShown`, `swapWalletsConfirmed`,
  `swapStarted`, `swapResumed`, `swapRetried`, `swapCancelled`.
- **Quote/route lifecycle events** (`QuoteEvent` channel): `routeRequested`,
  `routeNotFound`, `routeFetchFailed`, `routeChanged`.
- **Wallet events** (`WalletEvent` channel): the `connect` payload is enriched
  with `chain`, `walletName`, and `source`; new `connectInitiated` and
  `detected` events.
- Strongly-typed payloads for every new event, exported through the existing
  `UiEventData` / `QuoteEventData` / `WalletEventData` unions.

### Emit helpers (`utils/events.ts`)
- `emitUiEvent`, `emitQuoteEvent`, `emitWalletConnectInitiated`,
  `emitWalletDetected` for emitting the new events from across the widget.

### Instrumentation
Wired the new events at their source: the token selector & chain chips, settings
(slippage / infinite approval / liquidity sources), the fee breakdown, the gas
warning modal, the custom destination input, the swap button, the
confirm-wallets modal, swap details (retry / cancel), in-progress swap resume
detection, and the quote/route fetch lifecycle.

### Wallet connection source tracking
- Added `services/walletConnectionSource.ts`, which records where a wallet
  connection was initiated (nav / swap button / confirm-wallets modal) and
  applies it to the resulting `connect` event. It uses a
  stash-on-initiation / consume-on-connect approach so the source survives the
  async gap between the click and the connection completing.

### Misc
- `WidgetEvents` is now a plain string enum (queue-manager values inlined) to
  satisfy `no-mixed-enums`.
- Extracted the token selection-method logic into a helper to remove a nested
  ternary.

## Note on branching / release
> The base branch is currently **`main`** so we can publish **experimental
> versions** of the package and test the integration in other places. After the
> review and test phase, the base will be switched to **`next`** and this will be
> merged into the **`next`** branch.
