### PR TITLE
fix(publish): use native fetch to avoid node-fetch gzip premature-close on large registry docs

### DIFF
--- a/scripts/common/npm.mjs
+++ b/scripts/common/npm.mjs
@@ -2,7 +2,6 @@ import fs from 'node:fs/promises';
 import { $, execa } from 'execa';
 import { join } from 'node:path';
 import { compareSemVer } from 'semver-parser';
-import fetch, { Headers } from 'node-fetch';
 import {
   NpmGetPackageError,
   NpmPackageNotFoundError,
@@ -11,7 +10,6 @@ import {
 } from './errors.mjs';
 import { detectChannel } from './github.mjs';
 import { rootPath } from './path.mjs';
-
 
 /**
  * Publish a package using `yarn publish`


### PR DESCRIPTION
### Problem
The publish workflow was failing on next during the dependency-analysis step, and re-running the job never cleared it:

https://github.com/rango-exchange/rango-client/actions/runs/28323508271
```
FetchError: Invalid response body while trying to fetch
https://registry.npmjs.org/@rango-dev%2fwidget-embedded: Premature close
    at Gunzip.<anonymous> (.../node_modules/node-fetch/lib/index.js:400:12)
  type: 'system',
  code: 'ERR_STREAM_PREMATURE_CLOSE'
Root cause
The registry lookups in scripts/common/npm.mjs went through node-fetch v2.7.0, whose gzip handling has a size/timing-sensitive race that throws ERR_STREAM_PREMATURE_CLOSE while decompressing the response body (inside response.json()).
```

The failing call is the npm registry lookup in scripts/common/npm.mjs (getNpmPackage), reached via update() during getAffectedPackages().


### Change
Drop the node-fetch import so these registry lookups use Node's built-in global fetch/Headers (undici). No call-site changes — the API is compatible (fetch(url, { headers }), response.json(), response.status, new Headers()).

# How did you test this change?

- Added Registry Fetch Stress Test workflow (registry-fetch-test.yml) that runs scripts/test/registry-fetch-stress.mjs on PR pushes.
- The script mirrors getNpmPackage() in publish: same registry URL, Accept header, and parallel load (30 concurrent requests × 5 rounds) against @rango-dev/widget-embedded.
- Commit 1: used node-fetch → CI failed with FetchError: Invalid response body … Premature close (same error as publish).
- Commit 2: removed node-fetch in favor of native fetch (Node 24) → CI passed.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
