### PR TITLE
feat: integrate noir wallet

### DIFF
--- a/wallets/provider-all/package.json
+++ b/wallets/provider-all/package.json
@@ -37,6 +37,7 @@
     "@rango-dev/provider-ledger": "^0.32.1-next.5",
     "@rango-dev/provider-math-wallet": "^0.63.1-next.1",
     "@rango-dev/provider-metamask": "^0.62.1-next.1",
+    "@rango-dev/provider-noir-wallet": "^0.1.0",
     "@rango-dev/provider-okx": "^0.63.1-next.1",
     "@rango-dev/provider-phantom": "^0.62.1-next.5",
     "@rango-dev/provider-rabby": "^0.29.1-next.1",

--- a/wallets/provider-all/src/index.ts
+++ b/wallets/provider-all/src/index.ts
@@ -19,6 +19,7 @@ import { versions as gemwallet } from '@rango-dev/provider-gemwallet';
 import { versions as ledger } from '@rango-dev/provider-ledger';
 import { versions as mathwallet } from '@rango-dev/provider-math-wallet';
 import { versions as metamask } from '@rango-dev/provider-metamask';
+import { versions as noirWallet } from '@rango-dev/provider-noir-wallet';
 import { versions as okx } from '@rango-dev/provider-okx';
 import { versions as phantom } from '@rango-dev/provider-phantom';
 import { versions as rabby } from '@rango-dev/provider-rabby';
@@ -104,5 +105,6 @@ export const allProviders = (
     unisat,
     vultisig,
     gemwallet,
+    noirWallet,
   ];
 };

--- a/wallets/provider-noir-wallet/package.json
+++ b/wallets/provider-noir-wallet/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@rango-dev/provider-noir-wallet",
+  "version": "0.1.0",
+  "license": "MIT",
+  "type": "module",
+  "source": "./src/mod.ts",
+  "main": "./dist/mod.js",
+  "exports": {
+    ".": "./dist/mod.js"
+  },
+  "typings": "dist/mod.d.ts",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "yarn run rangutopia library build",
+    "ts-check": "tsc --declaration --emitDeclarationOnly -p ./tsconfig.json",
+    "clean": "rimraf dist",
+    "format": "prettier --write '{.,src}/**/*.{ts,tsx}'",
+    "lint": "eslint \"**/*.{ts,tsx}\""
+  },
+  "dependencies": {
+    "@hub3js/core": "^0.61.0",
+    "@hub3js/std": "^0.2.0",
+    "@rango-dev/wallets-core": "^0.60.1-next.3",
+    "@noir-wallet/sdk": "^0.1.9",
+    "bignumber.js": "^9.1.1",
+    "rango-types": "^0.5.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/wallets/provider-noir-wallet/readme.md
+++ b/wallets/provider-noir-wallet/readme.md
@@ -1,0 +1,28 @@
+# Noir Wallet Provider
+
+Noir Wallet integration for hub.
+[Homepage](https://www.zknoir.com/) | [Docs](https://github.com/NoirWallet/noir-wallet-sdk)
+
+More about implementation status can be found [here](../readme.md).
+
+## Implementation notes/limitation
+
+### Group
+
+#### ⚠️ UTXO
+
+Only supports Zcash.
+
+### Feature
+
+#### ⚠️ Sign transaction
+
+It only supports Zcash transparent transactions.
+
+#### ⚠️ Switch Account
+
+The wallet emits an empty array as switch account event when it gets locked and the namespace gets disconnected.
+
+---
+
+More wallet information can be found in [readme.md](../readme.md).

--- a/wallets/provider-noir-wallet/src/builders/utxo.ts
+++ b/wallets/provider-noir-wallet/src/builders/utxo.ts
@@ -1,0 +1,37 @@
+import { ChangeAccountSubscriberBuilder } from '@hub3js/std/hooks';
+import { type NoirWalletProvider, type ZcashAccount } from '@noir-wallet/sdk';
+import {
+  CAIP_ZCASH_CHAIN_ID,
+  utils,
+  type UtxoActions,
+} from '@rango-dev/wallets-core/namespaces/utxo';
+
+import { getInstanceOrThrow } from '../utils.js';
+
+export const changeAccountSubscriberBuilder = () => {
+  return new ChangeAccountSubscriberBuilder<
+    ZcashAccount['addresses'] | null,
+    NoirWalletProvider,
+    UtxoActions
+  >()
+    .getInstance(getInstanceOrThrow)
+    .onSwitchAccount((event, context) => {
+      if (!event.payload?.transparent) {
+        void context.action('disconnect');
+        event.preventDefault();
+        return;
+      }
+    })
+    .format(async (_, payload) =>
+      utils.formatAccountsToCAIP(
+        payload?.transparent ? [payload.transparent] : [],
+        CAIP_ZCASH_CHAIN_ID
+      )
+    )
+    .addEventListener((instance, callback) => {
+      instance.zcash.on('accountsChanged', callback);
+    })
+    .removeEventListener((instance, callback) => {
+      instance.zcash.removeListener('accountsChanged', callback);
+    });
+};

--- a/wallets/provider-noir-wallet/src/constants.ts
+++ b/wallets/provider-noir-wallet/src/constants.ts
@@ -1,0 +1,39 @@
+import type { ProviderMetadata } from '@hub3js/core';
+import type { BlockchainMeta } from 'rango-types';
+
+import getSigners from './signer.js';
+
+export const WALLET_ID = 'noir-wallet';
+
+export const info: ProviderMetadata = {
+  name: 'Noir Wallet',
+  icon: 'https://raw.githubusercontent.com/rango-exchange/assets/main/wallets/noir-wallet/icon.svg',
+  extensions: {
+    chrome:
+      'https://chromewebstore.google.com/detail/noir-wallet/mfoghjbpfanobmnoemoepenjjcmfpmdn',
+    homepage: 'https://www.zknoir.com/',
+  },
+  properties: [
+    {
+      name: 'namespaces',
+      value: {
+        selection: 'multiple',
+        data: [
+          {
+            label: 'Zcash',
+            value: 'UTXO',
+            id: 'ZCASH',
+            getSupportedChains: (allBlockchains: BlockchainMeta[]) =>
+              allBlockchains.filter(
+                (blockchain) => blockchain.name === 'ZCASH'
+              ),
+          },
+        ],
+      },
+    },
+    {
+      name: 'signers',
+      value: { getSigners: async () => getSigners() },
+    },
+  ],
+};

--- a/wallets/provider-noir-wallet/src/mod.ts
+++ b/wallets/provider-noir-wallet/src/mod.ts
@@ -1,0 +1,8 @@
+import { defineVersions } from '@hub3js/core/utils';
+
+import { buildProvider } from './provider.js';
+
+const versions = () =>
+  defineVersions().version('1.0.0', buildProvider()).build();
+
+export { versions };

--- a/wallets/provider-noir-wallet/src/namespaces/utxo.ts
+++ b/wallets/provider-noir-wallet/src/namespaces/utxo.ts
@@ -1,0 +1,82 @@
+import type { UtxoActions } from '@rango-dev/wallets-core/namespaces/utxo';
+
+import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
+import * as commonBuilders from '@hub3js/std/builders';
+import { standardizeAndThrowError } from '@hub3js/std/operators';
+import {
+  builders,
+  CAIP_ZCASH_CHAIN_ID,
+  utils,
+} from '@rango-dev/wallets-core/namespaces/utxo';
+
+import { changeAccountSubscriberBuilder } from '../builders/utxo.js';
+import { WALLET_ID } from '../constants.js';
+import { getInstanceOrThrow } from '../utils.js';
+
+const [changeAccountSubscriber, changeAccountCleanup] =
+  changeAccountSubscriberBuilder().build();
+
+const connect = builders
+  .connect()
+  .action(async function () {
+    const noirWallet = getInstanceOrThrow();
+    const zcash = noirWallet.zcash;
+
+    // Check existing connection (silent, no popup)
+    const accounts = await zcash.getAccounts();
+
+    // Connect wallet if not connected (shows popup)
+    if (!accounts) {
+      const newAccounts = await zcash.connect();
+      return utils.formatAccountsToCAIP(
+        [newAccounts.transparent],
+        CAIP_ZCASH_CHAIN_ID
+      );
+    }
+    return utils.formatAccountsToCAIP(
+      [accounts.transparent],
+      CAIP_ZCASH_CHAIN_ID
+    );
+  })
+  .before(changeAccountSubscriber)
+  .or(changeAccountCleanup)
+  .or(standardizeAndThrowError)
+  .build();
+
+const canEagerConnect = new ActionBuilder<UtxoActions, 'canEagerConnect'>(
+  'canEagerConnect'
+)
+  .action(async () => {
+    try {
+      const noirWallet = getInstanceOrThrow();
+      const zcash = noirWallet.zcash;
+
+      // Check existing connection (silent, no popup)
+      const accounts = await zcash.getAccounts();
+
+      return !!accounts;
+    } catch {
+      return false;
+    }
+  })
+  .build();
+
+const disconnect = commonBuilders
+  .disconnect<UtxoActions>()
+  .before(() => {
+    try {
+      const noirWallet = getInstanceOrThrow();
+      const zcash = noirWallet.zcash;
+      void zcash.disconnect();
+    } catch {
+      // Ignore errors during disconnect
+    }
+  })
+  .after(changeAccountCleanup)
+  .build();
+
+export const namespace = new NamespaceBuilder<UtxoActions>('UTXO', WALLET_ID)
+  .action(connect)
+  .action(disconnect)
+  .action(canEagerConnect)
+  .build();

--- a/wallets/provider-noir-wallet/src/provider.ts
+++ b/wallets/provider-noir-wallet/src/provider.ts
@@ -1,0 +1,20 @@
+import { ProviderBuilder } from '@hub3js/core';
+import { isNoirWalletInstalled } from '@noir-wallet/sdk';
+
+import { info, WALLET_ID } from './constants.js';
+import { namespace as utxo } from './namespaces/utxo.js';
+
+const buildProvider = () =>
+  new ProviderBuilder(WALLET_ID)
+    .init(function (context) {
+      const [, setState] = context.state();
+      if (isNoirWalletInstalled()) {
+        setState('installed', true);
+        console.debug('[noir-wallet] instance detected.', context);
+      }
+    })
+    .config('metadata', info)
+    .add('utxo', utxo)
+    .build();
+
+export { buildProvider };

--- a/wallets/provider-noir-wallet/src/signer.ts
+++ b/wallets/provider-noir-wallet/src/signer.ts
@@ -1,0 +1,12 @@
+import type { SignerFactory } from 'rango-types';
+
+import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
+
+import { CustomUtxoSigner } from './signers/signer.js';
+
+export default async function getSigners(): Promise<SignerFactory> {
+  const signers = new DefaultSignerFactory();
+
+  signers.registerSigner(TxType.TRANSFER, new CustomUtxoSigner());
+  return signers;
+}

--- a/wallets/provider-noir-wallet/src/signers/signer.ts
+++ b/wallets/provider-noir-wallet/src/signers/signer.ts
@@ -1,0 +1,61 @@
+import type { Transfer } from 'rango-types/mainApi';
+
+import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { BigNumber } from 'bignumber.js';
+import { type GenericSigner, SignerError, SignerErrorCode } from 'rango-types';
+
+import { getInstanceOrThrow } from '../utils.js';
+
+export class CustomUtxoSigner implements GenericSigner<Transfer> {
+  async signMessage(msg: string): Promise<string> {
+    const noirWallet = getInstanceOrThrow();
+    const zcash = noirWallet.zcash;
+
+    const result = await zcash.signMessage(msg);
+    return result.signature;
+  }
+
+  async signAndSendTx(tx: Transfer): Promise<{ hash: string }> {
+    const { memo, recipientAddress, amount, decimals, blockChain } = tx;
+
+    if (blockChain !== LegacyNetworks.ZCASH) {
+      throw new Error(`You can not sign ${tx.blockChain} using ZCash signer.`);
+    }
+
+    if (memo) {
+      throw new SignerError(
+        SignerErrorCode.UNEXPECTED_BEHAVIOUR,
+        'Noir Wallet can not attach a protocol memo (OP_RETURN) to a Zcash transaction.',
+        undefined
+      );
+    }
+
+    /*
+     * Rango provides `amount` in the asset's smallest unit (zatoshis), but the
+     * Noir Wallet expects a decimal ZEC string. Shift by `-decimals` to convert
+     * (e.g. "1000000" zatoshis -> "0.01" ZEC).
+     */
+    const amountInZec = new BigNumber(amount).shiftedBy(-decimals).toFixed();
+
+    try {
+      const noirWallet = getInstanceOrThrow();
+      const zcash = noirWallet.zcash;
+
+      const txid = await zcash.sendTransaction({
+        to: recipientAddress,
+        amount: amountInZec,
+        fundingSource: 'transparent',
+      });
+      return { hash: txid };
+    } catch (error) {
+      if (typeof error === 'string') {
+        throw new SignerError(
+          SignerErrorCode.UNEXPECTED_BEHAVIOUR,
+          error,
+          undefined
+        );
+      }
+      throw new SignerError(SignerErrorCode.SEND_TX_ERROR, undefined, error);
+    }
+  }
+}

--- a/wallets/provider-noir-wallet/src/utils.ts
+++ b/wallets/provider-noir-wallet/src/utils.ts
@@ -1,0 +1,9 @@
+import { getNoirWallet } from '@noir-wallet/sdk';
+
+export const getInstanceOrThrow = () => {
+  const noirWallet = getNoirWallet();
+  if (!noirWallet) {
+    throw new Error('Noir Wallet not installed');
+  }
+  return noirWallet;
+};

--- a/wallets/provider-noir-wallet/tsconfig.build.json
+++ b/wallets/provider-noir-wallet/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  // see https://www.typescriptlang.org/tsconfig to better understand tsconfigs
+  "extends": "../../tsconfig.libnext.json",
+  "include": ["src", "types"],
+  "files": ["../../global-wallets-env.d.ts"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./src",
+    "lib": ["dom", "esnext"]
+    // match output dir to input dir. e.g. dist/index instead of dist/src/index
+  }
+}

--- a/wallets/provider-noir-wallet/tsconfig.json
+++ b/wallets/provider-noir-wallet/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "./tsconfig.build.json", "include": ["src", "tests"] }

--- a/wallets/readme.md
+++ b/wallets/readme.md
@@ -165,6 +165,7 @@ For better user experience, wallet provider tries to connect to a wallet only wh
 | [Freighter](provider-freighter/readme.md)       | ❌  | ❌   | ❌     | ❌  | ❌   | ❌  | ❌       | ✅      |
 | [Trezor](provider-trezor/readme.md)             | ⚠️  | ❌   | ❌     | ❌  | ❌   | ❌  | ❌       | ❌      |
 | [Safe](provider-safe/readme.md)                 | ✅  | ❌   | ❌     | ❌  | ❌   | ❌  | ❌       | ❌      |
+| [Noir Wallet](provider-noir-wallet/readme.md)   | ❌  | ⚠️   | ❌     | ❌  | ❌   | ❌  | ❌       | ❌      |
 
 ## By Feature
 
@@ -202,6 +203,7 @@ For better user experience, wallet provider tries to connect to a wallet only wh
 | Freighter    | ✅             | ❌             | ✅           | Injected                  | ✅            |
 | Trezor       | ❌             | ❌             | ❌           | Transport                 | ✅            |
 | Safe         | ⚠️             | ⚠️             | ✅           | Safe App                  | ✅            |
+| Noir Wallet  | ✅             | ❌             | ✅           | Injected                  | ❌            |
 
 # Supported Wallets (Legacy)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3463,7 +3463,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.1.tgz#5738f6d765710921e7a751e00c20ae091ed8db0f"
   integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
 
-"@noble/hashes@1.8.0":
+"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -3472,6 +3472,15 @@
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.5.0.tgz#abadc5ca20332db2b1b2aa3e496e9af1213570b0"
   integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
+
+"@noir-wallet/sdk@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@noir-wallet/sdk/-/sdk-0.1.9.tgz#6178809986b51a574894d35e2027736a9624e217"
+  integrity sha512-VLoRYh3Omzz7GJphZootFzirhx4+RAtiur2iLj3sZVWOMHMifU/RR9Czc1oepqRJLPO940iypq1ma/5rbdJ08Q==
+  dependencies:
+    "@noble/curves" "^1.9.7"
+    "@noble/hashes" "^1.8.0"
+    bs58 "^6.0.0"
 
 "@nx/nx-darwin-arm64@22.7.0":
   version "22.7.0"


### PR DESCRIPTION
# Summary

Adds a new wallet provider — @rango-dev/provider-noir-wallet — integrating [Noir Wallet](https://www.zknoir.com/) into the hub (hub3js) wallet system, and registers it in provider-all so it's available everywhere the aggregate provider list is consumed.

Noir is a privacy-focused Zcash wallet. This integration exposes it through the UTXO namespace and supports:

- Connect / eager-connect / disconnect — silent getAccounts() check first, falling back to an interactive connect() only when needed.
- Account-change subscription — listens for the wallet's accountsChanged event and keeps the connected accounts in sync (CAIP-formatted), disconnecting when the active account goes away.
- Sign & send transfers — Zcash transparent transactions via the signer, with a guard that rejects non-Zcash blockchains.
- Sign message — passes the caller's message through to the wallet SDK.


# How did you test this change?

Tested by installing Noir wallet extension and executing zcash transactions.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
