### PR TITLE
feat(provider-okx): add ton namespace support

### DIFF
--- a/global-wallets-env.d.ts
+++ b/global-wallets-env.d.ts
@@ -21,6 +21,7 @@ declare global {
     safepalProvider?: any;
     trustwallet?: any;
     okxwallet?: any;
+    okxTonWallet?: any;
     starknet_argentX?: any;
     starknet_braavos?: any;
     tronLink?: any;

--- a/wallets/provider-okx/package.json
+++ b/wallets/provider-okx/package.json
@@ -30,6 +30,7 @@
     "@rango-dev/signer-solana": "^0.48.1-next.0",
     "@rango-dev/wallets-core": "^0.60.1-next.3",
     "@rango-dev/wallets-shared": "^0.61.1-next.4",
+    "@ton/core": "^0.59.0",
     "rango-types": "^0.5.0"
   },
   "publishConfig": {

--- a/wallets/provider-okx/readme.md
+++ b/wallets/provider-okx/readme.md
@@ -39,10 +39,6 @@ Supported networks :
 The wallet only supports bitcoin.
 
 
-#### 🚧 TON
-
-The wallet supports TON, but it is **not implemented** in the current integration.
-
 #### 🚧 Sui
 
 The wallet supports Sui, but it is **not implemented** in the current integration.

--- a/wallets/provider-okx/src/actions/ton.ts
+++ b/wallets/provider-okx/src/actions/ton.ts
@@ -1,0 +1,99 @@
+import type {
+  TonConnectEvent,
+  TonProviderApi,
+} from '../namespaces/ton/types.js';
+import type { Context, FunctionWithContext } from '@hub3js/core';
+
+import { type TonActions } from '@rango-dev/wallets-core/namespaces/ton';
+
+import {
+  TON_CONNECT_PROTOCOL_VERSION,
+  TON_CONNECT_USER_REJECTED_CODE,
+} from '../constants.js';
+import {
+  connectEventToCAIP,
+  getTonConnectManifestUrl,
+  isTonConnectEventSuccess,
+  nextTonRequestId,
+} from '../namespaces/ton/utils.js';
+
+export function connect(
+  getInstance: () => TonProviderApi
+): FunctionWithContext<TonActions['connect'], Context> {
+  return async () => {
+    const instance = getInstance();
+
+    /*
+     * If the dApp was approved before, `restoreConnection` resolves the current
+     * session without prompting the user; otherwise fall back to a fresh
+     * connect request.
+     */
+    let connectEvent: TonConnectEvent | undefined;
+    try {
+      connectEvent = await instance.restoreConnection();
+    } catch {
+      // No restorable session; a fresh connect request is made below.
+    }
+
+    if (!connectEvent || !isTonConnectEventSuccess(connectEvent)) {
+      connectEvent = await instance.connect(TON_CONNECT_PROTOCOL_VERSION, {
+        manifestUrl: getTonConnectManifestUrl(),
+        items: [{ name: 'ton_addr' }],
+      });
+    }
+
+    if (!isTonConnectEventSuccess(connectEvent)) {
+      // The bridge reports a user-cancelled prompt as a `connect_error` event.
+      if (connectEvent.payload.code === TON_CONNECT_USER_REJECTED_CODE) {
+        throw new Error('User rejected the request.');
+      }
+      throw new Error(
+        `Couldn't connect to OKX TON. code: ${connectEvent.payload.code}, message: ${connectEvent.payload.message}`
+      );
+    }
+
+    const accounts = await connectEventToCAIP(connectEvent);
+    if (!accounts.length) {
+      throw new Error("Couldn't find any TON address!");
+    }
+
+    return accounts;
+  };
+}
+
+export function canEagerConnect(
+  getInstance: () => TonProviderApi
+): FunctionWithContext<TonActions['canEagerConnect'], Context> {
+  return async () => {
+    /*
+     * Auto connect may run this before the wallet is injected; it should never
+     * throw.
+     */
+    try {
+      const connectEvent = await getInstance().restoreConnection();
+      return isTonConnectEventSuccess(connectEvent);
+    } catch {
+      return false;
+    }
+  };
+}
+
+export function disconnect(getInstance: () => TonProviderApi) {
+  return async () => {
+    /*
+     * Revoking the session on the wallet side is best effort; local state
+     * cleanup should proceed even if it fails.
+     */
+    try {
+      await getInstance().send({
+        method: 'disconnect',
+        params: [],
+        id: nextTonRequestId(),
+      });
+    } catch {
+      // ignore
+    }
+  };
+}
+
+export const tonActions = { connect, canEagerConnect, disconnect };

--- a/wallets/provider-okx/src/builders/ton.ts
+++ b/wallets/provider-okx/src/builders/ton.ts
@@ -1,0 +1,48 @@
+import type { TonProviderApi } from '../namespaces/ton/types.js';
+
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
+import { type TonActions, utils } from '@rango-dev/wallets-core/namespaces/ton';
+
+import { connectEventToCAIP } from '../namespaces/ton/utils.js';
+
+/*
+ * OKX emits its non-standard `accountChanged` event without a documented
+ * payload, so the switched address can't be read from the event. Because the
+ * bridge is standard TON Connect, `format` re-reads the active account from the
+ * instance via `restoreConnection` instead
+ */
+export const changeAccountSubscriber = (getInstance: () => TonProviderApi) =>
+  new ChangeAccountSubscriberBuilder<unknown, TonProviderApi, TonActions>()
+    .getInstance(getInstance)
+    .format(async (instance) => {
+      try {
+        const connectEvent = await instance.restoreConnection();
+        return await connectEventToCAIP(connectEvent);
+      } catch {
+        // No active session after the switch — treat as disconnected.
+        return utils.formatAccountsToCAIP([]);
+      }
+    })
+    .addEventListener((instance, callback) => {
+      instance.on('accountChanged', callback);
+    })
+    .removeEventListener((instance, callback) => {
+      instance.off('accountChanged', callback);
+    });
+
+export const disconnectSubscriber = (getInstance: () => TonProviderApi) =>
+  new ChangeAccountSubscriberBuilder<unknown, TonProviderApi, TonActions>()
+    .getInstance(getInstance)
+    .onSwitchAccount((event, context) => {
+      event.preventDefault();
+      void context.action('disconnect');
+    })
+    .format(async () => [])
+    .addEventListener((instance, callback) => {
+      instance.on('disconnect', callback);
+    })
+    .removeEventListener((instance, callback) => {
+      instance.off('disconnect', callback);
+    });
+
+export const tonBuilders = { changeAccountSubscriber, disconnectSubscriber };

--- a/wallets/provider-okx/src/constants.ts
+++ b/wallets/provider-okx/src/constants.ts
@@ -5,6 +5,7 @@ import { Networks } from '@rango-dev/wallets-shared';
 import {
   type BlockchainMeta,
   solanaBlockchain,
+  tonBlockchain,
   type TransferBlockchainMeta,
 } from 'rango-types';
 
@@ -12,6 +13,9 @@ import getSigners from './signer.js';
 import { getInstanceOrThrow } from './utils.js';
 
 export const WALLET_ID = 'okx';
+export const TON_CONNECT_PROTOCOL_VERSION = 2;
+export const TON_CONNECT_USER_REJECTED_CODE = 300;
+
 export const OKX_WALLET_SUPPORTED_CHAINS = [
   LegacyNetworks.ETHEREUM,
   LegacyNetworks.BSC,
@@ -72,6 +76,13 @@ export const metadata: ProviderMetadata = {
                 (chain): chain is TransferBlockchainMeta =>
                   chain.name === Networks.BTC
               ),
+          },
+          {
+            label: 'Ton',
+            value: 'Ton',
+            id: 'TON',
+            getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
+              tonBlockchain(allBlockchains),
           },
         ],
       },

--- a/wallets/provider-okx/src/namespaces/ton/ton.ts
+++ b/wallets/provider-okx/src/namespaces/ton/ton.ts
@@ -1,0 +1,50 @@
+import { NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
+import {
+  builders,
+  type TonActions,
+} from '@rango-dev/wallets-core/namespaces/ton';
+
+import { tonActions } from '../../actions/ton.js';
+import { tonBuilders } from '../../builders/ton.js';
+import { WALLET_ID } from '../../constants.js';
+import { tonOKX } from '../../utils.js';
+
+const [changeAccountSubscriber, changeAccountCleanup] = tonBuilders
+  .changeAccountSubscriber(tonOKX)
+  .build();
+
+const [walletDisconnectSubscriber, walletDisconnectCleanup] = tonBuilders
+  .disconnectSubscriber(tonOKX)
+  .build();
+
+const connect = builders
+  .connect()
+  .action(tonActions.connect(tonOKX))
+  .before(changeAccountSubscriber)
+  .before(walletDisconnectSubscriber)
+  .or(walletDisconnectCleanup)
+  .or(changeAccountCleanup)
+  .or(standardizeAndThrowError)
+  .build();
+
+const disconnect = commonBuilders
+  .disconnect<TonActions>()
+  .before(tonActions.disconnect(tonOKX))
+  .after(changeAccountCleanup)
+  .after(walletDisconnectCleanup)
+  .build();
+
+const canEagerConnect = builders
+  .canEagerConnect()
+  .action(tonActions.canEagerConnect(tonOKX))
+  .build();
+
+const ton = new NamespaceBuilder<TonActions>('Ton', WALLET_ID)
+  .action(connect)
+  .action(disconnect)
+  .action(canEagerConnect)
+  .build();
+
+export { ton };

--- a/wallets/provider-okx/src/namespaces/ton/types.ts
+++ b/wallets/provider-okx/src/namespaces/ton/types.ts
@@ -1,0 +1,89 @@
+export type Environments = {
+  tonConnectManifestUrl?: string;
+};
+
+/*
+ * OKX injects a standard TonConnect JS bridge at `window.okxTonWallet.tonconnect`.
+ * The types below describe the subset of the TonConnect protocol we rely on,
+ * plus OKX's non-standard `on`/`off` event API.
+ */
+export type TonAddressItemReply = {
+  name: 'ton_addr';
+  // Raw format: `<workchain>:<hex>`
+  address: string;
+  // '-239' for mainnet, '-3' for testnet
+  network: string;
+  walletStateInit: string;
+  publicKey: string;
+};
+
+export type TonConnectEventSuccess = {
+  event: 'connect';
+  id: number;
+  payload: {
+    items: Array<TonAddressItemReply | { name: string }>;
+    device: unknown;
+  };
+};
+
+export type TonConnectEventError = {
+  event: 'connect_error';
+  id: number;
+  payload: {
+    code: number;
+    message: string;
+  };
+};
+
+export type TonConnectEvent = TonConnectEventSuccess | TonConnectEventError;
+
+export type TonConnectRequest = {
+  manifestUrl: string;
+  items: Array<{ name: 'ton_addr' }>;
+};
+
+export type TonConnectAppRequest = {
+  method: 'sendTransaction' | 'disconnect';
+  params: string[];
+  id: string;
+};
+
+export type TonConnectWalletResponseSuccess = {
+  result: string;
+  id: string;
+};
+
+export type TonConnectWalletResponseError = {
+  error: { code: number; message: string; data?: unknown };
+  id: string;
+};
+
+export type TonConnectWalletResponse =
+  | TonConnectWalletResponseSuccess
+  | TonConnectWalletResponseError;
+
+export interface TonProviderApi {
+  deviceInfo: unknown;
+  walletInfo?: unknown;
+  protocolVersion: number;
+  connect(
+    protocolVersion: number,
+    message: TonConnectRequest
+  ): Promise<TonConnectEvent>;
+  restoreConnection(): Promise<TonConnectEvent>;
+  send(message: TonConnectAppRequest): Promise<TonConnectWalletResponse>;
+  listen(callback: (event: unknown) => void): () => void;
+  /*
+   * Non-standard OKX-specific event API. `accountChanged` fires when the user
+   * switches the active account inside the wallet; its payload is undocumented
+   * and must not be relied on.
+   */
+  on(
+    event: 'accountChanged' | 'connect' | 'disconnect',
+    callback: (payload?: unknown) => void
+  ): void;
+  off(
+    event: 'accountChanged' | 'connect' | 'disconnect',
+    callback: (payload?: unknown) => void
+  ): void;
+}

--- a/wallets/provider-okx/src/namespaces/ton/utils.ts
+++ b/wallets/provider-okx/src/namespaces/ton/utils.ts
@@ -1,0 +1,79 @@
+import type {
+  Environments,
+  TonAddressItemReply,
+  TonConnectEvent,
+  TonConnectEventSuccess,
+} from './types.js';
+import type { CaipAccount } from '@rango-dev/wallets-core/namespaces/common';
+
+import { utils as tonCoreUtils } from '@rango-dev/wallets-core/namespaces/ton';
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
+
+export function isTonConnectEventSuccess(
+  event: TonConnectEvent
+): event is TonConnectEventSuccess {
+  return (
+    !!event && event.event === 'connect' && Array.isArray(event.payload?.items)
+  );
+}
+
+export function isTonAddressItemReply(
+  item: unknown
+): item is TonAddressItemReply {
+  return (
+    typeof item === 'object' &&
+    item !== null &&
+    'name' in item &&
+    item.name === 'ton_addr' &&
+    'address' in item &&
+    typeof item.address === 'string'
+  );
+}
+
+let environments: Environments | undefined;
+
+export function setEnvironments(env?: Environments) {
+  environments = env;
+}
+
+export function getTonConnectManifestUrl(): string {
+  const manifestUrl = environments?.tonConnectManifestUrl;
+  if (!manifestUrl) {
+    throw new Error(
+      'OKX TON requires a TonConnect manifest URL. Please provide it through the provider environments.'
+    );
+  }
+  return manifestUrl;
+}
+
+let tonRequestId = 0;
+
+// TonConnect requires a unique string `id` on every request sent to the bridge.
+export function nextTonRequestId(): string {
+  tonRequestId += 1;
+  return tonRequestId.toString();
+}
+
+// Convert a `ConnectEvent`'s raw `<workchain>:<hex>` address to user-friendly CAIP.
+export async function connectEventToCAIP(
+  connectEvent: TonConnectEvent
+): Promise<CaipAccount[]> {
+  if (!isTonConnectEventSuccess(connectEvent)) {
+    return tonCoreUtils.formatAccountsToCAIP([]);
+  }
+
+  const addressItem = connectEvent.payload.items.find(isTonAddressItemReply);
+  if (!addressItem) {
+    return tonCoreUtils.formatAccountsToCAIP([]);
+  }
+
+  const { Address } = await dynamicImportWithRefinedError(
+    async () => await import('@ton/core')
+  );
+  const userFriendlyAddress = Address.parseRaw(addressItem.address).toString({
+    bounceable: false,
+    urlSafe: true,
+  });
+
+  return tonCoreUtils.formatAccountsToCAIP([userFriendlyAddress]);
+}

--- a/wallets/provider-okx/src/provider.ts
+++ b/wallets/provider-okx/src/provider.ts
@@ -1,14 +1,19 @@
+import type { Environments } from './namespaces/ton/types.js';
+
 import { ProviderBuilder } from '@hub3js/core';
 
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';
 import { solana } from './namespaces/solana.js';
+import { ton } from './namespaces/ton/ton.js';
+import { setEnvironments } from './namespaces/ton/utils.js';
 import { utxo } from './namespaces/utxo.js';
 import { okx as okxInstance } from './utils.js';
 
 const buildProvider = () =>
   new ProviderBuilder(WALLET_ID)
-    .init(function (context) {
+    .init(function (context, environments?: Environments) {
+      setEnvironments(environments);
       const [, setState] = context.state();
 
       if (okxInstance()) {
@@ -20,6 +25,7 @@ const buildProvider = () =>
     .add('solana', solana)
     .add('evm', evm)
     .add('utxo', utxo)
+    .add('ton', ton)
 
     .build();
 

--- a/wallets/provider-okx/src/signer.ts
+++ b/wallets/provider-okx/src/signer.ts
@@ -5,6 +5,7 @@ import {
   EVM_NAMESPACE,
   SOLANA_NAMESPACE,
   UTXO_NAMESPACE,
+  TON_NAMESPACE,
 } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
@@ -13,6 +14,7 @@ import {
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { OKXSolanaSigner } from './signers/solana.js';
+import { OKXTonSigner } from './signers/ton.js';
 import { OKXUTXOSigner } from './signers/utxo.js';
 
 export default async function getSigners(
@@ -21,6 +23,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
   const utxoProvider = getNetworkInstance(provider, UTXO_NAMESPACE);
+  const tonProvider = getNetworkInstance(provider, TON_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
@@ -29,6 +32,7 @@ export default async function getSigners(
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new OKXSolanaSigner(solProvider));
   signers.registerSigner(TxType.TRANSFER, new OKXUTXOSigner(utxoProvider));
+  signers.registerSigner(TxType.TON, new OKXTonSigner(tonProvider));
 
   return signers;
 }

--- a/wallets/provider-okx/src/signers/ton.ts
+++ b/wallets/provider-okx/src/signers/ton.ts
@@ -1,0 +1,70 @@
+import type {
+  TonConnectWalletResponseError,
+  TonProviderApi,
+} from '../namespaces/ton/types.js';
+import type { GenericSigner, TonTransaction } from 'rango-types';
+
+import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
+import { SignerError, SignerErrorCode, TonChainID } from 'rango-types';
+
+import { TON_CONNECT_USER_REJECTED_CODE } from '../constants.js';
+import { nextTonRequestId } from '../namespaces/ton/utils.js';
+
+function toSignerError(response: TonConnectWalletResponseError): SignerError {
+  const code =
+    response.error.code === TON_CONNECT_USER_REJECTED_CODE
+      ? SignerErrorCode.REJECTED_BY_USER
+      : SignerErrorCode.SEND_TX_ERROR;
+  return new SignerError(code, response.error.message, response.error);
+}
+
+export class OKXTonSigner implements GenericSigner<TonTransaction> {
+  private provider: TonProviderApi;
+
+  constructor(provider: TonProviderApi) {
+    this.provider = provider;
+  }
+
+  async signMessage(): Promise<string> {
+    throw SignerError.UnimplementedError('signMessage');
+  }
+
+  async signAndSendTx(tx: TonTransaction): Promise<{ hash: string }> {
+    const { validUntil, network, from, messages } = tx;
+
+    const { Address, Cell } = await dynamicImportWithRefinedError(
+      async () => await import('@ton/core')
+    );
+
+    const transactionPayload = {
+      valid_until: validUntil,
+      network: network ?? TonChainID.MAINNET,
+      ...(from && { from: Address.parse(from).toRawString() }),
+      messages: messages.map(({ stateInit, payload, ...message }) => ({
+        ...message,
+        ...(stateInit != null && { stateInit }),
+        ...(payload != null && { payload }),
+      })),
+    };
+
+    try {
+      const response = await this.provider.send({
+        method: 'sendTransaction',
+        params: [JSON.stringify(transactionPayload)],
+        id: nextTonRequestId(),
+      });
+
+      if ('error' in response) {
+        throw toSignerError(response);
+      }
+
+      const hash = Cell.fromBase64(response.result).hash().toString('hex');
+      return { hash };
+    } catch (error) {
+      if (error instanceof SignerError) {
+        throw error;
+      }
+      throw new SignerError(SignerErrorCode.SEND_TX_ERROR, undefined, error);
+    }
+  }
+}

--- a/wallets/provider-okx/src/types.ts
+++ b/wallets/provider-okx/src/types.ts
@@ -1,8 +1,10 @@
+import type { TonProviderApi } from './namespaces/ton/types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type {
   EVM_NAMESPACE,
   SOLANA_NAMESPACE,
   UTXO_NAMESPACE,
+  TON_NAMESPACE,
 } from '@hub3js/namespaces';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
@@ -12,10 +14,12 @@ export type OkxBtcAddress = {
   publicKey: string;
   compressedPublicKey: string;
 };
+
 export type ProviderObject = {
   [EVM_NAMESPACE]: EvmProviderApi;
   [SOLANA_NAMESPACE]: SolanaProviderApi;
   [UTXO_NAMESPACE]: UtxoProviderApi;
+  [TON_NAMESPACE]: TonProviderApi;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-okx/src/utils.ts
+++ b/wallets/provider-okx/src/utils.ts
@@ -1,3 +1,4 @@
+import type { TonProviderApi } from './namespaces/ton/types.js';
 import type { OkxBtcAddress, Provider } from './types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
@@ -7,11 +8,12 @@ import {
   EVM_NAMESPACE,
   SOLANA_NAMESPACE,
   UTXO_NAMESPACE,
+  TON_NAMESPACE,
 } from '@hub3js/namespaces';
 
 export function okx(): Provider | null {
-  const { okxwallet } = window;
-  if (!okxwallet) {
+  const { okxwallet, okxTonWallet } = window;
+  if (!okxwallet && !okxTonWallet) {
     return null;
   }
   const instances: Provider = new Map();
@@ -23,6 +25,9 @@ export function okx(): Provider | null {
   }
   if (okxwallet.bitcoin) {
     instances.set(UTXO_NAMESPACE, okxwallet.bitcoin);
+  }
+  if (okxTonWallet?.tonconnect) {
+    instances.set(TON_NAMESPACE, okxTonWallet.tonconnect);
   }
   return instances;
 }
@@ -75,6 +80,20 @@ export function bitcoinOKX(): UtxoProviderApi {
 
   return bitcoinInstance;
 }
+
+export function tonOKX(): TonProviderApi {
+  const instance = okx();
+  const tonInstance = instance?.get(TON_NAMESPACE);
+
+  if (!tonInstance) {
+    throw new Error(
+      'OKX Wallet not injected or TON not enabled. Please check your wallet.'
+    );
+  }
+
+  return tonInstance as TonProviderApi;
+}
+
 export async function getBitcoinAccounts(): Promise<OkxBtcAddress> {
   const instance = bitcoinOKX();
   const requestResult = await instance.connect();

--- a/wallets/readme.md
+++ b/wallets/readme.md
@@ -145,7 +145,7 @@ For better user experience, wallet provider tries to connect to a wallet only wh
 | [MathWallet](provider-math-wallet/readme.md)    | ✅  | 🚧   | ✅     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [MetaMask](provider-metamask/readme.md)         | ✅  | ❌   | ✅     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [Phantom](provider-phantom/readme.md)           | ⚠️  | ❌   | ✅     | ❌  | ❌   | ✅  | ❌       | ❌      |
-| [OKX](provider-okx/readme.md)                   | ⚠️  | ⚠️   | ✅     | 🚧  | ❌   | 🚧  | ❌       | ❌      |
+| [OKX](provider-okx/readme.md)                   | ⚠️  | ⚠️   | ✅     | ✅  | ❌   | 🚧  | ❌       | ❌      |
 | [Rabby](provider-rabby/readme.md)               | ✅  | ❌   | ❌     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [Ready](provider-ready/readme.md)               | ❌  | ❌   | ❌     | ❌  | ❌   | ❌  | ✅       |
 | [Slush](provider-slush/readme.md)               | ❌  | ❌   | ❌     | ❌  | ❌   | ✅  | ❌       | ❌      |

--- a/widget/embedded/src/containers/Wallets/Wallets.tsx
+++ b/widget/embedded/src/containers/Wallets/Wallets.tsx
@@ -109,6 +109,11 @@ function Main(props: PropsWithChildren<PropTypes>) {
             [WalletTypes.TON_CONNECT]: {
               provider: { manifestUrl: config.tonConnect?.manifestUrl },
             },
+            [WalletTypes.OKX]: {
+              provider: {
+                tonConnectManifestUrl: config.tonConnect?.manifestUrl,
+              },
+            },
             [WalletTypes.TREZOR]: {
               provider: { manifest: config.trezorManifest },
             },


### PR DESCRIPTION
## Summary

Adds TON support to the OKX wallet provider through OKX's injected TonConnect bridge (`window.okxTonWallet.tonconnect`, a separate global from `window.okxwallet`). All bridge interaction — connect/restore, account switching, wallet-side disconnect, user-rejection handling, and signing — is encapsulated in a single `OkxTonConnect` client so the actions, builders, and signer only touch a small public surface.

## Changes

- New `ton` namespace (actions/builders/namespace/signer) registered on the OKX provider
- `OkxTonConnect` client wrapping the TonConnect JS-bridge (instance resolution, request-id, manifest, raw→CAIP address conversion)
- Connect restores an approved session first, else prompts; maps TonConnect `300` to a user-rejection error
- Change-account subscriber re-reads the active account via `restoreConnection` (OKX's `accountChanged` payload is undocumented); disconnect subscriber tears the namespace down on wallet-side disconnect
- Custom `OKXTonSigner` sending `sendTransaction` through the client
- Requires a TonConnect `manifestUrl` via provider environments (wired from the widget's `tonConnect.manifestUrl`)
- Adds `window.okxTonWallet` to the global type augmentation; docs/matrix updated 

## How tested

-`yarn build` pass. 
-Connect, account switch, wallet-side disconnect, eager reconnect, and a real signed transaction were verified against the shipped extension.


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
