### PR TITLE
fix(phantom): temporarily disable bitcoin (utxo) namespace

### DIFF
--- a/wallets/provider-phantom/readme.md
+++ b/wallets/provider-phantom/readme.md
@@ -8,8 +8,8 @@ More about implementation status can be found [here](../readme.md).
 
 ### Group
 
-#### ⚠️ UTXO
-Only supports Bitcoin.
+#### ❌ UTXO
+Bitcoin support is temporarily disabled because Phantom no longer injects a Bitcoin instance, which caused errors for users. It will be re-enabled once Phantom restores Bitcoin injection.
 
 #### ⚠️ EVM
 Only supports Ethereum, Base, and Polygon.

--- a/wallets/provider-phantom/src/constants.ts
+++ b/wallets/provider-phantom/src/constants.ts
@@ -1,7 +1,7 @@
 import type { ProviderMetadata } from '@hub3js/core';
+import type { Networks } from '@rango-dev/wallets-shared';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
-import { Networks } from '@rango-dev/wallets-shared';
 import {
   type BlockchainMeta,
   type EvmBlockchainMeta,
@@ -9,7 +9,6 @@ import {
   solanaBlockchain,
   type SuiBlockchainMeta,
   TransactionType,
-  type TransferBlockchainMeta,
 } from 'rango-types';
 
 import getSigners from './signer.js';
@@ -55,16 +54,6 @@ export const metadata: ProviderMetadata = {
             id: 'SOLANA',
             getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
               solanaBlockchain(allBlockchains),
-          },
-          {
-            label: 'BTC',
-            value: 'UTXO',
-            id: 'BTC',
-            getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
-              allBlockchains.filter(
-                (chain): chain is TransferBlockchainMeta =>
-                  chain.name === Networks.BTC
-              ),
           },
           {
             label: 'Sui',

--- a/wallets/provider-phantom/src/provider.ts
+++ b/wallets/provider-phantom/src/provider.ts
@@ -4,7 +4,6 @@ import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';
 import { solana } from './namespaces/solana.js';
 import { sui } from './namespaces/sui.js';
-import { utxo } from './namespaces/utxo.js';
 import { phantom as phantomInstance } from './utils.js';
 
 const buildProvider = () =>
@@ -20,7 +19,6 @@ const buildProvider = () =>
     .config('metadata', metadata)
     .add('solana', solana)
     .add('evm', evm)
-    .add('utxo', utxo)
     .add('sui', sui)
     .build();
 

--- a/wallets/readme.md
+++ b/wallets/readme.md
@@ -144,7 +144,7 @@ For better user experience, wallet provider tries to connect to a wallet only wh
 | [Ledger](provider-ledger/readme.md)             | ⚠️  | ❌   | ✅     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [MathWallet](provider-math-wallet/readme.md)    | ✅  | 🚧   | ✅     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [MetaMask](provider-metamask/readme.md)         | ✅  | ❌   | ✅     | ❌  | ❌   | ❌  | ❌       | ❌      |
-| [Phantom](provider-phantom/readme.md)           | ⚠️  | ⚠️   | ✅     | ❌  | ❌   | ✅  | ❌       | ❌      |
+| [Phantom](provider-phantom/readme.md)           | ⚠️  | ❌   | ✅     | ❌  | ❌   | ✅  | ❌       | ❌      |
 | [OKX](provider-okx/readme.md)                   | ⚠️  | ⚠️   | ✅     | 🚧  | ❌   | 🚧  | ❌       | ❌      |
 | [Rabby](provider-rabby/readme.md)               | ✅  | ❌   | ❌     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [Ready](provider-ready/readme.md)               | ❌  | ❌   | ❌     | ❌  | ❌   | ❌  | ✅       |


### PR DESCRIPTION
## Summary

Phantom no longer injects a Bitcoin instance into the page. Since our Phantom provider still registered the `utxo` namespace and advertised BTC as a supported chain, users trying to connect/use Bitcoin through Phantom were hitting errors because the Bitcoin instance is unavailable.

This temporarily disables Bitcoin (UTXO) support for Phantom to prevent those errors:

- Remove the `utxo` namespace registration from the Phantom hub3 provider.
- Drop BTC from the provider metadata's supported chains list.
- Update the Phantom and root wallets READMEs to mark UTXO as temporarily disabled.

The underlying `utxo` namespace / signer code is intentionally left in place so support can be re-enabled once Phantom restores Bitcoin injection.

## Notes

Temporary measure — to be reverted once Phantom re-introduces Bitcoin instance injection.