### PR TITLE
Feat/add utxo namespace to wallet connect

### DIFF
--- a/wallets/provider-walletconnect-2/src/constants.ts
+++ b/wallets/provider-walletconnect-2/src/constants.ts
@@ -1,6 +1,11 @@
 import type { ProviderMetadata } from '@hub3js/core';
 
 import { isEvmNamespace } from '@hub3js/evm';
+import { getChainIdFromCaip2ChainId } from '@hub3js/std/utils';
+import {
+  CAIP_BITCOIN_CHAIN_ID,
+  isUtxoNamespace,
+} from '@rango-dev/wallets-core/namespaces/utxo';
 
 import getSigners from './signer.js';
 
@@ -23,6 +28,14 @@ export const metadata: ProviderMetadata = {
             value: 'EVM',
             id: 'ETH',
             isChainSupported: isEvmNamespace,
+          },
+          {
+            label: 'BTC',
+            value: 'UTXO',
+            id: 'BTC',
+            isChainSupported: (chainId: string) =>
+              isUtxoNamespace(chainId) &&
+              getChainIdFromCaip2ChainId(chainId) === CAIP_BITCOIN_CHAIN_ID,
           },
         ],
       },

--- a/wallets/provider-walletconnect-2/src/namespaces/utxo/hooks.ts
+++ b/wallets/provider-walletconnect-2/src/namespaces/utxo/hooks.ts
@@ -1,0 +1,130 @@
+import type { UtxoActions } from '@rango-dev/wallets-core/namespaces/utxo';
+
+import {
+  CAIP_BITCOIN_CHAIN_ID,
+  utils,
+} from '@rango-dev/wallets-core/namespaces/utxo';
+import { AccountId } from 'caip';
+
+import {
+  type Bip122AddressEntry,
+  filterBip122Accounts,
+  getAnnouncedAddresses,
+  pickPaymentAddress,
+} from '../../session/bip122.js';
+import { expireWalletConnectTopic } from '../../session/teardown.js';
+import { BitcoinEvents, NAMESPACES } from '../../wcConstants.js';
+import { createSessionSubscriber } from '../subscriber.js';
+
+/**
+ * WC signals a bip122 account switch via `session_update` (re-shared namespaces
+ * with the newly-selected account first), so the active account is published
+ * from this event.
+ */
+export function sessionUpdateSubscriber() {
+  return createSessionSubscriber<'session_update', UtxoActions>(
+    'utxo',
+    'session_update',
+    ({ args, session, adapter, context }) => {
+      const bip122Namespace = args.params.namespaces[NAMESPACES.BITCOIN];
+      if (!bip122Namespace?.accounts?.length) {
+        return;
+      }
+
+      /*
+       * Keep the cached struct in step with what the wallet just re-shared:
+       * `sessionEventSubscriber` reads the shared account back out of it, and
+       * a stale copy would keep re-publishing the account that was replaced.
+       */
+      adapter.cacheSession('utxo', {
+        ...session,
+        namespaces: args.params.namespaces,
+      });
+
+      const [, setState] = context.state();
+      setState(
+        'accounts',
+        utils.formatAccountsToCAIP(
+          [new AccountId(bip122Namespace.accounts[0]).address],
+          CAIP_BITCOIN_CHAIN_ID
+        )
+      );
+    }
+  );
+}
+
+/**
+ * Handles WC `session_event` payloads: bip122 `addressesChanged` (re-publish the
+ * account the session shares, fall back to the announced payment address once
+ * the wallet stops offering that account, or run the hub `disconnect` action
+ * when it reports no usable addresses at all).
+ */
+export function sessionEventSubscriber() {
+  return createSessionSubscriber<'session_event', UtxoActions>(
+    'utxo',
+    'session_event',
+    ({ args, session, context }) => {
+      if (args.params.event.name !== BitcoinEvents.ADDRESSES_CHANGED) {
+        return;
+      }
+
+      const data = args.params.event.data as
+        | Bip122AddressEntry[]
+        | string[]
+        | undefined;
+      const announced = getAnnouncedAddresses(data);
+      if (!announced.length) {
+        void context.action('disconnect');
+        return;
+      }
+
+      /*
+       * The payload is not a "selected account" signal: Ledger announces every
+       * address in the wallet at once, so a pick out of it says nothing about
+       * which account the session shares. Only trust the pick once the wallet
+       * has dropped the shared account from the list.
+       */
+      const sharedAddress = filterBip122Accounts(session)
+        .map((account) => account.address)
+        .find((address) =>
+          announced.some(
+            (announcedAddress) =>
+              announcedAddress.toLowerCase() === address.toLowerCase()
+          )
+        );
+
+      /*
+       * `||`, not `??`: `pickPaymentAddress` reads `entries[0].address` as its
+       * own fallback and can hand back an empty string, which `??` would keep.
+       * `announced` is non-empty and holds only truthy addresses, so its first
+       * entry always settles this.
+       */
+      const activeAddress =
+        sharedAddress || pickPaymentAddress(data) || announced[0];
+
+      const [, setState] = context.state();
+      setState(
+        'accounts',
+        utils.formatAccountsToCAIP([activeAddress], CAIP_BITCOIN_CHAIN_ID)
+      );
+    }
+  );
+}
+
+/**
+ * Reflects a wallet-initiated `session_delete` into the hub: clears the cached
+ * session, expires the WC topic, and runs the hub `disconnect` action.
+ */
+export function sessionDeleteSubscriber() {
+  return createSessionSubscriber<'session_delete', UtxoActions>(
+    'utxo',
+    'session_delete',
+    ({ args, adapter, context }) => {
+      adapter.clearSession('utxo');
+      void adapter
+        .getClient()
+        .then(async (client) => expireWalletConnectTopic(client, args.topic));
+      context.action('disconnect');
+    }
+  );
+}

--- a/wallets/provider-walletconnect-2/src/namespaces/utxo/namespace.ts
+++ b/wallets/provider-walletconnect-2/src/namespaces/utxo/namespace.ts
@@ -1,0 +1,76 @@
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
+import {
+  builders,
+  CAIP_BITCOIN_CHAIN_ID,
+  utils,
+  type UtxoActions,
+} from '@rango-dev/wallets-core/namespaces/utxo';
+
+import { getAdapter } from '../../adapter/registry.js';
+import { WALLET_ID } from '../../constants.js';
+import { filterBip122Accounts } from '../../session/bip122.js';
+
+import {
+  sessionDeleteSubscriber,
+  sessionEventSubscriber,
+  sessionUpdateSubscriber,
+} from './hooks.js';
+
+const [sessionUpdate, sessionUpdateCleanup] = sessionUpdateSubscriber();
+const [sessionEvent, sessionEventCleanup] = sessionEventSubscriber();
+const [sessionDelete, sessionDeleteCleanup] = sessionDeleteSubscriber();
+
+const connect = builders
+  .connect()
+  .action(async function () {
+    const adapter = getAdapter();
+    const session = await adapter.ensureSession({ namespace: 'utxo' });
+    const bip122Accounts = filterBip122Accounts(session);
+
+    if (!bip122Accounts.length) {
+      throw new Error('No Bitcoin accounts found in WalletConnect session.');
+    }
+
+    return utils.formatAccountsToCAIP(
+      [bip122Accounts[0].address],
+      CAIP_BITCOIN_CHAIN_ID
+    );
+  })
+  .before(sessionUpdate)
+  .before(sessionEvent)
+  .before(sessionDelete)
+  .or(sessionUpdateCleanup)
+  .or(sessionEventCleanup)
+  .or(sessionDeleteCleanup)
+  .or((_, err) => {
+    void getAdapter().disconnectSession('utxo');
+    return err;
+  })
+  .or(standardizeAndThrowError)
+  .build();
+
+const canEagerConnect = new ActionBuilder<UtxoActions, 'canEagerConnect'>(
+  'canEagerConnect'
+)
+  .action(async () => getAdapter().tryRestoreEagerSession('utxo'))
+  .build();
+
+const disconnect = commonBuilders
+  .disconnect<UtxoActions>()
+  .before(async () => {
+    await getAdapter().disconnectSession('utxo');
+  })
+  .after(sessionUpdateCleanup)
+  .after(sessionEventCleanup)
+  .after(sessionDeleteCleanup)
+  .build();
+
+const utxo = new NamespaceBuilder<UtxoActions>('UTXO', WALLET_ID)
+  .action(connect)
+  .action(disconnect)
+  .action(canEagerConnect)
+  .build();
+
+export { utxo };

--- a/wallets/provider-walletconnect-2/src/provider.ts
+++ b/wallets/provider-walletconnect-2/src/provider.ts
@@ -6,6 +6,7 @@ import { WalletConnectAdapter } from './adapter/adapter.js';
 import { setAdapter } from './adapter/registry.js';
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm/namespace.js';
+import { utxo } from './namespaces/utxo/namespace.js';
 
 const buildProvider = () =>
   new ProviderBuilder(WALLET_ID)
@@ -30,6 +31,7 @@ const buildProvider = () =>
     })
     .config('metadata', metadata)
     .add('evm', evm)
+    .add('utxo', utxo)
     .build();
 
 export { buildProvider };

--- a/wallets/provider-walletconnect-2/src/signer.ts
+++ b/wallets/provider-walletconnect-2/src/signer.ts
@@ -14,9 +14,14 @@ export default async function getSigners(): Promise<SignerFactory> {
 
   const signers = new DefaultSignerFactory();
   const EVMSigner = (await import('./signers/evm.js')).default;
+  const UtxoSigner = (await import('./signers/utxo.js')).default;
   signers.registerSigner(
     TxType.EVM,
     new EVMSigner(client, () => adapter.getSession('evm'))
+  );
+  signers.registerSigner(
+    TxType.TRANSFER,
+    new UtxoSigner(client, () => adapter.getSession('utxo'))
   );
 
   return signers;

--- a/wallets/provider-walletconnect-2/src/signers/utxo.ts
+++ b/wallets/provider-walletconnect-2/src/signers/utxo.ts
@@ -1,0 +1,160 @@
+import type { ISignClient, SessionTypes } from '@walletconnect/types';
+import type { GenericSigner, Transfer } from 'rango-types';
+
+import * as secp256k1 from '@bitcoinerlab/secp256k1';
+import { Networks } from '@rango-dev/internal-blockchains';
+import { CAIP_BITCOIN_CHAIN_ID } from '@rango-dev/wallets-core/namespaces/utxo';
+import * as bitcoin from 'bitcoinjs-lib';
+import { AccountId, ChainId } from 'caip';
+import { SignerError, SignerErrorCode } from 'rango-types';
+
+import { BitcoinRPCMethods, NAMESPACES } from '../wcConstants.js';
+
+const BTC_RPC_URL = 'https://go.getblock.io/f37bad28a991436483c0a3679a3acbee';
+
+type SignPsbtResponse = {
+  psbt: string;
+  txid?: string;
+};
+
+type SessionGetter = () => SessionTypes.Struct | null;
+
+class UtxoSigner implements GenericSigner<Transfer> {
+  private client: ISignClient;
+  private getSession: SessionGetter;
+
+  constructor(client: ISignClient, getSession: SessionGetter) {
+    this.client = client;
+    this.getSession = getSession;
+  }
+
+  private get session(): SessionTypes.Struct {
+    const session = this.getSession();
+    if (!session) {
+      throw new Error('UTXO WalletConnect session is not available.');
+    }
+    return session;
+  }
+
+  async signMessage(): Promise<string> {
+    throw SignerError.UnimplementedError('signMessage');
+  }
+
+  async signAndSendTx(
+    tx: Transfer,
+    address: string,
+    _chainId: string | null
+  ): Promise<{ hash: string }> {
+    const { asset, psbt } = tx;
+
+    if (!psbt) {
+      throw new Error(
+        'No PSBT found to sign. Ensure a valid PSBT is provided.'
+      );
+    }
+
+    if (asset.blockchain !== Networks.BTC) {
+      throw new Error(
+        `Signing ${asset.blockchain} transaction is not implemented by the signer.`
+      );
+    }
+
+    this.assertAccountInSession(address);
+
+    const signInputs = psbt.inputsToSign.flatMap(
+      ({ address: inputAddress, signingIndexes }) =>
+        signingIndexes.map((index) => ({ address: inputAddress, index }))
+    );
+
+    const caipChainId = new ChainId({
+      namespace: NAMESPACES.BITCOIN,
+      reference: CAIP_BITCOIN_CHAIN_ID,
+    }).toString();
+
+    try {
+      const response: SignPsbtResponse = await this.client.request({
+        topic: this.session.topic,
+        chainId: caipChainId,
+        request: {
+          method: BitcoinRPCMethods.SIGN_PSBT,
+          params: {
+            account: address,
+            psbt: psbt.unsignedPsbtBase64,
+            signInputs,
+            broadcast: true,
+          },
+        },
+      });
+
+      if (response.txid) {
+        // signer wallet already broadcasted the transaction
+        return { hash: response.txid };
+      }
+
+      return await this.broadcastSignedPsbt(response.psbt);
+    } catch (error) {
+      if (typeof error === 'string') {
+        throw new SignerError(
+          SignerErrorCode.UNEXPECTED_BEHAVIOUR,
+          error,
+          undefined
+        );
+      }
+      throw new SignerError(SignerErrorCode.SEND_TX_ERROR, undefined, error);
+    }
+  }
+
+  private assertAccountInSession(address: string) {
+    const caipAddress = new AccountId({
+      chainId: {
+        namespace: NAMESPACES.BITCOIN,
+        reference: CAIP_BITCOIN_CHAIN_ID,
+      },
+      address,
+    }).toString();
+
+    const accounts = this.session.namespaces[NAMESPACES.BITCOIN]?.accounts;
+    if (!accounts?.includes(caipAddress)) {
+      throw new Error(
+        'Your requested address does not exist in your WalletConnect session. Please reconnect your wallet.'
+      );
+    }
+  }
+
+  private async broadcastSignedPsbt(signedPsbtBase64: string) {
+    bitcoin.initEccLib(secp256k1);
+
+    const finalPsbt = bitcoin.Psbt.fromBase64(signedPsbtBase64);
+
+    if (finalPsbt.data.inputs.some((input) => !input.finalScriptWitness)) {
+      finalPsbt.finalizeAllInputs();
+    }
+
+    const finalPsbtBaseHex = finalPsbt.extractTransaction().toHex();
+
+    const response = await fetch(BTC_RPC_URL, {
+      method: 'POST',
+      body: JSON.stringify({
+        method: 'sendrawtransaction',
+        params: [finalPsbtBaseHex],
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Error broadcasting transaction: ${errorText}`);
+    }
+
+    const data = await response.json();
+
+    if (!data.result) {
+      throw new Error(
+        `Error broadcasting transaction. Error Code ${data.error.code}: ${data.error.message}`
+      );
+    }
+
+    return { hash: data.result };
+  }
+}
+
+export default UtxoSigner;


### PR DESCRIPTION
# Summary

Add a UTXO namespace to the WalletConnect hub provider with Bitcoin connect/disconnect/eager-connect support and a transfer signer.

# Changes
- New namespaces/utxo with connect, disconnect, and eager-connect actions
- Bitcoin transfer signer (signers/utxo.ts) and BTC entry in provider metadata

# Test Plan

 - UTXO: connect WalletConnect with BTC namespace selected; verify Bitcoin address is returned
 - UTXO: sign a Bitcoin transfer (if applicable in your test flow)


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
