### PR TITLE
feat: add Bitcoin (UTXO) support to Trezor provider

### DIFF
--- a/wallets/core/src/namespaces/utxo/types.ts
+++ b/wallets/core/src/namespaces/utxo/types.ts
@@ -7,9 +7,18 @@ import type {
 export interface UtxoActions
   extends AutoImplementedActionsByRecommended,
     CommonActions {
-  connect: () => Promise<Accounts>;
+  connect: (options?: ConnectOptions) => Promise<Accounts>;
   canEagerConnect: () => Promise<boolean>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ProviderAPI = Record<string, any>;
+
+/*
+ * Hardware wallets (e.g. Trezor) need to know which derivation path / address type to
+ * connect. Injected UTXO wallets ignore this. Optional so existing providers are
+ * unaffected.
+ */
+export type ConnectOptions = {
+  derivationPath?: string;
+};

--- a/wallets/provider-trezor/package.json
+++ b/wallets/provider-trezor/package.json
@@ -21,9 +21,14 @@
     "lint": "eslint \"**/*.{ts,tsx}\""
   },
   "dependencies": {
+    "@bitcoinerlab/secp256k1": "^1.2.0",
+    "@hub3js/core": "^0.60.1",
+    "@hub3js/evm": "^0.2.1",
+    "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.43.0",
     "@rango-dev/wallets-shared": "^0.61.0",
     "@trezor/connect-web": "^9.5.0",
+    "bitcoinjs-lib": "^6.1.7",
     "ethers": "^6.13.2",
     "rango-types": "^0.5.0"
   },

--- a/wallets/provider-trezor/readme.md
+++ b/wallets/provider-trezor/readme.md
@@ -11,6 +11,21 @@ Trezor integration for hub.
 
 We only support Ethereum for now.
 
+#### ⚠️ UTXO
+
+We support Bitcoin only. The connect flow lets the user pick the address type via
+derivation path (Native SegWit `84'`, Nested SegWit `49'`, Legacy `44'`, Taproot `86'`).
+
+Trezor Connect has no PSBT API — its `signTransaction` takes explicit `inputs`/`outputs` —
+so Rango's BTC PSBT is parsed with `bitcoinjs-lib` and translated into that shape, then
+signed and broadcast via Trezor's Blockbook backend (`push: true`). `version`, `locktime`
+and per-input `sequence` are preserved from the PSBT; only `SIGHASH_ALL` is supported.
+Rango's PSBT carries no `bip32Derivation`, so the connect-time path is kept (like the EVM
+signer) and applied to the inputs.
+
+Other UTXO chains (LTC/DOGE/BCH/ZEC) are not implemented — they arrive from Rango as plain
+transfers (no PSBT) and would use Trezor's `composeTransaction` instead.
+
 ### Feature
 
 #### ❌ Switch Account

--- a/wallets/provider-trezor/src/actions/utxo.ts
+++ b/wallets/provider-trezor/src/actions/utxo.ts
@@ -1,0 +1,56 @@
+import type { Context, FunctionWithContext } from '@hub3js/core';
+import type { UtxoActions } from '@rango-dev/wallets-core/namespaces/utxo';
+
+import {
+  CAIP_BITCOIN_CHAIN_ID,
+  utils,
+} from '@rango-dev/wallets-core/namespaces/utxo';
+
+import { initTrezor } from '../init.js';
+import {
+  getTrezorModule,
+  getTrezorNormalizedDerivationPath,
+} from '../legacy/helpers.js';
+import { setBitcoinDerivationPath } from '../state.js';
+import { BITCOIN_COIN_NAME, resolveBitcoinScriptType } from '../utxo/config.js';
+
+/**
+ * Connect the Bitcoin account for the selected derivation path: derive the receive
+ * address and return it CAIP-encoded with the bip122 Bitcoin chain id. The path is kept
+ * (like the EVM namespace does) because Rango's PSBT has no derivation data, so the
+ * signer needs it at signing time.
+ */
+export function connect(): FunctionWithContext<
+  UtxoActions['connect'],
+  Context
+> {
+  return async (_context, options) => {
+    if (!options?.derivationPath) {
+      throw new Error('Derivation Path can not be empty.');
+    }
+
+    await initTrezor();
+
+    const path = getTrezorNormalizedDerivationPath(options.derivationPath);
+    const inputScriptType = resolveBitcoinScriptType(path);
+    setBitcoinDerivationPath(path);
+
+    const TrezorConnect = await getTrezorModule();
+    const result = await TrezorConnect.getAddress({
+      path,
+      coin: BITCOIN_COIN_NAME,
+      scriptType: inputScriptType,
+      showOnTrezor: false,
+    });
+
+    if (!result.success) {
+      throw new Error(result.payload.error);
+    }
+
+    const { address } = result.payload;
+
+    return utils.formatAccountsToCAIP([address], CAIP_BITCOIN_CHAIN_ID);
+  };
+}
+
+export const utxoActions = { connect };

--- a/wallets/provider-trezor/src/constants.ts
+++ b/wallets/provider-trezor/src/constants.ts
@@ -1,9 +1,10 @@
 import type { ProviderMetadata } from '@hub3js/core';
 
 import { Networks, WalletTypes } from '@rango-dev/wallets-shared';
-import { type BlockchainMeta } from 'rango-types';
+import { type BlockchainMeta, type TransferBlockchainMeta } from 'rango-types';
 
 import getSigners from './signer.js';
+import { BITCOIN_ADDRESS_TYPES } from './utxo/config.js';
 
 export const WALLET_ID = WalletTypes.TREZOR;
 
@@ -26,6 +27,16 @@ export const metadata: ProviderMetadata = {
             getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
               allBlockchains.filter(
                 (chain) => chain.name === Networks.ETHEREUM
+              ),
+          },
+          {
+            label: 'Bitcoin',
+            value: 'UTXO',
+            id: 'BTC',
+            getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
+              allBlockchains.filter(
+                (chain): chain is TransferBlockchainMeta =>
+                  chain.name === Networks.BTC
               ),
           },
         ],
@@ -53,6 +64,17 @@ export const metadata: ProviderMetadata = {
             namespace: 'EVM',
             generateDerivationPath: (index: string) => `44'/60'/0'/${index}`,
           },
+          /*
+           * Bitcoin derivation templates. The BIP-43 purpose (and thus the address
+           * type) is what the user picks here; `index` selects the account.
+           */
+          ...BITCOIN_ADDRESS_TYPES.map((addressType) => ({
+            id: `bitcoin-${addressType.id}`,
+            label: `${addressType.label} (m/${addressType.purpose}'/0'/index')`,
+            namespace: 'UTXO',
+            generateDerivationPath: (index: string) =>
+              `${addressType.purpose}'/0'/${index}'/0/0`,
+          })),
         ],
       },
     },

--- a/wallets/provider-trezor/src/init.ts
+++ b/wallets/provider-trezor/src/init.ts
@@ -1,0 +1,20 @@
+import { getTrezorModule } from './legacy/helpers.js';
+import { getTrezorManifest } from './provider.js';
+
+let isTrezorInitialized = false;
+
+/*
+ * `TrezorConnect.init` throws if called twice, so initialization is shared across every
+ * namespace (EVM, UTXO). `lazyLoad` defers iframe injection until the first method call.
+ */
+export async function initTrezor() {
+  if (isTrezorInitialized) {
+    return;
+  }
+  const TrezorConnect = await getTrezorModule();
+  await TrezorConnect.init({
+    lazyLoad: true,
+    manifest: getTrezorManifest(),
+  });
+  isTrezorInitialized = true;
+}

--- a/wallets/provider-trezor/src/namespaces/evm.ts
+++ b/wallets/provider-trezor/src/namespaces/evm.ts
@@ -7,15 +7,12 @@ import { standardizeAndThrowError } from '@hub3js/std/operators';
 import { ETHEREUM_CHAIN_ID } from '@rango-dev/wallets-shared';
 
 import { WALLET_ID } from '../constants.js';
+import { initTrezor } from '../init.js';
 import {
   getEthereumAccounts,
-  getTrezorModule,
   getTrezorNormalizedDerivationPath,
 } from '../legacy/helpers.js';
-import { getTrezorManifest } from '../provider.js';
 import { setDerivationPath } from '../state.js';
-
-let isTrezorInitialized = false;
 
 const connect = builders
   .connect()
@@ -27,14 +24,7 @@ const connect = builders
       getTrezorNormalizedDerivationPath(options.derivationPath)
     );
 
-    if (!isTrezorInitialized) {
-      const TrezorConnect = await getTrezorModule();
-      await TrezorConnect.init({
-        lazyLoad: true, // this param will prevent iframe injection until TrezorConnect.method will be called
-        manifest: getTrezorManifest(),
-      });
-      isTrezorInitialized = true;
-    }
+    await initTrezor();
 
     const result = await getEthereumAccounts();
 

--- a/wallets/provider-trezor/src/namespaces/utxo.ts
+++ b/wallets/provider-trezor/src/namespaces/utxo.ts
@@ -1,0 +1,24 @@
+import type { UtxoActions } from '@rango-dev/wallets-core/namespaces/utxo';
+
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
+import { builders } from '@rango-dev/wallets-core/namespaces/utxo';
+
+import { utxoActions } from '../actions/utxo.js';
+import { WALLET_ID } from '../constants.js';
+
+const connect = builders
+  .connect()
+  .action(utxoActions.connect())
+  .or(standardizeAndThrowError)
+  .build();
+
+const disconnect = commonBuilders.disconnect<UtxoActions>().build();
+
+const utxo = new NamespaceBuilder<UtxoActions>('UTXO', WALLET_ID)
+  .action(connect)
+  .action(disconnect)
+  .build();
+
+export { utxo };

--- a/wallets/provider-trezor/src/provider.ts
+++ b/wallets/provider-trezor/src/provider.ts
@@ -4,6 +4,7 @@ import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';
+import { utxo } from './namespaces/utxo.js';
 
 let trezorManifest: Environments['manifest'];
 
@@ -24,6 +25,7 @@ const buildProvider = () =>
     })
     .config('metadata', metadata)
     .add('evm', evm)
+    .add('utxo', utxo)
     .build();
 
 export { buildProvider };

--- a/wallets/provider-trezor/src/signer.ts
+++ b/wallets/provider-trezor/src/signer.ts
@@ -8,6 +8,10 @@ export default async function getSigners(): Promise<SignerFactory> {
   const { EthereumSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/ethereum.js')
   );
+  const { BTCSigner } = await dynamicImportWithRefinedError(
+    async () => await import('./signers/utxo.js')
+  );
   signers.registerSigner(TxType.EVM, new EthereumSigner());
+  signers.registerSigner(TxType.TRANSFER, new BTCSigner());
   return signers;
 }

--- a/wallets/provider-trezor/src/signers/utxo.ts
+++ b/wallets/provider-trezor/src/signers/utxo.ts
@@ -1,0 +1,90 @@
+import type { GenericSigner, Transfer } from 'rango-types';
+
+import { Networks } from '@rango-dev/wallets-shared';
+import { SignerError } from 'rango-types';
+
+import { getTrezorModule } from '../legacy/helpers.js';
+import { getBitcoinDerivationPath } from '../state.js';
+import { BITCOIN_COIN_NAME } from '../utxo/config.js';
+import { buildTrezorBitcoinTransaction } from '../utxo/psbt.js';
+
+function getTrezorErrorMessage(payload: { error: string; code?: string }) {
+  return new Error(
+    payload.code ? `${payload.error} (${payload.code})` : payload.error
+  );
+}
+
+export class BTCSigner implements GenericSigner<Transfer> {
+  async signMessage(): Promise<string> {
+    throw SignerError.UnimplementedError('signMessage');
+  }
+
+  async signAndSendTx(tx: Transfer): Promise<{ hash: string }> {
+    const { blockchain } = tx.asset;
+    if (blockchain !== Networks.BTC) {
+      throw new Error(
+        `Signing ${blockchain} transactions is not supported by Trezor.`
+      );
+    }
+
+    const { psbt } = tx;
+    if (!psbt) {
+      throw new Error(
+        'No PSBT found to sign. Ensure a valid PSBT is provided.'
+      );
+    }
+
+    const path = getBitcoinDerivationPath();
+    if (!path) {
+      throw new Error(
+        'No connected Bitcoin account found. Please connect the wallet first.'
+      );
+    }
+
+    const TrezorConnect = await getTrezorModule();
+    const { inputs, outputs, version, locktime } =
+      buildTrezorBitcoinTransaction(psbt.unsignedPsbtBase64, path);
+
+    // `push: true` signs and broadcasts via Trezor's Blockbook backend.
+    const result = await TrezorConnect.signTransaction({
+      coin: BITCOIN_COIN_NAME,
+      inputs,
+      outputs,
+      version,
+      locktime,
+      push: true,
+    });
+
+    if (!result.success) {
+      throw getTrezorErrorMessage(result.payload);
+    }
+
+    return { hash: await this.#resolveHash(result.payload) };
+  }
+
+  /**
+   * `push: true` usually returns the txid directly. If it isn't present (older
+   * firmware/connect), push the serialized transaction explicitly as a fallback.
+   */
+  async #resolveHash(payload: {
+    txid?: string;
+    serializedTx?: string;
+  }): Promise<string> {
+    if (payload.txid) {
+      return payload.txid;
+    }
+    if (!payload.serializedTx) {
+      throw new Error('Trezor did not return a transaction id.');
+    }
+
+    const TrezorConnect = await getTrezorModule();
+    const pushResult = await TrezorConnect.pushTransaction({
+      tx: payload.serializedTx,
+      coin: BITCOIN_COIN_NAME,
+    });
+    if (!pushResult.success) {
+      throw getTrezorErrorMessage(pushResult.payload);
+    }
+    return pushResult.payload.txid;
+  }
+}

--- a/wallets/provider-trezor/src/state.ts
+++ b/wallets/provider-trezor/src/state.ts
@@ -8,3 +8,18 @@ export function setDerivationPath(path: string) {
 export function getDerivationPath() {
   return derivationPath;
 }
+
+/*
+ * Bitcoin's connect-time path, kept for the same reason as the EVM one: Rango's PSBT
+ * carries no derivation data, so the signer must remember which path to sign with. Kept
+ * separate from the EVM path so the two namespaces never collide.
+ */
+let bitcoinDerivationPath = '';
+
+export function setBitcoinDerivationPath(path: string) {
+  bitcoinDerivationPath = path;
+}
+
+export function getBitcoinDerivationPath() {
+  return bitcoinDerivationPath;
+}

--- a/wallets/provider-trezor/src/utxo/config.ts
+++ b/wallets/provider-trezor/src/utxo/config.ts
@@ -1,0 +1,67 @@
+/*
+ * Trezor needs the input `script_type` to sign a Bitcoin input. It is determined by the
+ * BIP-43 `purpose` of the derivation path the address was derived from, so we expose the
+ * four common address types and let the user connect whichever one they hold funds on.
+ */
+export type TrezorInputScriptType =
+  | 'SPENDADDRESS'
+  | 'SPENDP2SHWITNESS'
+  | 'SPENDWITNESS'
+  | 'SPENDTAPROOT';
+
+export interface BitcoinAddressType {
+  /** Stable id used in the derivationPath metadata entries. */
+  id: 'legacy' | 'nested-segwit' | 'native-segwit' | 'taproot';
+  label: string;
+  /** BIP-43 purpose: 44 legacy, 49 nested segwit, 84 native segwit, 86 taproot. */
+  purpose: number;
+  inputScriptType: TrezorInputScriptType;
+}
+
+export const BITCOIN_COIN_NAME = 'btc';
+
+export const BITCOIN_ADDRESS_TYPES: readonly BitcoinAddressType[] = [
+  {
+    id: 'native-segwit',
+    label: 'Native SegWit',
+    purpose: 84,
+    inputScriptType: 'SPENDWITNESS',
+  },
+  {
+    id: 'nested-segwit',
+    label: 'Nested SegWit',
+    purpose: 49,
+    inputScriptType: 'SPENDP2SHWITNESS',
+  },
+  {
+    id: 'legacy',
+    label: 'Legacy',
+    purpose: 44,
+    inputScriptType: 'SPENDADDRESS',
+  },
+  {
+    id: 'taproot',
+    label: 'Taproot',
+    purpose: 86,
+    inputScriptType: 'SPENDTAPROOT',
+  },
+] as const;
+
+/**
+ * Resolve the Trezor input script type for a derivation path by reading its BIP-43
+ * purpose (the first hardened level). The path always comes from one of our own
+ * derivation templates, so an unknown purpose is a programming error.
+ */
+export function resolveBitcoinScriptType(path: string): TrezorInputScriptType {
+  const purpose = Number.parseInt(
+    path.replace(/^m\//, '').split('/')[0]?.replace(/['h]$/, '') ?? '',
+    10
+  );
+  const addressType = BITCOIN_ADDRESS_TYPES.find(
+    (type) => type.purpose === purpose
+  );
+  if (!addressType) {
+    throw new Error(`Unsupported Bitcoin derivation path: ${path}`);
+  }
+  return addressType.inputScriptType;
+}

--- a/wallets/provider-trezor/src/utxo/psbt.test.ts
+++ b/wallets/provider-trezor/src/utxo/psbt.test.ts
@@ -1,0 +1,162 @@
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+import * as ecc from '@bitcoinerlab/secp256k1';
+import * as bitcoin from 'bitcoinjs-lib';
+import { describe, expect, it } from 'vitest';
+
+import { buildTrezorBitcoinTransaction } from './psbt.js';
+
+bitcoin.initEccLib(ecc);
+const NETWORK = bitcoin.networks.bitcoin;
+
+const PRIVATE_KEY = Buffer.alloc(32, 7);
+const PUBKEY = Buffer.from(
+  ecc.pointFromScalar(PRIVATE_KEY, true) as Uint8Array
+);
+const { address: OWN_ADDRESS } = bitcoin.payments.p2wpkh({
+  pubkey: PUBKEY,
+  network: NETWORK,
+});
+
+const NATIVE_SEGWIT_PATH = "m/84'/0'/0'/0/0";
+
+// Non-palindromic on purpose, so the txid byte-reversal is actually exercised.
+const FAKE_PREV_TXID =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+const RECIPIENT = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
+
+function nativeSegwitInput() {
+  const witnessScript = bitcoin.payments.p2wpkh({
+    pubkey: PUBKEY,
+    network: NETWORK,
+  }).output as Buffer;
+  return {
+    hash: FAKE_PREV_TXID,
+    index: 0,
+    witnessUtxo: { script: witnessScript, value: 100_000 },
+  };
+}
+
+describe('buildTrezorBitcoinTransaction', () => {
+  it('maps each input to the connected path and its script type', () => {
+    const psbt = new bitcoin.Psbt({ network: NETWORK });
+    psbt.addInput(nativeSegwitInput());
+    psbt.addOutput({ address: RECIPIENT, value: 90_000 });
+
+    const { inputs } = buildTrezorBitcoinTransaction(
+      psbt.toBase64(),
+      NATIVE_SEGWIT_PATH,
+      NETWORK
+    );
+
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0].address_n).toBe(NATIVE_SEGWIT_PATH);
+    expect(inputs[0].script_type).toBe('SPENDWITNESS');
+    expect(inputs[0].prev_hash).toBe(FAKE_PREV_TXID);
+    expect(inputs[0].prev_index).toBe(0);
+    expect(inputs[0].amount).toBe('100000');
+  });
+
+  it('preserves version, locktime and per-input sequence from the PSBT', () => {
+    const psbt = new bitcoin.Psbt({ network: NETWORK });
+    psbt.setVersion(2);
+    psbt.setLocktime(800_000);
+    // RBF-signaling sequence.
+    psbt.addInput({ ...nativeSegwitInput(), sequence: 0xfffffffd });
+    psbt.addOutput({ address: RECIPIENT, value: 90_000 });
+
+    const { inputs, version, locktime } = buildTrezorBitcoinTransaction(
+      psbt.toBase64(),
+      NATIVE_SEGWIT_PATH,
+      NETWORK
+    );
+
+    expect(version).toBe(2);
+    expect(locktime).toBe(800_000);
+    expect(inputs[0].sequence).toBe(0xfffffffd);
+  });
+
+  it('rejects an input with a non-SIGHASH_ALL sighash type', () => {
+    const psbt = new bitcoin.Psbt({ network: NETWORK });
+    psbt.addInput({
+      ...nativeSegwitInput(),
+      sighashType: bitcoin.Transaction.SIGHASH_SINGLE,
+    });
+    psbt.addOutput({ address: RECIPIENT, value: 90_000 });
+
+    expect(() =>
+      buildTrezorBitcoinTransaction(
+        psbt.toBase64(),
+        NATIVE_SEGWIT_PATH,
+        NETWORK
+      )
+    ).toThrow(/only SIGHASH_ALL is supported/);
+  });
+
+  it('reconstructs outputs as address payments', () => {
+    const psbt = new bitcoin.Psbt({ network: NETWORK });
+    psbt.addInput(nativeSegwitInput());
+    psbt.addOutput({ address: RECIPIENT, value: 60_000 });
+    psbt.addOutput({ address: OWN_ADDRESS as string, value: 39_000 });
+
+    const { outputs } = buildTrezorBitcoinTransaction(
+      psbt.toBase64(),
+      NATIVE_SEGWIT_PATH,
+      NETWORK
+    );
+
+    expect(outputs).toEqual([
+      { script_type: 'PAYTOADDRESS', address: RECIPIENT, amount: '60000' },
+      { script_type: 'PAYTOADDRESS', address: OWN_ADDRESS, amount: '39000' },
+    ]);
+  });
+
+  it('derives the script type from the path purpose (legacy P2PKH)', () => {
+    const p2pkh = bitcoin.payments.p2pkh({ pubkey: PUBKEY, network: NETWORK });
+
+    // A previous transaction that funds the legacy address at vout 0.
+    const prevTx = new bitcoin.Transaction();
+    prevTx.version = 2;
+    prevTx.addInput(Buffer.alloc(32, 1), 0);
+    prevTx.addOutput(p2pkh.output as Buffer, 100_000);
+
+    const psbt = new bitcoin.Psbt({ network: NETWORK });
+    psbt.addInput({
+      hash: prevTx.getId(),
+      index: 0,
+      nonWitnessUtxo: prevTx.toBuffer(),
+    });
+    psbt.addOutput({ address: RECIPIENT, value: 90_000 });
+
+    const { inputs } = buildTrezorBitcoinTransaction(
+      psbt.toBase64(),
+      "m/44'/0'/0'/0/0",
+      NETWORK
+    );
+
+    expect(inputs[0].script_type).toBe('SPENDADDRESS');
+    expect(inputs[0].amount).toBe('100000');
+  });
+
+  it('encodes an OP_RETURN output as PAYTOOPRETURN', () => {
+    const memo = Buffer.from('rango', 'utf8');
+    const psbt = new bitcoin.Psbt({ network: NETWORK });
+    psbt.addInput(nativeSegwitInput());
+    psbt.addOutput({ address: RECIPIENT, value: 90_000 });
+    psbt.addOutput({
+      script: bitcoin.payments.embed({ data: [memo] }).output as Buffer,
+      value: 0,
+    });
+
+    const { outputs } = buildTrezorBitcoinTransaction(
+      psbt.toBase64(),
+      NATIVE_SEGWIT_PATH,
+      NETWORK
+    );
+
+    expect(outputs[1]).toEqual({
+      script_type: 'PAYTOOPRETURN',
+      amount: '0',
+      op_return_data: memo.toString('hex'),
+    });
+  });
+});

--- a/wallets/provider-trezor/src/utxo/psbt.ts
+++ b/wallets/provider-trezor/src/utxo/psbt.ts
@@ -1,0 +1,96 @@
+import type { SignTransaction } from '@trezor/connect-web';
+
+import * as ecc from '@bitcoinerlab/secp256k1';
+import * as bitcoin from 'bitcoinjs-lib';
+
+import { resolveBitcoinScriptType } from './config.js';
+
+// Lets bitcoinjs-lib decode taproot (witness v1) output addresses.
+bitcoin.initEccLib(ecc);
+
+type TrezorInput = SignTransaction['inputs'][number];
+type TrezorOutput = SignTransaction['outputs'][number];
+
+export interface TrezorBitcoinTransaction {
+  inputs: TrezorInput[];
+  outputs: TrezorOutput[];
+  /** Transaction version from the PSBT — preserved so the signed tx matches Rango's. */
+  version: number;
+  /** Transaction locktime from the PSBT (e.g. for CLTV) — preserved as-is. */
+  locktime: number;
+}
+
+const reverseTxid = (hash: Buffer) =>
+  Buffer.from(hash).reverse().toString('hex');
+
+/**
+ * Translate Rango's unsigned PSBT into the transaction Trezor's `signTransaction` expects
+ * (Trezor has no "sign this PSBT" call). Every field that affects the resulting bytes is
+ * preserved: `version`, `locktime`, and per-input `sequence` (RBF / locktime signaling),
+ * alongside each input's amount and script.
+ *
+ * Rango's PSBT carries no derivation data, so the connected `path` (and the script type
+ * from its BIP-43 purpose) is applied to every input — Rango funds the swap from that
+ * single address. `refTxs` are omitted: Trezor Connect fetches previous transactions from
+ * its Blockbook backend. Pure function -> unit testable.
+ *
+ * Only SIGHASH_ALL is supported: a non-default per-input sighash can't be honored through
+ * Trezor's signTransaction, so we reject it rather than sign the wrong thing. Multisig /
+ * script-path spends are out of scope (Rango funds from a single-key address).
+ */
+export function buildTrezorBitcoinTransaction(
+  unsignedPsbtBase64: string,
+  path: string,
+  network: bitcoin.Network = bitcoin.networks.bitcoin
+): TrezorBitcoinTransaction {
+  const psbt = bitcoin.Psbt.fromBase64(unsignedPsbtBase64, { network });
+  const scriptType = resolveBitcoinScriptType(path);
+
+  const inputs = psbt.txInputs.map((input, index): TrezorInput => {
+    const data = psbt.data.inputs[index];
+
+    if (
+      data.sighashType != null &&
+      data.sighashType !== bitcoin.Transaction.SIGHASH_ALL
+    ) {
+      throw new Error(
+        `PSBT input #${index} uses sighash type ${data.sighashType}; only SIGHASH_ALL is supported.`
+      );
+    }
+
+    const utxo =
+      data.witnessUtxo ??
+      bitcoin.Transaction.fromBuffer(data.nonWitnessUtxo as Buffer).outs[
+        input.index
+      ];
+    return {
+      // Trezor Connect accepts the path string directly (like our EVM signer).
+      address_n: path,
+      prev_hash: reverseTxid(input.hash),
+      prev_index: input.index,
+      amount: utxo.value.toString(),
+      script_type: scriptType,
+      sequence: input.sequence,
+    };
+  });
+
+  const outputs = psbt.txOutputs.map(
+    (output): TrezorOutput =>
+      output.address
+        ? {
+            script_type: 'PAYTOADDRESS',
+            address: output.address,
+            amount: output.value.toString(),
+          }
+        : {
+            script_type: 'PAYTOOPRETURN',
+            amount: '0',
+            op_return_data: (
+              bitcoin.script.decompile(output.script)?.find(Buffer.isBuffer) ??
+              Buffer.alloc(0)
+            ).toString('hex'),
+          }
+  );
+
+  return { inputs, outputs, version: psbt.version, locktime: psbt.locktime };
+}

--- a/wallets/react/src/hub/useHubAdapter.ts
+++ b/wallets/react/src/hub/useHubAdapter.ts
@@ -25,6 +25,7 @@ import {
   getSupportedChainsFromProvider,
   isEvmNamespace,
   isSolanaNamespace,
+  isUtxoNamespace,
   mapHubEventsToLegacy,
   transformHubResultToLegacyResult,
   tryConvertNamespaceNetworkToChainInfo,
@@ -250,6 +251,11 @@ export function useHubAdapter(params: UseAdapterParams): ProviderContext {
           } else if (isEvmNamespace(namespace)) {
             connectNamespacePromise = async () =>
               namespace.connect(network, {
+                derivationPath: namespaceInput.derivationPath,
+              });
+          } else if (isUtxoNamespace(namespace)) {
+            connectNamespacePromise = async () =>
+              namespace.connect({
                 derivationPath: namespaceInput.derivationPath,
               });
           } else {

--- a/wallets/react/src/hub/utils.ts
+++ b/wallets/react/src/hub/utils.ts
@@ -401,3 +401,8 @@ export function isEvmNamespace(
 ): ns is ProxiedNamespace<EvmActions> & { namespaceId: 'EVM' } {
   return ns.namespaceId === 'EVM';
 }
+export function isUtxoNamespace(
+  ns: ProxiedNamespace<EvmActions | SolanaActions | SuiActions | UtxoActions>
+): ns is ProxiedNamespace<UtxoActions> & { namespaceId: 'UTXO' } {
+  return ns.namespaceId === 'UTXO';
+}

--- a/wallets/shared/src/rango.ts
+++ b/wallets/shared/src/rango.ts
@@ -115,6 +115,28 @@ export const namespaces: Record<
   UTXO: {
     title: 'UTXO',
     mainBlockchain: 'BTC',
+    derivationPaths: [
+      {
+        id: 'bitcoin-native-segwit',
+        label: `Native SegWit (m/84'/0'/index')`,
+        generateDerivationPath: (index: string) => `84'/0'/${index}'/0/0`,
+      },
+      {
+        id: 'bitcoin-nested-segwit',
+        label: `Nested SegWit (m/49'/0'/index')`,
+        generateDerivationPath: (index: string) => `49'/0'/${index}'/0/0`,
+      },
+      {
+        id: 'bitcoin-legacy',
+        label: `Legacy (m/44'/0'/index')`,
+        generateDerivationPath: (index: string) => `44'/0'/${index}'/0/0`,
+      },
+      {
+        id: 'bitcoin-taproot',
+        label: `Taproot (m/86'/0'/index')`,
+        generateDerivationPath: (index: string) => `86'/0'/${index}'/0/0`,
+      },
+    ],
   },
   Starknet: {
     title: 'Starknet',


### PR DESCRIPTION
## Add Bitcoin (UTXO) support to the Trezor provider — Draft / RFC

Adds a `UTXO` namespace to the hub Trezor provider so users can connect a Bitcoin
account (selectable address type: Native SegWit / Nested SegWit / Legacy / Taproot) and
sign BTC swaps. Verified end-to-end on-device (connect → sign → broadcast).

### Open question I'd like a decision on

Trezor Connect has **no PSBT API** — its [`signTransaction`](https://github.com/trezor/connect/blob/develop/docs/methods/signTransaction.md)
only accepts explicit `inputs`/`outputs`. Every other wallet in the repo receives Rango's
BTC **PSBT** and hands it to the wallet's own `signPsbt`, but Trezor can't do that. So here
I parse Rango's PSBT with `bitcoinjs-lib` and translate it into Trezor's `inputs`/`outputs`
for `signTransaction`.

It works, but I'm not sure it's the best long-term approach. An alternative would be to have
the backend send Trezor a plain transfer (amount + recipient) and use Trezor's
`composeTransaction` instead. **Leaving this as a draft for a decision on which direction we
want.**

### Notes

- Rango's BTC PSBT does **not** include `bip32Derivation`, so the signer remembers the
  connect-time path in `state.ts` — the same pattern the EVM/Solana hardware signers already
  use.
- `refTxs` are omitted; Trezor Connect fetches previous transactions from its Blockbook
  backend.
- The PSBT → `signTransaction` conversion is a pure function with unit tests.

### References that Trezor Connect doesn't take a PSBT

- Official docs — [`signTransaction` requires `coin`/`inputs`/`outputs`, no PSBT param](https://github.com/trezor/connect/blob/develop/docs/methods/signTransaction.md)
- Feature request to sign externally-built / BIP-174 transactions — [trezor/python-trezor#183](https://github.com/trezor/python-trezor/issues/183)
- `@trezor/utxo-lib` ships no PSBT module (removed); `@trezor/connect` exposes no PSBT method.
