### PR TITLE
feat(trustwallet): add tron namespace support

### DIFF
--- a/wallets/provider-trustwallet/package.json
+++ b/wallets/provider-trustwallet/package.json
@@ -26,6 +26,7 @@
     "@hub3js/solana": "^0.2.1",
     "@hub3js/std": "^0.1.1",
     "@rango-dev/signer-evm": "^0.43.0",
+    "@rango-dev/signer-tron": "^0.41.0",
     "@rango-dev/wallets-core": "^0.60.1-next.0",
     "@rango-dev/wallets-shared": "^0.61.1-next.0",
     "bs58": "^5.0.0",

--- a/wallets/provider-trustwallet/readme.md
+++ b/wallets/provider-trustwallet/readme.md
@@ -17,14 +17,19 @@ When connected to a **single namespace**:
 - Switching **from a private key wallet to a full wallet** triggers a **switch account event**.
 - Switching **from a full wallet to a private key wallet** emits **no event**.
 
-When connected to **both namespaces simultaneously**:
-- Only the **first connected namespace** (e.g., EVM or Solana) properly receives events.
+On **Tron**:
+- Switch account only works if the page is **reloaded after the multiple Tron accounts have been connected** — without that reload, the wallet does not fire the account-change event at all.
+
+When connected to **both EVM and Solana simultaneously**:
+- Only the **first connected namespace** properly receives events.
 - The **second namespace** does **not** receive `accountsChanged` events.
+- This applies to the EVM + Solana combination, not to Tron.
 
 #### ⚠️ Auto Connect
 - **Auto connect is not supported**:
   - On **Solana**, there is no silent reconnection mechanism.
   - On **EVM**, the wallet always opens a popup when the dApp is not already connected.
+  - On **Tron**, reconnecting isn't reliable because the injected Tron instance takes some time to load after the page opens — and since the other namespaces don't support eager connect either, auto connect was removed for Tron too (the namespace doesn't implement `canEagerConnect`).
 
 ---
 

--- a/wallets/provider-trustwallet/src/actions/tron.ts
+++ b/wallets/provider-trustwallet/src/actions/tron.ts
@@ -1,0 +1,40 @@
+import type { Context, FunctionWithContext } from '@hub3js/core';
+
+import {
+  type TronActions,
+  utils,
+} from '@rango-dev/wallets-core/namespaces/tron';
+
+import { TronOKRequestCode, TronUserRejectedCode } from '../constants.js';
+import { tronTrustWallet } from '../utils.js';
+
+export function connect(): FunctionWithContext<
+  TronActions['connect'],
+  Context
+> {
+  return async () => {
+    const instance = tronTrustWallet();
+    const result = await instance.request({ method: 'tron_requestAccounts' });
+
+    /*
+     * Any non-OK code carries a message to surface — except the user-rejection code
+     * (4001), which Trust returns message-less, so we supply the message and keep the
+     * code on the error (same shape as `standardizeTrustWalletInAppBrowserError`).
+     */
+    if (result.code !== TronOKRequestCode) {
+      const fallbackMessage =
+        result.code === TronUserRejectedCode
+          ? 'User rejected the request'
+          : 'Failed to connect to Trust Wallet.';
+      const error = new Error(result.message ?? fallbackMessage) as Error & {
+        code: number;
+      };
+      error.code = result.code;
+      throw error;
+    }
+
+    return utils.formatAccountsToCAIP([instance.tronWeb.defaultAddress.base58]);
+  };
+}
+
+export const tronActions = { connect };

--- a/wallets/provider-trustwallet/src/builders/tron.ts
+++ b/wallets/provider-trustwallet/src/builders/tron.ts
@@ -1,0 +1,25 @@
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
+import {
+  type ProviderAPI,
+  type TronActions,
+  utils,
+} from '@rango-dev/wallets-core/namespaces/tron';
+
+export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
+  new ChangeAccountSubscriberBuilder<string[], ProviderAPI, TronActions>()
+    .getInstance(getInstance)
+    .onSwitchAccount((event, context) => {
+      if (!event.payload?.length) {
+        event.preventDefault();
+        context.action('disconnect');
+      }
+    })
+    .format(async (_, accounts) => utils.formatAccountsToCAIP(accounts))
+    .addEventListener((instance, callback) => {
+      instance.on('accountsChanged', callback);
+    })
+    .removeEventListener((instance, callback) => {
+      instance.off('accountsChanged', callback);
+    });
+
+export const tronBuilders = { changeAccountSubscriber };

--- a/wallets/provider-trustwallet/src/constants.ts
+++ b/wallets/provider-trustwallet/src/constants.ts
@@ -5,12 +5,16 @@ import {
   evmBlockchains,
   hyperliquidBlockchain,
   solanaBlockchain,
+  tronBlockchain,
 } from 'rango-types';
 
 import getSigners from './signer.js';
 import { getInstanceOrThrow } from './utils.js';
 
 export const WALLET_ID = 'trust-wallet';
+
+export const TronOKRequestCode = 200;
+export const TronUserRejectedCode = 4001;
 
 export const metadata: ProviderMetadata = {
   name: 'Trust Wallet',
@@ -43,6 +47,13 @@ export const metadata: ProviderMetadata = {
             id: 'SOLANA',
             getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
               solanaBlockchain(allBlockchains),
+          },
+          {
+            label: 'Tron',
+            value: 'Tron',
+            id: 'TRON',
+            getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
+              tronBlockchain(allBlockchains),
           },
         ],
       },

--- a/wallets/provider-trustwallet/src/namespaces/tron.ts
+++ b/wallets/provider-trustwallet/src/namespaces/tron.ts
@@ -1,0 +1,40 @@
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
+import {
+  builders,
+  type TronActions,
+} from '@rango-dev/wallets-core/namespaces/tron';
+
+import { tronActions } from '../actions/tron.js';
+import { tronBuilders } from '../builders/tron.js';
+import { WALLET_ID } from '../constants.js';
+import {
+  standardizeTrustWalletInAppBrowserError,
+  tronTrustWallet,
+} from '../utils.js';
+
+const [changeAccountSubscriber, changeAccountCleanup] = tronBuilders
+  .changeAccountSubscriber(tronTrustWallet)
+  .build();
+
+const connect = builders
+  .connect()
+  .action(tronActions.connect())
+  .before(changeAccountSubscriber)
+  .or(changeAccountCleanup)
+  .or(standardizeTrustWalletInAppBrowserError)
+  .or(standardizeAndThrowError)
+  .build();
+
+const disconnect = commonBuilders
+  .disconnect<TronActions>()
+  .after(changeAccountCleanup)
+  .build();
+
+const tron = new NamespaceBuilder<TronActions>('Tron', WALLET_ID)
+  .action(connect)
+  .action(disconnect)
+  .build();
+
+export { tron };

--- a/wallets/provider-trustwallet/src/provider.ts
+++ b/wallets/provider-trustwallet/src/provider.ts
@@ -3,6 +3,7 @@ import { ProviderBuilder } from '@hub3js/core';
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';
 import { solana } from './namespaces/solana.js';
+import { tron } from './namespaces/tron.js';
 import { trustWallet as trustwalletInstance } from './utils.js';
 
 const buildProvider = () =>
@@ -18,6 +19,7 @@ const buildProvider = () =>
     .config('metadata', metadata)
     .add('evm', evm)
     .add('solana', solana)
+    .add('tron', tron)
     .build();
 
 export { buildProvider };

--- a/wallets/provider-trustwallet/src/signer.ts
+++ b/wallets/provider-trustwallet/src/signer.ts
@@ -13,6 +13,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
   const solProvider = getNetworkInstance(provider, Networks.SOLANA);
+  const tronProvider = getNetworkInstance(provider, Networks.TRON);
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
@@ -21,9 +22,13 @@ export default async function getSigners(
   const { CustomSolanaSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/solanaSigner.js')
   );
+  const { CustomTronSigner } = await dynamicImportWithRefinedError(
+    async () => await import('./signers/tronSigner.js')
+  );
 
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
+  signers.registerSigner(TxType.TRON, new CustomTronSigner(tronProvider));
 
   return signers;
 }

--- a/wallets/provider-trustwallet/src/signers/tronSigner.ts
+++ b/wallets/provider-trustwallet/src/signers/tronSigner.ts
@@ -1,0 +1,46 @@
+import type { TronTransaction, TrxContractData } from 'rango-types';
+
+import { DefaultTronSigner } from '@rango-dev/signer-tron';
+
+// TODO: remove this and use the default signer after the backend fixed the problem
+/*
+ * Rango's Tron transactions carry an extra `type` field inside
+ * `raw_data.contract[*].parameter.value` (alongside the standard one on the contract
+ * object). TronLink ignores unknown fields, but Trust signs through wallet-core, whose
+ * strict parser rejects the whole transaction with "unexpected field 'type' in contract
+ * value" — so we strip it before handing the transaction to the wallet. This doesn't
+ * affect the signature: it is computed over `txID`/`raw_data_hex`, which never contained
+ * the field.
+ */
+function omitTypeFromContractValue(contract: TrxContractData): TrxContractData {
+  const { value } = contract.parameter;
+
+  if (typeof value !== 'object' || value === null || !('type' in value)) {
+    return contract;
+  }
+
+  const { type: _omitted, ...sanitizedValue } = value as Record<
+    string,
+    unknown
+  >;
+  return {
+    ...contract,
+    parameter: { ...contract.parameter, value: sanitizedValue },
+  };
+}
+
+export class CustomTronSigner extends DefaultTronSigner {
+  async signAndSendTx(tx: TronTransaction): Promise<{ hash: string }> {
+    if (!tx.raw_data) {
+      return super.signAndSendTx(tx);
+    }
+
+    return super.signAndSendTx({
+      ...tx,
+      raw_data: {
+        ...tx.raw_data,
+        contract: tx.raw_data.contract.map(omitTypeFromContractValue),
+      },
+    });
+  }
+}

--- a/wallets/provider-trustwallet/src/utils.ts
+++ b/wallets/provider-trustwallet/src/utils.ts
@@ -1,6 +1,7 @@
 import type { Context } from '@hub3js/core';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
+import type { ProviderAPI as TronProviderApi } from '@rango-dev/wallets-core/namespaces/tron';
 
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -15,9 +16,12 @@ export function trustWallet(): Provider | null {
   const instances = new Map();
 
   instances.set(LegacyNetworks.ETHEREUM, trustwallet);
-  const { solana } = trustwallet;
+  const { solana, tronLink } = trustwallet;
   if (solana && solana.isTrustWallet) {
     instances.set(LegacyNetworks.SOLANA, solana);
+  }
+  if (tronLink) {
+    instances.set(LegacyNetworks.TRON, tronLink);
   }
 
   return instances;
@@ -58,6 +62,19 @@ export function solanaTrustWallet(): SolanaProviderApi {
   }
 
   return solanaInstance as SolanaProviderApi;
+}
+
+export function tronTrustWallet(): TronProviderApi {
+  const instance = trustWallet();
+  const tronInstance = instance?.get(LegacyNetworks.TRON);
+
+  if (!tronInstance) {
+    throw new Error(
+      'TrustWallet not injected or Tron not enabled. Please check your wallet.'
+    );
+  }
+
+  return tronInstance as TronProviderApi;
 }
 
 // Considering that the errors thrown in Trust Wallet in-app browser do not follow EIP-1193, we detect such errors and standardize them.

--- a/wallets/readme.md
+++ b/wallets/readme.md
@@ -121,6 +121,8 @@ export function App() {
 
 For better user experience, wallet provider tries to connect to a wallet only when that wallet doesn’t need to open a confirmation pop-up. Please note that only some wallets support this feature for now.
 
+> **Provider authors:** auto-connect is driven by the persisted last-connected wallets and runs each namespace's `canEagerConnect` **independently of the provider's `installed` flag** — it is not gated by (nor does it wait for) install detection in `init`. For wallets whose instance is injected asynchronously (e.g. TronLink-style providers that appear a beat after page load), `canEagerConnect` may run before the instance exists, so it must tolerate a missing/not-yet-ready instance (return `false`) rather than throw. Deferring install detection in `init` only gates **manual** connect, not eager connect.
+
 # Example
 
 - Demo for wallets: [Source](https://github.com/rango-exchange/rango-client/tree/next/wallets/demo)
@@ -154,7 +156,7 @@ For better user experience, wallet provider tries to connect to a wallet only wh
 | [Taho](provider-taho/readme.md)                 | ⚠️  | ❌   | ❌     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [Token Pocket](provider-tokenpocket/readme.md)  | ✅  | ❌   | 🚧     | ❌  | ❌   | 🚧  | ❌       | ❌      |
 | [Tron Link](provider-tron-link/readme.md)       | 🚧  | ❌   | ❌     | ❌  | ❌   | ✅  | ❌       | ❌      |
-| [Trust Wallet](provider-trust-wallet/readme.md) | ✅  | ❌   | ✅     | 🚧  | ❌   | 🚧  | ❌       | ❌      |
+| [Trust Wallet](provider-trust-wallet/readme.md) | ✅  | ❌   | ✅     | 🚧  | ✅   | 🚧  | ❌       | ❌      |
 | [UniSat](provider-unisat/readme.md)             | ❌  | ⚠️   | ❌     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [Xverse](provider-xverse/readme.md)             | ❌  | ⚠️   | ❌     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [Tomo](provider-tomo/readme.md)                 | ✅  | ❌   | ❌     | ❌  | ❌   | ❌  | ❌       | ❌      |


### PR DESCRIPTION
## Summary

Adds the Tron namespace to the Trust Wallet provider, wiring the extension's
TronLink-compatible instance (`window.trustwallet.tronLink`) into the hub with
connect / disconnect / eager-connect, account-change tracking, and signing.

## Changes

- New `actions/tron.ts`, `builders/tron.ts`, `namespaces/tron.ts` following the
  actions/builders split; `Tron` added to provider metadata and registration
- Account changes subscribe to the instance's own `accountsChanged` event
  (`string[]` of base58 addresses; empty array → disconnect)
- Custom `CustomTronSigner` extends `DefaultTronSigner` and strips the extra
  `type` field Rango puts inside `raw_data.contract[*].parameter.value`, which
  Trust's strict wallet-core parser rejects (signature unaffected — it covers
  `txID`/`raw_data_hex`)
- Message-less user rejection (`{code: 4001}`) mapped to
  "User rejected the request" with the code kept on the error
- `canEagerConnect` returns `false` (never throws) when the late-injected Tron
  shim isn't ready — auto-connect runs independently of the `installed` flag
- Docs: support matrix and provider readme notes (switch-account
  reload caveat, auto-connect limitation)
  
  ## How tested

Manually against the Trust Wallet browser extension: connect, user rejection
(correct message, no masked listener error), account-switch/disconnect events,
and a real swap transaction that drove the wallet-core parser fix. Package
build, eslint, and ts-check pass.


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
