### PR TITLE
fix: convert chain id to chain name to compare to the user selected c…

### DIFF
--- a/widget/embedded/src/utils/wallets.ts
+++ b/widget/embedded/src/utils/wallets.ts
@@ -24,6 +24,7 @@ import { legacyReadAccountAddress as readAccountAddress } from '@rango-dev/walle
 import {
   detectInstallLink,
   HYPERLIQUID_SIGN_NETWORK,
+  getBlockChainNameFromId,
   isEvmAddress,
   Networks,
 } from '@rango-dev/wallets-shared';
@@ -44,6 +45,20 @@ import { formatThousandsWithCommas } from './sanitizers';
 
 export type ExtendedModalWalletInfo = WalletInfoWithExtra &
   Pick<ExtendedWalletInfo, 'properties' | 'isHub'>;
+
+function getConnectedEvmChainName(
+  namespaces: ReturnType<ProviderContext['state']>['namespaces'],
+  supportedChains: BlockchainMeta[]
+): string | null {
+  const evmNamespace = namespaces?.get('EVM');
+  if (!!evmNamespace?.network) {
+    return (
+      getBlockChainNameFromId(evmNamespace.network, supportedChains) ??
+      evmNamespace.network
+    );
+  }
+  return null;
+}
 
 export function getWalletConnectionStatus(
   wallet: ExtendedWalletInfo,
@@ -75,9 +90,12 @@ export function mapWalletTypesToWalletInfo(
     .filter((wallet) => {
       const { supportedChains, isContractWallet } = getWalletInfo(wallet);
 
-      const { installed, network } = getState(wallet);
+      const { installed, namespaces } = getState(wallet);
       const filterContractWallets =
-        isContractWallet && (!installed || (!!chain && network !== chain));
+        isContractWallet &&
+        (!installed ||
+          (!!chain &&
+            getConnectedEvmChainName(namespaces, supportedChains) !== chain));
       if (filterContractWallets) {
         return false;
       }


### PR DESCRIPTION
# Summary

Hub EVM wallets report `network` as a chain id (e.g. `0x1`), whereas `chain` is a Rango blockchain name (e.g. `ETH`). For contract wallets (e.g. Safe), we compare the two to check that the wallet is connected to the required chain, so we normalize the chain id to a name first. `getBlockChainNameFromId` returns the value unchanged when it's already a name (legacy wallets), so this stays correct for both.

We have to convert here because legacy and hub differ on where the conversion happens. In legacy, the provider also returned a numeric chain id, but the `Wallet` class converted it via `getBlockChainNameFromId` inside `connect()` before writing it to `state.network`, so consumers always read a network name. Hub dropped that central step: the connect action's raw chain id flows straight into `state.network` (via `connectAndUpdateStateForMultiNetworks`), so the conversion has to be reintroduced wherever `network` is read.

# How did you test this change?

You can refer to this PR for test details: https://github.com/rango-exchange/rango-client/pull/1412


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
