### PR TITLE
feat(provider-okx): add Tron namespace support

### DIFF
--- a/wallets/provider-okx/package.json
+++ b/wallets/provider-okx/package.json
@@ -30,6 +30,7 @@
     "@rango-dev/signer-solana": "^0.48.1-next.0",
     "@rango-dev/wallets-core": "^0.60.1-next.3",
     "@rango-dev/wallets-shared": "^0.61.1-next.4",
+    "@rango-dev/signer-tron": "^0.41.1-next.0",
     "@ton/core": "^0.59.0",
     "rango-types": "^0.5.0"
   },

--- a/wallets/provider-okx/readme.md
+++ b/wallets/provider-okx/readme.md
@@ -47,6 +47,16 @@ The wallet supports Sui, but it is **not implemented** in the current integratio
 
 ### Feature
 
+#### ⚠️ Connect and AutoConnect
+
+For Tron, connecting on page load — or disconnecting and reconnecting within the app —
+returns the **first account you connected**, not the account you last switched to. The OKX
+extension resets the Tron address in these cases and gives no way to recover the active
+one; it corrects itself only once you switch accounts in the wallet.
+
+If you sign a transaction while that wrong account is selected, the OKX wallet rejects it
+with a **"Transaction Unavailable"** error.
+
 #### ⚠️ Disconnect
 
 The disconnect function will not work for this wallet, as it attempts to invoke disconnect on the connect method for private key imported wallets.

--- a/wallets/provider-okx/src/actions/tron.ts
+++ b/wallets/provider-okx/src/actions/tron.ts
@@ -1,0 +1,37 @@
+import { utils } from '@rango-dev/wallets-core/namespaces/tron';
+
+import {
+  TRON_OK_REQUEST_CODE,
+  TRON_USER_REJECTION_CODE,
+} from '../constants.js';
+import { tronOKX } from '../utils.js';
+
+const connect = async () => {
+  const instance = tronOKX();
+  const accountsResult = await instance.request({
+    method: 'tron_requestAccounts',
+  });
+
+  if (accountsResult?.code && accountsResult.code !== TRON_OK_REQUEST_CODE) {
+    if (accountsResult.code === TRON_USER_REJECTION_CODE) {
+      throw new Error('User rejected the request.');
+    }
+    throw new Error(
+      accountsResult.message ?? 'Failed to connect to OKX Wallet Tron.'
+    );
+  }
+  return utils.formatAccountsToCAIP([instance.tronWeb.defaultAddress.base58]);
+};
+
+/*
+ * Wrapped in a try-catch in the case of wallet injection delay
+ */
+const canEagerConnect = async () => {
+  try {
+    const tronInstance = tronOKX();
+    return !!tronInstance.ready;
+  } catch {
+    return false;
+  }
+};
+export const tronActions = { connect, canEagerConnect };

--- a/wallets/provider-okx/src/builders/tron.ts
+++ b/wallets/provider-okx/src/builders/tron.ts
@@ -1,0 +1,63 @@
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
+import {
+  type ProviderAPI,
+  type TronActions,
+  utils,
+} from '@rango-dev/wallets-core/namespaces/tron';
+
+import { isOkxTronMessageEvent } from '../utils.js';
+
+export const changeAccountSubscriber = (getInstance: () => ProviderAPI) =>
+  new ChangeAccountSubscriberBuilder<
+    MessageEvent<unknown>,
+    ProviderAPI,
+    TronActions
+  >()
+    .getInstance(getInstance)
+    .onSwitchAccount((event, context) => {
+      const data = event.payload?.data;
+
+      if (!isOkxTronMessageEvent(data)) {
+        event.preventDefault();
+        return;
+      }
+
+      const { action } = data.message;
+
+      if (action === 'disconnect') {
+        event.preventDefault();
+        context.action('disconnect');
+        return;
+      }
+
+      /*
+       * Change account only on `accountsChanged` with a string address (`format`
+       * reads it). Everything else — including `accountsChanged` with address
+       * `false` (its disconnect is handled above) — is ignored.
+       */
+      if (
+        action !== 'accountsChanged' ||
+        typeof data.message.data?.address !== 'string'
+      ) {
+        event.preventDefault();
+      }
+    })
+    .format(async (_, event) => {
+      const data = event.data;
+      const address =
+        isOkxTronMessageEvent(data) && data.message.action === 'accountsChanged'
+          ? data.message.data?.address
+          : undefined;
+      if (typeof address !== 'string') {
+        throw new Error('No Tron address received from OKX Wallet.');
+      }
+      return utils.formatAccountsToCAIP([address]);
+    })
+    .addEventListener((_, callback) => {
+      window.addEventListener('message', callback);
+    })
+    .removeEventListener((_, callback) => {
+      window.removeEventListener('message', callback);
+    });
+
+export const tronBuilders = { changeAccountSubscriber };

--- a/wallets/provider-okx/src/constants.ts
+++ b/wallets/provider-okx/src/constants.ts
@@ -7,6 +7,7 @@ import {
   solanaBlockchain,
   tonBlockchain,
   type TransferBlockchainMeta,
+  tronBlockchain,
 } from 'rango-types';
 
 import getSigners from './signer.js';
@@ -15,6 +16,9 @@ import { getInstanceOrThrow } from './utils.js';
 export const WALLET_ID = 'okx';
 export const TON_CONNECT_PROTOCOL_VERSION = 2;
 export const TON_CONNECT_USER_REJECTED_CODE = 300;
+export const TRON_OK_REQUEST_CODE = 200;
+// EIP-1193 user-rejected-request code returned by `tron_requestAccounts`.
+export const TRON_USER_REJECTION_CODE = 4001;
 
 export const OKX_WALLET_SUPPORTED_CHAINS = [
   LegacyNetworks.ETHEREUM,
@@ -83,6 +87,13 @@ export const metadata: ProviderMetadata = {
             id: 'TON',
             getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
               tonBlockchain(allBlockchains),
+          },
+          {
+            label: 'Tron',
+            value: 'Tron',
+            id: 'TRON',
+            getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
+              tronBlockchain(allBlockchains),
           },
         ],
       },

--- a/wallets/provider-okx/src/namespaces/tron.ts
+++ b/wallets/provider-okx/src/namespaces/tron.ts
@@ -1,0 +1,40 @@
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
+import { type TronActions } from '@rango-dev/wallets-core/namespaces/tron';
+import { builders } from '@rango-dev/wallets-core/namespaces/tron';
+
+import { tronActions } from '../actions/tron.js';
+import { tronBuilders } from '../builders/tron.js';
+import { WALLET_ID } from '../constants.js';
+import { tronOKX } from '../utils.js';
+
+const [changeAccountSubscriber, changeAccountCleanup] = tronBuilders
+  .changeAccountSubscriber(tronOKX)
+  .build();
+
+const connect = builders
+  .connect()
+  .action(tronActions.connect)
+  .before(changeAccountSubscriber)
+  .or(changeAccountCleanup)
+  .or(standardizeAndThrowError)
+  .build();
+
+const canEagerConnect = builders
+  .canEagerConnect()
+  .action(tronActions.canEagerConnect)
+  .build();
+
+const disconnect = commonBuilders
+  .disconnect<TronActions>()
+  .after(changeAccountCleanup)
+  .build();
+
+const tron = new NamespaceBuilder<TronActions>('Tron', WALLET_ID)
+  .action(connect)
+  .action(disconnect)
+  .action(canEagerConnect)
+  .build();
+
+export { tron };

--- a/wallets/provider-okx/src/provider.ts
+++ b/wallets/provider-okx/src/provider.ts
@@ -7,6 +7,7 @@ import { evm } from './namespaces/evm.js';
 import { solana } from './namespaces/solana.js';
 import { ton } from './namespaces/ton/ton.js';
 import { setEnvironments } from './namespaces/ton/utils.js';
+import { tron } from './namespaces/tron.js';
 import { utxo } from './namespaces/utxo.js';
 import { okx as okxInstance } from './utils.js';
 
@@ -26,6 +27,7 @@ const buildProvider = () =>
     .add('evm', evm)
     .add('utxo', utxo)
     .add('ton', ton)
+    .add('tron', tron)
 
     .build();
 

--- a/wallets/provider-okx/src/signer.ts
+++ b/wallets/provider-okx/src/signer.ts
@@ -6,6 +6,7 @@ import {
   SOLANA_NAMESPACE,
   UTXO_NAMESPACE,
   TON_NAMESPACE,
+  TRON_NAMESPACE,
 } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
@@ -24,15 +25,20 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
   const utxoProvider = getNetworkInstance(provider, UTXO_NAMESPACE);
   const tonProvider = getNetworkInstance(provider, TON_NAMESPACE);
+  const tronProvider = getNetworkInstance(provider, TRON_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')
   );
+  const { DefaultTronSigner } = await dynamicImportWithRefinedError(
+    async () => await import('@rango-dev/signer-tron')
+  );
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new OKXSolanaSigner(solProvider));
   signers.registerSigner(TxType.TRANSFER, new OKXUTXOSigner(utxoProvider));
   signers.registerSigner(TxType.TON, new OKXTonSigner(tonProvider));
+  signers.registerSigner(TxType.TRON, new DefaultTronSigner(tronProvider));
 
   return signers;
 }

--- a/wallets/provider-okx/src/types.ts
+++ b/wallets/provider-okx/src/types.ts
@@ -5,8 +5,10 @@ import type {
   SOLANA_NAMESPACE,
   UTXO_NAMESPACE,
   TON_NAMESPACE,
+  TRON_NAMESPACE,
 } from '@hub3js/namespaces';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
+import type { ProviderAPI as TronProviderApi } from '@rango-dev/wallets-core/namespaces/tron';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 
 export type OkxBtcAddress = {
@@ -20,8 +22,22 @@ export type ProviderObject = {
   [SOLANA_NAMESPACE]: SolanaProviderApi;
   [UTXO_NAMESPACE]: UtxoProviderApi;
   [TON_NAMESPACE]: TonProviderApi;
+  [TRON_NAMESPACE]: TronProviderApi;
 };
 export type Provider = Map<
   keyof ProviderObject,
   ProviderObject[keyof ProviderObject]
 >;
+
+/*
+ * On `accountsChanged`, `data.address` is the new base58 address, or `false`
+ * when disconnected; on `disconnect`, `data` is absent.
+ */
+export type OkxTronMessageEvent = {
+  message: {
+    action: string;
+    data?: {
+      address: string | false;
+    };
+  };
+};

--- a/wallets/provider-okx/src/utils.ts
+++ b/wallets/provider-okx/src/utils.ts
@@ -1,7 +1,8 @@
 import type { TonProviderApi } from './namespaces/ton/types.js';
-import type { OkxBtcAddress, Provider } from './types.js';
+import type { OkxBtcAddress, OkxTronMessageEvent, Provider } from './types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
+import type { ProviderAPI as TronProviderApi } from '@rango-dev/wallets-core/namespaces/tron';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 
 import {
@@ -9,6 +10,7 @@ import {
   SOLANA_NAMESPACE,
   UTXO_NAMESPACE,
   TON_NAMESPACE,
+  TRON_NAMESPACE,
 } from '@hub3js/namespaces';
 
 export function okx(): Provider | null {
@@ -28,6 +30,9 @@ export function okx(): Provider | null {
   }
   if (okxTonWallet?.tonconnect) {
     instances.set(TON_NAMESPACE, okxTonWallet.tonconnect);
+  }
+  if (okxwallet.tronLink) {
+    instances.set(TRON_NAMESPACE, okxwallet.tronLink);
   }
   return instances;
 }
@@ -94,6 +99,18 @@ export function tonOKX(): TonProviderApi {
   return tonInstance as TonProviderApi;
 }
 
+export function tronOKX(): TronProviderApi {
+  const instance = okx();
+  const tronInstance = instance?.get(TRON_NAMESPACE);
+
+  if (!tronInstance) {
+    throw new Error(
+      'OKX Wallet not injected or Tron not enabled. Please check your wallet.'
+    );
+  }
+
+  return tronInstance;
+}
 export async function getBitcoinAccounts(): Promise<OkxBtcAddress> {
   const instance = bitcoinOKX();
   const requestResult = await instance.connect();
@@ -103,4 +120,18 @@ export async function getBitcoinAccounts(): Promise<OkxBtcAddress> {
   }
 
   return requestResult;
+}
+
+export function isOkxTronMessageEvent(
+  value: unknown
+): value is OkxTronMessageEvent {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const event = value as { message?: { action?: unknown } };
+  return (
+    typeof event.message === 'object' &&
+    event.message !== null &&
+    typeof event.message.action === 'string'
+  );
 }

--- a/wallets/readme.md
+++ b/wallets/readme.md
@@ -145,7 +145,7 @@ For better user experience, wallet provider tries to connect to a wallet only wh
 | [MathWallet](provider-math-wallet/readme.md)    | ✅  | 🚧   | ✅     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [MetaMask](provider-metamask/readme.md)         | ✅  | ❌   | ✅     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [Phantom](provider-phantom/readme.md)           | ⚠️  | ❌   | ✅     | ❌  | ❌   | ✅  | ❌       | ❌      |
-| [OKX](provider-okx/readme.md)                   | ⚠️  | ⚠️   | ✅     | ✅  | ❌   | 🚧  | ❌       | ❌      |
+| [OKX](provider-okx/readme.md)                   | ⚠️  | ⚠️   | ✅     | ✅  | ✅   | 🚧  | ❌       | ❌      |
 | [Rabby](provider-rabby/readme.md)               | ✅  | ❌   | ❌     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [Ready](provider-ready/readme.md)               | ❌  | ❌   | ❌     | ❌  | ❌   | ❌  | ✅       |
 | [Slush](provider-slush/readme.md)               | ❌  | ❌   | ❌     | ❌  | ❌   | ✅  | ❌       | ❌      |
@@ -182,7 +182,7 @@ For better user experience, wallet provider tries to connect to a wallet only wh
 | Ledger       | ✅             | ❌             | ❌           | Transport                 | ✅            |
 | MathWallet   | ❌             | ❌             | ⚠️           | Injected                  | ❌            |
 | MetaMask     | ✅             | ✅             | ✅           | Injected                  | ✅            |
-| OKX          | ⚠️             | ✅             | ✅           | Injected                  | ✅            |
+| OKX          | ⚠️             | ✅             | ⚠️           | Injected                  | ✅            |
 | Phantom      | ✅             | ✅             | ⚠️           | Wallet Standard, Injected | ✅            |
 | Rabby        | ✅             | ✅             | ✅           | Injected                  | ✅            |
 | Ready        | ✅             | ❌             | ✅           | Injected                  | ✅            |


### PR DESCRIPTION
## Summary

Adds **Tron** namespace support to the OKX wallet provider (hub / v1 provider). The
legacy v0 provider is untouched.

## Changes

- Wire OKX's injected `window.okxwallet.tronLink` into the hub across
  `actions/`, `builders/`, `namespaces/` Tron files (`types.ts` / `utils.ts` /
  `provider.ts` glue).
- **Connect** via `tron_requestAccounts`, reading the address from
  `tronWeb.defaultAddress.base58`. User rejection (EIP-1193 `4001`) surfaces a clear
  `User rejected the request.` error; other non-OK codes surface the wallet's message.
- **Account switch** handled via OKX's `walletChanged` provider-stream event — the Tron
  entry is matched by `chainId === '195'`; empty `params` triggers a disconnect.
- **Signing** registered through the shared `@rango-dev/signer-tron`
  (`tronWeb.trx.sign` / `sendRawTransaction`); **eager-connect** via the `ready` flag.
- Metadata namespace entry + `@rango-dev/signer-tron` dependency; matrix set to ✅.

## Known limitation

On page load / in-app disconnect+reconnect, OKX returns the **first-connected** Tron
account, not the last switched-to one — the extension resets the address and emits no
load-time event, so there's no client-side fix (the official
`@tronweb3/tronwallet-adapter-okxwallet` has the same limitation). Signing with that
stale account triggers OKX's `Transaction Unavailable` error. Documented in the provider
readme.

## Testing

- `yarn build` all pass.
- Manually tested on the shipped extension: connecting, disconnecting, switching
  accounts, and other actions all work as expected.
- Real Tron transaction signed end-to-end.


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
