### PR TITLE
ci: speed up Check PR workflow

### DIFF
--- a/.github/actions/build-deploy/action.yml
+++ b/.github/actions/build-deploy/action.yml
@@ -40,6 +40,9 @@ runs:
   steps:              
     - name: Build Clients
       shell: bash
+      # Pure nx: build the deployable apps via `nx run-many`. Their library
+      # dependencies (^build) are restored from the nx cache produced by
+      # build-libs, so only the apps themselves are compiled.
       run: node ./scripts/build-clients/command.mjs
 
     - name: Deploy Clients

--- a/.github/actions/build-examples/action.yml
+++ b/.github/actions/build-examples/action.yml
@@ -25,6 +25,22 @@ runs:
         restore-keys: |
           ${{ runner.os }}-examples-
 
+    # Persist the bundlers' incremental build caches that live OUTSIDE
+    # node_modules so the examples don't rebuild cold every run (next's
+    # .next/cache and parcel's .parcel-cache). vite's node_modules/.vite and
+    # webpack's node_modules/.cache are already covered by the cache above.
+    # A rolling key (run id) with an examples-build- restore-keys fallback
+    # refreshes the cache every run and always restores the most recent one.
+    - name: ⚙️ Cache example build caches
+      uses: actions/cache@v4
+      with:
+        path: |
+          examples/*/.next/cache
+          examples/*/.parcel-cache
+        key: ${{ runner.os }}-examples-build-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-examples-build-
+
     - name: 📦 Install Example Dependencies
       if: steps.cache-examples.outputs.cache-hit != 'true'
       run: |
@@ -80,6 +96,10 @@ runs:
       shell: bash
 
     - name: 🚀 Build All Examples (Concurrent)
+      # Cap each build's V8 heap so several bundlers running at once can't
+      # overcommit the runner's RAM (the cause of the swap-thrash / OOM runs).
+      env:
+        NODE_OPTIONS: --max-old-space-size=4096
       run: |
         echo "::group::🚀 Building all examples concurrently"
 
@@ -88,7 +108,7 @@ runs:
         names=()
 
         for dir in ./examples/*; do
-          if [ -f "$dir/package.json" ]; then            
+          if [ -f "$dir/package.json" ]; then
             name=$(basename "$dir")
             cmds+=("yarn --cwd $dir build")
             names+=("$name")
@@ -103,7 +123,12 @@ runs:
         # Join arrays into comma-separated strings
         name_list=$(IFS=,; echo "${names[*]}")
 
+        # Limit how many examples build at once (--max-processes). Building all
+        # of them simultaneously exhausts the runner's memory and leads to
+        # 20+ minute runs or OOM failures; a bounded pool keeps memory in check
+        # while still building in parallel.
         yarn concurrently --kill-others-on-fail \
+          --max-processes 3 \
           --names "$name_list" \
           "${cmds[@]}"
 

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -3,12 +3,18 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
+# Force Nx to accept and reuse computation caches restored from different CI runners
+env:
+  NX_REJECT_UNKNOWN_LOCAL_CACHE: '0'
+
 jobs:
   check-commits:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
+          # Full history is required so check-conventional-commits can run
+          # `git log origin/<base>..HEAD`.
           fetch-depth: 0
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -21,11 +27,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Prepare
         uses: ./.github/actions/prepare
+
+      # Cache Nx outputs (.nx/cache) and metadata (.nx/workspace-data) to optimize incremental builds
+      - name: Cache nx computation cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .nx/cache
+            .nx/workspace-data
+          key: ${{ runner.os }}-nx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nx-
+
       - name: Extract new translation keys and check if any error exists
         run: node ./scripts/lingui/command.js extract --clean
 
@@ -44,8 +60,6 @@ jobs:
     needs: build-libs
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Download Build Information For Current Branch
         uses: actions/download-artifact@v4
         with:
@@ -59,14 +73,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-libs, run-tests]
     environment: preview
-    env:          
+    env:
       REACT_APP_PLAYGROUND_RANGO_API_KEY: ${{ vars.PLAYGROUND_RANGO_API_KEY }}
-      REACT_APP_RANGO_API_KEY: ${{ vars.RANGO_API_KEY }}          
+      REACT_APP_RANGO_API_KEY: ${{ vars.RANGO_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -77,17 +89,28 @@ jobs:
         with:
           name: ${{needs.build-libs.outputs.hashed_branch}}
 
+      # Read-only restore of the Nx build state to skip rebuilding shared dependencies
+      - name: Restore nx computation cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            .nx/cache
+            .nx/workspace-data
+          key: ${{ runner.os }}-nx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nx-
+
       - name: Build & Deploy
         uses: ./.github/actions/build-deploy
         id: build-deploy
         with:
           PLAYGROUND_RANGO_API_KEY: ${{ vars.PLAYGROUND_RANGO_API_KEY }}
-          RANGO_API_KEY: ${{ vars.RANGO_API_KEY }}                        
+          RANGO_API_KEY: ${{ vars.RANGO_API_KEY }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_WIDGET_CONFIG: ${{ secrets.VERCEL_PROJECT_WIDGET_CONFIG }}
           VERCEL_PROJECT_WIDGET_APP: ${{ secrets.VERCEL_PROJECT_WIDGET_APP }}
-          VERCEL_PROJECT_Q: ${{ secrets.VERCEL_PROJECT_Q }}          
+          VERCEL_PROJECT_Q: ${{ secrets.VERCEL_PROJECT_Q }}
           ENABLE_PREVIEW_DEPLOY: true
 
     outputs:
@@ -127,7 +150,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: ${{ github.ref }}
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -154,7 +176,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: ${{ github.ref }}
       - name: Prepare
         uses: ./.github/actions/prepare

--- a/nx.json
+++ b/nx.json
@@ -9,7 +9,9 @@
   },
   "targetDefaults": {
     "build": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "cache": true,
+      "outputs": ["{projectRoot}/dist"]
     },
     "dev": {
       "dependsOn": ["^build"]


### PR DESCRIPTION
# Summary

Speeds up the **Check PR** workflow by making nx reuse already-built outputs across jobs and runs, and stops the intermittent memory-exhaustion failures in `build-examples`. No nx Cloud — everything uses nx's local cache persisted via `actions/cache`.

**Motivation:** `deploy` rebuilt the apps' whole dependency tree (~40 packages, dragged in by `provider-all`) that `build-libs` had already built, and `build-examples` built all 7 examples at once, occasionally exhausting the runner's memory (20-minute runs / OOM failures).

**Changes**

1. **nx local computation cache (no nx Cloud)**
   - `nx.json`: mark the `build` target cacheable — `cache: true` + `outputs: ["{projectRoot}/dist"]`.
   - Cache **both** `.nx/cache` (task outputs) and `.nx/workspace-data` (the cache database that indexes them).
   - Set `NX_REJECT_UNKNOWN_LOCAL_CACHE=0` so nx accepts cache restored from a different runner.
   - Key on `github.sha` with an `nx-` `restore-keys` fallback: `deploy` reuses `build-libs`' cache within the same run (cross-job); later runs reuse the most recent cache (cross-run).
   - Result: `build-libs` replays unchanged libraries; `deploy`'s `nx run-many` compiles only the 3 deployable apps.

2. **build-examples**
   - Bound the concurrent build fan-out (`--max-processes 3`) and cap each build's Node heap (`--max-old-space-size=4096`) — fixes the memory-exhaustion 20-minute / OOM runs.
   - Cache the bundlers' incremental build caches that live outside `node_modules` (`.next/cache`, `.parcel-cache`).

3. **Faster checkout** — drop `fetch-depth: 0` from jobs that don't need full git history (`check-commits` keeps it for `git log origin/<base>..HEAD`).

**Caveats**
- `NX_REJECT_UNKNOWN_LOCAL_CACHE=0` is discouraged by nx for shared *network drives*; on GitHub Actions the cache is branch-scoped and written by trusted runs, so the risk is low — this is the deliberate local-cache choice in lieu of nx Cloud.
- Workflow is `pull_request`-only, so cross-*run* reuse warms on a PR's 2nd+ push; the within-run cross-job reuse (`deploy`) works on every run.
- The `dist` artifact is unchanged and still required by `run-tests` / `build-examples` / `analyze-bundle` (they consume `dist` without running nx).

Fixes # (no linked issue — CI performance improvement)

# How did you test this change?

Ran the full **Check PR** workflow on this branch multiple times (cold cache, then warm) and measured per-job durations from the Actions logs:

- [x] **build-libs** (warm): build step `200s → 1.2s` (nx replays unchanged libs); job `~240s → 58s`
- [x] **deploy** (warm): client build `232s → 35s` (nx cache hit, only the 3 apps compiled); job `~214–243s → 92s`
- [x] **build-examples**: completes within memory limits — no OOM / 20-minute runs
- [x] All jobs green on the branch (`check-commits`, `run-tests`, `analyze-bundle`, previews)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A — CI config only)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — verified via the workflow runs above)
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision (N/A)
