### PR TITLE
chore: use npm dist-tags endpoint in getNpmPackage

### DIFF
--- a/scripts/common/npm.mjs
+++ b/scripts/common/npm.mjs
@@ -41,37 +41,31 @@ export async function publishOnNpm(pkg) {
  */
 export async function getNpmPackage(pkg) {
   const packageName = pkg.name;
-  const headers = new Headers();
-  // This is to use less bandwidth unless we really need to get the full response.
-  // See https://github.com/npm/npm-registry-client#request
-  headers.append(
-    'Accept',
-    'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*'
-  );
   const response = await fetch(
-    `https://registry.npmjs.org/${escapeName(packageName)}`,
-    {
-      headers,
-    }
+    `https://registry.npmjs.org/-/package/${escapeName(packageName)}/dist-tags`
   ).catch((err) => {
     const msg =
       err.message || 'An error has occured when trying to get npm package.';
     throw new NpmGetPackageError(msg);
   });
 
-  const body = await response.json();
-
   // A new package which never has been published on npm.
   if (response.status === 404) {
     throw new NpmPackageNotFoundError(packageName);
-  } else if (response.status > 300) {
-    const msg = `Package: ${packageName}, Status: ${response.status}, Body: ${body}`;
+  }
+
+  const body = await response.json();
+
+  if (!response.ok) {
+    const msg = `Package: ${packageName}, Status: ${response.status}, Body: ${JSON.stringify(
+      body
+    )}`;
     throw new NpmGetPackageError(msg);
   }
 
   const versions = {
-    next: body['dist-tags'].next || null,
-    prod: body['dist-tags'].latest || null,
+    next: body.next || null,
+    prod: body.latest || null,
   };
 
   return versions;


### PR DESCRIPTION
# Summary

getNpmPackage in [scripts/common/npm.mjs](vscode-webview://18nkah7fcseiu3pn8ubrnf9fdqhnt8gqqddkbuqfdqg450ua1taf/scripts/common/npm.mjs) now fetches the dedicated dist-tags endpoint instead of the full packument, and the surrounding error handling is tightened up.

The function only ever needs the next and latest dist-tags, but it was downloading the entire package document (https://registry.npmjs.org/<pkg>) and digging dist-tags out of it. Switching to https://registry.npmjs.org/-/package/<pkg>/dist-tags returns exactly those tags and nothing else.

Alongside that, the original error handling had a few latent issues:

- The response body was parsed with response.json() before the status was checked, so a non-JSON error body would throw an - unwrapped error instead of a NpmGetPackageError.
- The error message interpolated the body object directly, producing Body: [object Object].
- The failure check used response.status > 300, an odd boundary given node-fetch follows redirects


# How did you test this change?

Can be tested by publishing an experimental version.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
