### PR TITLE
refactor: key instance maps by namespace

### DIFF
--- a/queue-manager/rango-preset/package.json
+++ b/queue-manager/rango-preset/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@hub3js/core": "^0.61.0",
-    "@hub3js/namespaces": "^0.2.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/stellar": "^0.2.0",
     "@hub3js/xrpl": "^0.2.0",
     "@rango-dev/logging-core": "^0.13.0",

--- a/wallets/provider-binance/package.json
+++ b/wallets/provider-binance/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",
     "@rango-dev/wallets-core": "^0.60.1-next.1",

--- a/wallets/provider-binance/src/signer.ts
+++ b/wallets/provider-binance/src/signer.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
-import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
@@ -11,7 +11,7 @@ import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const evmProvider = getNetworkInstance(provider, Networks.ETHEREUM);
+  const evmProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-binance/src/types.ts
+++ b/wallets/provider-binance/src/types.ts
@@ -1,8 +1,8 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 export type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EvmProviderApi;
+  [EVM_NAMESPACE]: EvmProviderApi;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-binance/src/utils.ts
+++ b/wallets/provider-binance/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 
 import { type ProviderAPI as EvmProviderApi } from '@hub3js/evm';
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 export function binance(): Provider | null {
   const { binancew3w } = window;
@@ -12,7 +12,7 @@ export function binance(): Provider | null {
 
   const instances = new Map();
   if (binancew3w.ethereum) {
-    instances.set(LegacyNetworks.ETHEREUM, binancew3w.ethereum);
+    instances.set(EVM_NAMESPACE, binancew3w.ethereum);
   }
 
   if (instances.size === 0) {
@@ -37,7 +37,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmBinance(): EvmProviderApi {
   const instances = binance();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(

--- a/wallets/provider-bitget/package.json
+++ b/wallets/provider-bitget/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",
     "@rango-dev/signer-tron": "^0.41.0",

--- a/wallets/provider-bitget/src/signer.ts
+++ b/wallets/provider-bitget/src/signer.ts
@@ -1,9 +1,11 @@
+import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import {
-  type LegacyNetworkProviderMap,
-  LegacyNetworks,
-} from '@rango-dev/wallets-core/legacy';
+  EVM_NAMESPACE,
+  TRON_NAMESPACE,
+  UTXO_NAMESPACE,
+} from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
@@ -13,11 +15,11 @@ import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 import { BitgetUTXOSigner } from './signers/utxo.js';
 
 export default async function getSigners(
-  provider: LegacyNetworkProviderMap
+  provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, LegacyNetworks.ETHEREUM);
-  const tronProvider = getNetworkInstance(provider, LegacyNetworks.TRON);
-  const utxoProvider = getNetworkInstance(provider, LegacyNetworks.BTC);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
+  const tronProvider = getNetworkInstance(provider, TRON_NAMESPACE);
+  const utxoProvider = getNetworkInstance(provider, UTXO_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(

--- a/wallets/provider-bitget/src/types.ts
+++ b/wallets/provider-bitget/src/types.ts
@@ -1,12 +1,16 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type {
+  EVM_NAMESPACE,
+  TRON_NAMESPACE,
+  UTXO_NAMESPACE,
+} from '@hub3js/namespaces';
 import type { ProviderAPI as TronProviderApi } from '@rango-dev/wallets-core/namespaces/tron';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 
 export type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EvmProviderApi;
-  [LegacyNetworks.TRON]: TronProviderApi;
-  [LegacyNetworks.BTC]: UtxoProviderApi;
+  [EVM_NAMESPACE]: EvmProviderApi;
+  [TRON_NAMESPACE]: TronProviderApi;
+  [UTXO_NAMESPACE]: UtxoProviderApi;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-bitget/src/utils.ts
+++ b/wallets/provider-bitget/src/utils.ts
@@ -3,7 +3,11 @@ import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as TronProviderApi } from '@rango-dev/wallets-core/namespaces/tron';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import {
+  EVM_NAMESPACE,
+  TRON_NAMESPACE,
+  UTXO_NAMESPACE,
+} from '@hub3js/namespaces';
 
 export function bitget(): Provider | null {
   const instances: Provider = new Map();
@@ -14,14 +18,14 @@ export function bitget(): Provider | null {
   }
 
   if (bitkeep.ethereum) {
-    instances.set(LegacyNetworks.ETHEREUM, bitkeep.ethereum);
+    instances.set(EVM_NAMESPACE, bitkeep.ethereum);
   }
 
   if (bitkeep.tronLink) {
-    instances.set(LegacyNetworks.TRON, bitkeep.tronLink);
+    instances.set(TRON_NAMESPACE, bitkeep.tronLink);
   }
   if (bitkeep.unisat) {
-    instances.set(LegacyNetworks.BTC, bitkeep.unisat);
+    instances.set(UTXO_NAMESPACE, bitkeep.unisat);
   }
 
   if (instances.size === 0) {
@@ -44,7 +48,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmBitget(): EvmProviderApi {
   const instances = bitget();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(
@@ -57,7 +61,7 @@ export function evmBitget(): EvmProviderApi {
 
 export function tronBitget(): TronProviderApi {
   const instance = bitget();
-  const tronInstance = instance?.get(LegacyNetworks.TRON);
+  const tronInstance = instance?.get(TRON_NAMESPACE);
 
   if (!tronInstance) {
     throw new Error(
@@ -69,7 +73,7 @@ export function tronBitget(): TronProviderApi {
 }
 export function utxoBitget(): UtxoProviderApi {
   const instance = bitget();
-  const utxoInstance = instance?.get(LegacyNetworks.BTC);
+  const utxoInstance = instance?.get(UTXO_NAMESPACE);
 
   if (!utxoInstance) {
     throw new Error(

--- a/wallets/provider-braavos/package.json
+++ b/wallets/provider-braavos/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@hub3js/core": "^0.61.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/starknet": "^0.2.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-starknet": "^0.42.0",

--- a/wallets/provider-braavos/src/signer.ts
+++ b/wallets/provider-braavos/src/signer.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { STARKNET_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
@@ -13,10 +13,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
 
-  const starknetProvider = getNetworkInstance(
-    provider,
-    LegacyNetworks.STARKNET
-  );
+  const starknetProvider = getNetworkInstance(provider, STARKNET_NAMESPACE);
 
   const { DefaultStarknetSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-starknet')

--- a/wallets/provider-braavos/src/types.ts
+++ b/wallets/provider-braavos/src/types.ts
@@ -1,8 +1,8 @@
-import type { ProviderAPI as StarknetProviderAPI } from '@hub3js/starknet';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { STARKNET_NAMESPACE } from '@hub3js/namespaces';
+import type { ProviderAPI as StarknetProviderAPI } from '@rango-dev/wallets-core/namespaces/starknet';
 
 export type ProviderObject = {
-  [LegacyNetworks.STARKNET]: StarknetProviderAPI;
+  [STARKNET_NAMESPACE]: StarknetProviderAPI;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-braavos/src/utils.ts
+++ b/wallets/provider-braavos/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { ProviderAPI as StarknetProviderAPI } from '@hub3js/starknet';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { STARKNET_NAMESPACE } from '@hub3js/namespaces';
 
 export function braavos(): Provider | null {
   const instances: Provider = new Map();
@@ -11,7 +11,7 @@ export function braavos(): Provider | null {
     return null;
   }
 
-  instances.set(LegacyNetworks.STARKNET, starknet_braavos);
+  instances.set(STARKNET_NAMESPACE, starknet_braavos);
 
   return instances;
 }
@@ -29,7 +29,7 @@ export function getInstanceOrThrow(): Provider {
 export function starknetBraavos(): StarknetProviderAPI {
   const instances = braavos();
 
-  const starknetInstance = instances?.get(LegacyNetworks.STARKNET);
+  const starknetInstance = instances?.get(STARKNET_NAMESPACE);
 
   if (!starknetInstance) {
     throw new Error(

--- a/wallets/provider-brave/package.json
+++ b/wallets/provider-brave/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",

--- a/wallets/provider-brave/src/signer.ts
+++ b/wallets/provider-brave/src/signer.ts
@@ -1,10 +1,10 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -13,8 +13,8 @@ import { BraveSolanaSigner } from './signers/solana.js';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
-  const solProvider = getNetworkInstance(provider, Networks.SOLANA);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
+  const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-brave/src/types.ts
+++ b/wallets/provider-brave/src/types.ts
@@ -1,10 +1,10 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 
 export type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EvmProviderApi;
-  [LegacyNetworks.SOLANA]: SolanaProviderApi;
+  [EVM_NAMESPACE]: EvmProviderApi;
+  [SOLANA_NAMESPACE]: SolanaProviderApi;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-brave/src/utils.ts
+++ b/wallets/provider-brave/src/utils.ts
@@ -2,7 +2,7 @@ import type { Provider } from './types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 
 export function brave(): Provider | null {
   const { braveEthereum, braveSolana } = window;
@@ -11,10 +11,10 @@ export function brave(): Provider | null {
   }
   const instances: Provider = new Map();
   if (braveEthereum) {
-    instances.set(LegacyNetworks.ETHEREUM, braveEthereum);
+    instances.set(EVM_NAMESPACE, braveEthereum);
   }
   if (braveSolana) {
-    instances.set(LegacyNetworks.SOLANA, braveSolana);
+    instances.set(SOLANA_NAMESPACE, braveSolana);
   }
 
   return instances;
@@ -33,7 +33,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmBrave(): EvmProviderApi {
   const instances = brave();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(
@@ -46,7 +46,7 @@ export function evmBrave(): EvmProviderApi {
 
 export function solanaBrave(): SolanaProviderApi {
   const instance = brave();
-  const solanaInstance = instance?.get(LegacyNetworks.SOLANA);
+  const solanaInstance = instance?.get(SOLANA_NAMESPACE);
 
   if (!solanaInstance) {
     throw new Error(

--- a/wallets/provider-coin98/package.json
+++ b/wallets/provider-coin98/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",

--- a/wallets/provider-coin98/src/signer.ts
+++ b/wallets/provider-coin98/src/signer.ts
@@ -1,20 +1,20 @@
-import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
+import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { Coin98SolanaSigner } from './signers/solana.js';
 
 export default async function getSigners(
-  provider: LegacyNetworkProviderMap
+  provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
-  const solProvider = getNetworkInstance(provider, Networks.SOLANA);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
+  const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-coin98/src/types.ts
+++ b/wallets/provider-coin98/src/types.ts
@@ -1,10 +1,10 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 
 type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EvmProviderApi;
-  [LegacyNetworks.SOLANA]: SolanaProviderApi;
+  [EVM_NAMESPACE]: EvmProviderApi;
+  [SOLANA_NAMESPACE]: SolanaProviderApi;
 };
 
 export type Provider = Map<

--- a/wallets/provider-coin98/src/utils.ts
+++ b/wallets/provider-coin98/src/utils.ts
@@ -2,7 +2,7 @@ import type { Provider } from './types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
-import { Networks } from '@rango-dev/wallets-shared';
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 
 export function coin98() {
   const { coin98 } = window;
@@ -14,10 +14,10 @@ export function coin98() {
   const instances = new Map();
 
   if (coin98.provider) {
-    instances.set(Networks.ETHEREUM, coin98.provider);
+    instances.set(EVM_NAMESPACE, coin98.provider);
   }
   if (coin98.sol) {
-    instances.set(Networks.SOLANA, coin98.sol);
+    instances.set(SOLANA_NAMESPACE, coin98.sol);
   }
 
   return instances;
@@ -35,7 +35,7 @@ export function getInstanceOrThrow(): Provider {
 
 export function evmCoin98(): EvmProviderApi {
   const instances = coin98();
-  const evmInstance = instances?.get(Networks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
   if (!evmInstance) {
     throw new Error(
       'Coin98 not injected or EVM not enabled. Please check your wallet.'
@@ -46,7 +46,7 @@ export function evmCoin98(): EvmProviderApi {
 
 export function solanaCoin98(): SolanaProviderApi {
   const instances = coin98();
-  const solanaInstance = instances?.get(Networks.SOLANA);
+  const solanaInstance = instances?.get(SOLANA_NAMESPACE);
   if (!solanaInstance) {
     throw new Error(
       'Coin98 Solana instance is not available. Ensure that Solana support is enabled in your wallet.'

--- a/wallets/provider-coinbase/package.json
+++ b/wallets/provider-coinbase/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",

--- a/wallets/provider-coinbase/src/signer.ts
+++ b/wallets/provider-coinbase/src/signer.ts
@@ -1,10 +1,10 @@
 import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -13,8 +13,8 @@ import { CustomSolanaSigner } from './signers/solana-signer.js';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
-  const solProvider = getNetworkInstance(provider, Networks.SOLANA);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
+  const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-coinbase/src/utils.ts
+++ b/wallets/provider-coinbase/src/utils.ts
@@ -1,7 +1,7 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Provider = Record<string, any>;
@@ -16,11 +16,11 @@ export function coinbase(): Provider | null {
   const instances = new Map();
 
   if (coinbaseWalletExtension) {
-    instances.set(LegacyNetworks.ETHEREUM, coinbaseWalletExtension);
+    instances.set(EVM_NAMESPACE, coinbaseWalletExtension);
   }
 
   if (coinbaseSolana) {
-    instances.set(LegacyNetworks.SOLANA, coinbaseSolana);
+    instances.set(SOLANA_NAMESPACE, coinbaseSolana);
   }
 
   return instances;
@@ -29,7 +29,7 @@ export function coinbase(): Provider | null {
 export function evmCoinbase(): EvmProviderApi {
   const instances = coinbase();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(
@@ -42,7 +42,7 @@ export function evmCoinbase(): EvmProviderApi {
 
 export function solanaCoinbase(): SolanaProviderApi {
   const instance = coinbase();
-  const solanaInstance = instance?.get(LegacyNetworks.SOLANA);
+  const solanaInstance = instance?.get(SOLANA_NAMESPACE);
 
   if (!solanaInstance) {
     throw new Error(

--- a/wallets/provider-ctrl/package.json
+++ b/wallets/provider-ctrl/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",

--- a/wallets/provider-ctrl/src/signer.ts
+++ b/wallets/provider-ctrl/src/signer.ts
@@ -3,7 +3,7 @@ import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { SolanaExternalProvider } from '@rango-dev/signer-solana';
 import type { SignerFactory } from 'rango-types';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { CustomSolanaSigner } from './signers/solana.js';
@@ -12,10 +12,8 @@ import { CustomTransferSigner } from './signers/utxo.js';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = provider.get(LegacyNetworks.ETHEREUM) as EvmProviderApi;
-  const solProvider = provider.get(
-    LegacyNetworks.SOLANA
-  ) as SolanaExternalProvider;
+  const ethProvider = provider.get(EVM_NAMESPACE) as EvmProviderApi;
+  const solProvider = provider.get(SOLANA_NAMESPACE) as SolanaExternalProvider;
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');

--- a/wallets/provider-ctrl/src/signers/utxo.ts
+++ b/wallets/provider-ctrl/src/signers/utxo.ts
@@ -1,7 +1,8 @@
-import type { Provider, ProviderObject } from '../types.js';
+import type { Provider, UtxoProvider } from '../types.js';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 import type { GenericSigner, Transfer } from 'rango-types';
 
+import { UTXO_NAMESPACE } from '@hub3js/namespaces';
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { SignerError, SignerErrorCode } from 'rango-types';
 
@@ -53,6 +54,26 @@ async function ctrlTransfer(
   });
 }
 
+function getUtxoProvider(
+  provider: Provider,
+  blockchain: string
+): UtxoProviderApi {
+  const utxoInstances = provider.get(UTXO_NAMESPACE) as
+    | UtxoProvider
+    | undefined;
+  const instance = utxoInstances?.get(
+    blockchain as Parameters<UtxoProvider['get']>[0]
+  );
+
+  if (!instance) {
+    throw new Error(
+      `Ctrl UTXO provider for ${blockchain} is not available. Please check your wallet.`
+    );
+  }
+
+  return instance;
+}
+
 /**
  * One signer for all of Ctrl's UTXO chains. BTC is signed via PSBT (`sign_psbt`);
  * LTC/DOGE/BCH use the generic `transfer` request. It receives the whole provider
@@ -94,9 +115,7 @@ export class CustomTransferSigner implements GenericSigner<Transfer> {
       );
     }
 
-    const provider = this.provider.get(
-      asset.blockchain as keyof ProviderObject
-    ) as UtxoProviderApi;
+    const provider = getUtxoProvider(this.provider, asset.blockchain);
 
     const signInputs: { [key: string]: number[] } = {};
     psbt.inputsToSign.forEach((input) => {
@@ -137,9 +156,7 @@ export class CustomTransferSigner implements GenericSigner<Transfer> {
   async #signTransferObject(tx: Transfer): Promise<{ hash: string }> {
     const { blockchain } = tx.asset;
 
-    const transferProvider = this.provider.get(
-      blockchain as keyof ProviderObject
-    ) as UtxoProviderApi;
+    const transferProvider = getUtxoProvider(this.provider, blockchain);
 
     const {
       method,

--- a/wallets/provider-ctrl/src/types.ts
+++ b/wallets/provider-ctrl/src/types.ts
@@ -1,15 +1,29 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type {
+  EVM_NAMESPACE,
+  SOLANA_NAMESPACE,
+  UTXO_NAMESPACE,
+} from '@hub3js/namespaces';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 
-export type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EvmProviderApi;
-  [LegacyNetworks.SOLANA]: SolanaProviderApi;
+type UtxoProviderObject = {
   [LegacyNetworks.BTC]: UtxoProviderApi;
   [LegacyNetworks.LTC]: UtxoProviderApi;
   [LegacyNetworks.DOGE]: UtxoProviderApi;
   [LegacyNetworks.BCH]: UtxoProviderApi;
+};
+
+export type UtxoProvider = Map<
+  keyof UtxoProviderObject,
+  UtxoProviderObject[keyof UtxoProviderObject]
+>;
+
+export type ProviderObject = {
+  [EVM_NAMESPACE]: EvmProviderApi;
+  [SOLANA_NAMESPACE]: SolanaProviderApi;
+  [UTXO_NAMESPACE]: UtxoProvider;
 };
 
 export type Provider = Map<

--- a/wallets/provider-ctrl/src/utils.ts
+++ b/wallets/provider-ctrl/src/utils.ts
@@ -1,9 +1,14 @@
-import type { Provider } from './types.js';
+import type { Provider, UtxoProvider } from './types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { CaipAccount } from '@hub3js/std/types';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 
+import {
+  EVM_NAMESPACE,
+  SOLANA_NAMESPACE,
+  UTXO_NAMESPACE,
+} from '@hub3js/namespaces';
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import { utils } from '@rango-dev/wallets-core/namespaces/utxo';
 
@@ -17,24 +22,28 @@ export function ctrl(): Provider | null {
   }
 
   const instances: Provider = new Map();
+  const utxoInstances: UtxoProvider = new Map();
 
   if (ctrl.ethereum) {
-    instances.set(LegacyNetworks.ETHEREUM, ctrl.ethereum);
+    instances.set(EVM_NAMESPACE, ctrl.ethereum);
   }
   if (ctrl.bitcoin) {
-    instances.set(LegacyNetworks.BTC, ctrl.bitcoin);
+    utxoInstances.set(LegacyNetworks.BTC, ctrl.bitcoin);
   }
   if (ctrl.litecoin) {
-    instances.set(LegacyNetworks.LTC, ctrl.litecoin);
+    utxoInstances.set(LegacyNetworks.LTC, ctrl.litecoin);
   }
   if (ctrl.dogecoin) {
-    instances.set(LegacyNetworks.DOGE, ctrl.dogecoin);
+    utxoInstances.set(LegacyNetworks.DOGE, ctrl.dogecoin);
   }
   if (ctrl.bitcoincash) {
-    instances.set(LegacyNetworks.BCH, ctrl.bitcoincash);
+    utxoInstances.set(LegacyNetworks.BCH, ctrl.bitcoincash);
+  }
+  if (utxoInstances.size > 0) {
+    instances.set(UTXO_NAMESPACE, utxoInstances);
   }
   if (ctrl.solana) {
-    instances.set(LegacyNetworks.SOLANA, ctrl.solana);
+    instances.set(SOLANA_NAMESPACE, ctrl.solana);
   }
 
   if (instances.size === 0) {
@@ -56,7 +65,7 @@ export function getInstanceOrThrow(): Provider {
 
 export function evmCtrl(): EvmProviderApi {
   const instances = ctrl();
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(
@@ -69,7 +78,7 @@ export function evmCtrl(): EvmProviderApi {
 
 export function solanaCtrl(): SolanaProviderApi {
   const instances = ctrl();
-  const solanaInstance = instances?.get(LegacyNetworks.SOLANA);
+  const solanaInstance = instances?.get(SOLANA_NAMESPACE);
 
   if (!solanaInstance) {
     throw new Error(
@@ -89,7 +98,7 @@ export function solanaCtrl(): SolanaProviderApi {
  * Returns an empty object when EVM isn't injected so the subscriber attaches safely.
  */
 export function evmEventSource(): EvmProviderApi {
-  return (ctrl()?.get(LegacyNetworks.ETHEREUM) ?? {}) as EvmProviderApi;
+  return (ctrl()?.get(EVM_NAMESPACE) ?? {}) as EvmProviderApi;
 }
 
 /** Promisified `request_accounts` for a callback-style ctrl UTXO instance. */
@@ -127,10 +136,17 @@ export async function getAllUtxoAccounts(): Promise<CaipAccount[]> {
    * the rest and propagating that error — we don't want to silently return a partial
    * account set if one chain errors.
    */
+  const utxoInstances = instances.get(UTXO_NAMESPACE) as
+    | UtxoProvider
+    | undefined;
+  if (!utxoInstances) {
+    return [];
+  }
+
   const perChain = await Promise.all(
-    UTXO_CHAINS.filter(({ network }) => instances.get(network)).map(
+    UTXO_CHAINS.filter(({ network }) => utxoInstances.get(network)).map(
       async ({ network, caip }) => {
-        const instance = instances.get(network) as UtxoProviderApi;
+        const instance = utxoInstances.get(network) as UtxoProviderApi;
         const accounts = await requestUtxoAccounts(instance);
         return utils.formatAccountsToCAIP(accounts, caip);
       }

--- a/wallets/provider-default/package.json
+++ b/wallets/provider-default/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",
     "@rango-dev/wallets-core": "^0.60.1-next.1",

--- a/wallets/provider-default/src/signer.ts
+++ b/wallets/provider-default/src/signer.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
-import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
@@ -11,7 +11,7 @@ import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const evmProvider = getNetworkInstance(provider, Networks.ETHEREUM);
+  const evmProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-default/src/types.ts
+++ b/wallets/provider-default/src/types.ts
@@ -1,8 +1,8 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EvmProviderApi;
+  [EVM_NAMESPACE]: EvmProviderApi;
 };
 
 export type Provider = Map<

--- a/wallets/provider-default/src/utils.ts
+++ b/wallets/provider-default/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 /*
  * `provider-default` is the catch-all fallback for any injected EVM provider
@@ -16,7 +16,7 @@ export function defaultInjected(): Provider | null {
   }
 
   const instances = new Map();
-  instances.set(LegacyNetworks.ETHEREUM, ethereum);
+  instances.set(EVM_NAMESPACE, ethereum);
 
   return instances;
 }
@@ -34,7 +34,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmDefault(): EvmProviderApi {
   const instances = defaultInjected();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(

--- a/wallets/provider-enkrypt/package.json
+++ b/wallets/provider-enkrypt/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",
     "@rango-dev/wallets-core": "^0.60.1-next.1",

--- a/wallets/provider-enkrypt/src/signer.ts
+++ b/wallets/provider-enkrypt/src/signer.ts
@@ -1,17 +1,17 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType } from 'rango-types';
 
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-enkrypt/src/types.ts
+++ b/wallets/provider-enkrypt/src/types.ts
@@ -1,11 +1,11 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 export type EnkryptEvmProvider = EvmProviderApi & {
   selectedAddress: string;
 };
 export type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EnkryptEvmProvider;
+  [EVM_NAMESPACE]: EnkryptEvmProvider;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-enkrypt/src/utils.ts
+++ b/wallets/provider-enkrypt/src/utils.ts
@@ -1,6 +1,6 @@
 import type { EnkryptEvmProvider, Provider } from './types.js';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 export function enkrypt(): Provider | null {
   const { enkrypt } = window;
@@ -9,7 +9,7 @@ export function enkrypt(): Provider | null {
     return null;
   }
   const instances: Provider = new Map();
-  instances.set(LegacyNetworks.ETHEREUM, ethereum);
+  instances.set(EVM_NAMESPACE, ethereum);
 
   return instances;
 }
@@ -29,7 +29,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmEnkrypt(): EnkryptEvmProvider {
   const instances = enkrypt();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(

--- a/wallets/provider-exodus/package.json
+++ b/wallets/provider-exodus/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",

--- a/wallets/provider-exodus/src/signer.ts
+++ b/wallets/provider-exodus/src/signer.ts
@@ -1,10 +1,10 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -13,8 +13,8 @@ import { ExodusSolanaSigner } from './signers/solana.js';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
-  const solProvider = getNetworkInstance(provider, Networks.SOLANA);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
+  const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-exodus/src/types.ts
+++ b/wallets/provider-exodus/src/types.ts
@@ -1,10 +1,10 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 
 export type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EvmProviderApi;
-  [LegacyNetworks.SOLANA]: SolanaProviderApi;
+  [EVM_NAMESPACE]: EvmProviderApi;
+  [SOLANA_NAMESPACE]: SolanaProviderApi;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-exodus/src/utils.ts
+++ b/wallets/provider-exodus/src/utils.ts
@@ -2,7 +2,7 @@ import type { Provider } from './types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 
 export function exodus(): Provider | null {
   const { exodus } = window;
@@ -11,10 +11,10 @@ export function exodus(): Provider | null {
   }
   const instances: Provider = new Map();
   if (exodus.ethereum) {
-    instances.set(LegacyNetworks.ETHEREUM, exodus.ethereum);
+    instances.set(EVM_NAMESPACE, exodus.ethereum);
   }
   if (exodus.solana) {
-    instances.set(LegacyNetworks.SOLANA, exodus.solana);
+    instances.set(SOLANA_NAMESPACE, exodus.solana);
   }
 
   return instances;
@@ -33,7 +33,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmExodus(): EvmProviderApi {
   const instances = exodus();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(
@@ -46,7 +46,7 @@ export function evmExodus(): EvmProviderApi {
 
 export function solanaExodus(): SolanaProviderApi {
   const instance = exodus();
-  const solanaInstance = instance?.get(LegacyNetworks.SOLANA);
+  const solanaInstance = instance?.get(SOLANA_NAMESPACE);
 
   if (!solanaInstance) {
     throw new Error(

--- a/wallets/provider-ledger/package.json
+++ b/wallets/provider-ledger/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@ledgerhq/errors": "^6.16.4",

--- a/wallets/provider-ledger/src/utils.ts
+++ b/wallets/provider-ledger/src/utils.ts
@@ -1,5 +1,6 @@
 import type Transport from '@ledgerhq/hw-transport';
 
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import { CAIP_SOLANA_CHAIN_ID } from '@hub3js/solana';
 import { getAltStatusMessage } from '@ledgerhq/errors';
 import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
@@ -22,8 +23,8 @@ export function ledger(): Provider | null {
    */
   const instances = new Map();
 
-  instances.set(LegacyNetworks.ETHEREUM, { chainId: ETHEREUM_CHAIN_ID });
-  instances.set(LegacyNetworks.SOLANA, { chainId: LegacyNetworks.SOLANA });
+  instances.set(EVM_NAMESPACE, { chainId: ETHEREUM_CHAIN_ID });
+  instances.set(SOLANA_NAMESPACE, { chainId: LegacyNetworks.SOLANA });
 
   return instances;
 }

--- a/wallets/provider-math-wallet/package.json
+++ b/wallets/provider-math-wallet/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",

--- a/wallets/provider-math-wallet/src/signer.ts
+++ b/wallets/provider-math-wallet/src/signer.ts
@@ -1,18 +1,18 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
-  const solProvider = getNetworkInstance(provider, Networks.SOLANA);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
+  const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(

--- a/wallets/provider-math-wallet/src/types.ts
+++ b/wallets/provider-math-wallet/src/types.ts
@@ -1,6 +1,6 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 
 export type OkxBtcAddress = {
   address: string;
@@ -8,8 +8,8 @@ export type OkxBtcAddress = {
   compressedPublicKey: string;
 };
 export type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EvmProviderApi;
-  [LegacyNetworks.SOLANA]: SolanaProviderApi;
+  [EVM_NAMESPACE]: EvmProviderApi;
+  [SOLANA_NAMESPACE]: SolanaProviderApi;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-math-wallet/src/utils.ts
+++ b/wallets/provider-math-wallet/src/utils.ts
@@ -2,16 +2,16 @@ import type { Provider } from './types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 
 export function mathWallet(): Provider | null {
   const { solana, ethereum } = window;
   const instances: Provider = new Map();
   if (ethereum && ethereum.isMathWallet) {
-    instances.set(LegacyNetworks.ETHEREUM, ethereum);
+    instances.set(EVM_NAMESPACE, ethereum);
   }
   if (solana && solana.isMathWallet) {
-    instances.set(LegacyNetworks.SOLANA, solana);
+    instances.set(SOLANA_NAMESPACE, solana);
   }
   if (instances.size === 0) {
     return null;
@@ -32,7 +32,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmMathWallet(): EvmProviderApi {
   const instances = mathWallet();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(
@@ -45,7 +45,7 @@ export function evmMathWallet(): EvmProviderApi {
 
 export function solanaMathWallet(): SolanaProviderApi {
   const instance = mathWallet();
-  const solanaInstance = instance?.get(LegacyNetworks.SOLANA);
+  const solanaInstance = instance?.get(SOLANA_NAMESPACE);
 
   if (!solanaInstance) {
     throw new Error(

--- a/wallets/provider-metamask/package.json
+++ b/wallets/provider-metamask/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",

--- a/wallets/provider-metamask/src/signer.ts
+++ b/wallets/provider-metamask/src/signer.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
-import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
@@ -13,8 +13,8 @@ import { MetamaskSolanaSigner } from './signers/solana.js';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
-  const solanaProvider = getNetworkInstance(provider, Networks.SOLANA);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
+  const solanaProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(

--- a/wallets/provider-metamask/src/types.ts
+++ b/wallets/provider-metamask/src/types.ts
@@ -1,5 +1,5 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import type { WalletWithFeatures as StandardWalletWithFeatures } from '@wallet-standard/base';
 
 import {
@@ -45,8 +45,8 @@ export type MetamaskEvmProviderApi = EvmProviderApi & {
   isSafePal?: boolean;
 };
 export type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: MetamaskEvmProviderApi;
-  [LegacyNetworks.SOLANA]: WalletStandardSolanaInstance;
+  [EVM_NAMESPACE]: MetamaskEvmProviderApi;
+  [SOLANA_NAMESPACE]: WalletStandardSolanaInstance;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-metamask/src/utils.ts
+++ b/wallets/provider-metamask/src/utils.ts
@@ -5,7 +5,7 @@ import type {
 } from './types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import { getWallets } from '@wallet-standard/app';
 
 import {
@@ -23,10 +23,10 @@ export function metamask(): Provider | null {
   const instances: Provider = new Map();
 
   if (ethereum) {
-    instances.set(LegacyNetworks.ETHEREUM, ethereum);
+    instances.set(EVM_NAMESPACE, ethereum);
   }
   if (solana) {
-    instances.set(LegacyNetworks.SOLANA, solana);
+    instances.set(SOLANA_NAMESPACE, solana);
   }
 
   return instances;
@@ -104,7 +104,7 @@ function isEthereumMetamaskProvider(ethereum: MetamaskEvmProviderApi): boolean {
 export function evmMetamask(): EvmProviderApi {
   const instances = metamask();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(
@@ -116,7 +116,7 @@ export function evmMetamask(): EvmProviderApi {
 }
 export function solanaMetamask(): WalletStandardSolanaInstance {
   const instances = metamask();
-  const solanaInstance = instances?.get(LegacyNetworks.SOLANA);
+  const solanaInstance = instances?.get(SOLANA_NAMESPACE);
   if (!solanaInstance) {
     throw new Error(
       'Metamask Solana instance is not available. Ensure that Solana support is enabled in your wallet.'

--- a/wallets/provider-okx/package.json
+++ b/wallets/provider-okx/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",

--- a/wallets/provider-okx/src/signer.ts
+++ b/wallets/provider-okx/src/signer.ts
@@ -2,9 +2,13 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import {
+  EVM_NAMESPACE,
+  SOLANA_NAMESPACE,
+  UTXO_NAMESPACE,
+} from '@hub3js/namespaces';
+import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -14,9 +18,9 @@ import { OKXUTXOSigner } from './signers/utxo.js';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
-  const solProvider = getNetworkInstance(provider, Networks.SOLANA);
-  const utxoProvider = getNetworkInstance(provider, Networks.BTC);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
+  const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
+  const utxoProvider = getNetworkInstance(provider, UTXO_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(

--- a/wallets/provider-okx/src/types.ts
+++ b/wallets/provider-okx/src/types.ts
@@ -1,6 +1,10 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
+import type {
+  EVM_NAMESPACE,
+  SOLANA_NAMESPACE,
+  UTXO_NAMESPACE,
+} from '@hub3js/namespaces';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 
 export type OkxBtcAddress = {
@@ -9,9 +13,9 @@ export type OkxBtcAddress = {
   compressedPublicKey: string;
 };
 export type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EvmProviderApi;
-  [LegacyNetworks.SOLANA]: SolanaProviderApi;
-  [LegacyNetworks.BTC]: UtxoProviderApi;
+  [EVM_NAMESPACE]: EvmProviderApi;
+  [SOLANA_NAMESPACE]: SolanaProviderApi;
+  [UTXO_NAMESPACE]: UtxoProviderApi;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-okx/src/utils.ts
+++ b/wallets/provider-okx/src/utils.ts
@@ -3,7 +3,11 @@ import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { ProviderAPI as UtxoProviderApi } from '@rango-dev/wallets-core/namespaces/utxo';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import {
+  EVM_NAMESPACE,
+  SOLANA_NAMESPACE,
+  UTXO_NAMESPACE,
+} from '@hub3js/namespaces';
 
 export function okx(): Provider | null {
   const { okxwallet } = window;
@@ -12,13 +16,13 @@ export function okx(): Provider | null {
   }
   const instances: Provider = new Map();
   if (okxwallet) {
-    instances.set(LegacyNetworks.ETHEREUM, okxwallet);
+    instances.set(EVM_NAMESPACE, okxwallet);
   }
   if (okxwallet.solana) {
-    instances.set(LegacyNetworks.SOLANA, okxwallet.solana);
+    instances.set(SOLANA_NAMESPACE, okxwallet.solana);
   }
   if (okxwallet.bitcoin) {
-    instances.set(LegacyNetworks.BTC, okxwallet.bitcoin);
+    instances.set(UTXO_NAMESPACE, okxwallet.bitcoin);
   }
   return instances;
 }
@@ -36,7 +40,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmOKX(): EvmProviderApi {
   const instances = okx();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(
@@ -49,7 +53,7 @@ export function evmOKX(): EvmProviderApi {
 
 export function solanaOKX(): SolanaProviderApi {
   const instance = okx();
-  const solanaInstance = instance?.get(LegacyNetworks.SOLANA);
+  const solanaInstance = instance?.get(SOLANA_NAMESPACE);
 
   if (!solanaInstance) {
     throw new Error(
@@ -61,7 +65,7 @@ export function solanaOKX(): SolanaProviderApi {
 }
 export function bitcoinOKX(): UtxoProviderApi {
   const instance = okx();
-  const bitcoinInstance = instance?.get(LegacyNetworks.BTC);
+  const bitcoinInstance = instance?.get(UTXO_NAMESPACE);
 
   if (!bitcoinInstance) {
     throw new Error(

--- a/wallets/provider-phantom/package.json
+++ b/wallets/provider-phantom/package.json
@@ -24,6 +24,7 @@
     "@bitcoinerlab/secp256k1": "^1.2.0",
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@hub3js/sui": "^0.2.0",

--- a/wallets/provider-phantom/src/signer.ts
+++ b/wallets/provider-phantom/src/signer.ts
@@ -1,8 +1,12 @@
 import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
+import {
+  EVM_NAMESPACE,
+  SOLANA_NAMESPACE,
+  UTXO_NAMESPACE,
+} from '@hub3js/namespaces';
 import { getInstance as getSuiInstance } from '@hub3js/sui';
-import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
@@ -14,9 +18,9 @@ import { WALLET_NAME_IN_WALLET_STANDARD } from './constants.js';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const solProvider = getNetworkInstance(provider, Networks.SOLANA);
-  const evmProvider = getNetworkInstance(provider, Networks.ETHEREUM);
-  const bitcoinInstance = getNetworkInstance(provider, Networks.BTC);
+  const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
+  const evmProvider = getNetworkInstance(provider, EVM_NAMESPACE);
+  const bitcoinInstance = getNetworkInstance(provider, UTXO_NAMESPACE);
 
   const suiProvider = getSuiInstance(WALLET_NAME_IN_WALLET_STANDARD);
 

--- a/wallets/provider-phantom/src/utils.ts
+++ b/wallets/provider-phantom/src/utils.ts
@@ -2,7 +2,12 @@ import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { ProviderAPI as SuiProviderApi } from '@hub3js/sui';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import {
+  EVM_NAMESPACE,
+  SOLANA_NAMESPACE,
+  SUI_NAMESPACE,
+  UTXO_NAMESPACE,
+} from '@hub3js/namespaces';
 
 export type Provider = Map<string, unknown>;
 
@@ -18,18 +23,18 @@ export function phantom(): Provider | null {
   const instances: Provider = new Map();
 
   if (ethereum && ethereum.isPhantom) {
-    instances.set(LegacyNetworks.ETHEREUM, ethereum);
+    instances.set(EVM_NAMESPACE, ethereum);
   }
 
   if (solana && solana.isPhantom) {
-    instances.set(LegacyNetworks.SOLANA, solana);
+    instances.set(SOLANA_NAMESPACE, solana);
   }
 
   if (bitcoin && bitcoin.isPhantom) {
-    instances.set(LegacyNetworks.BTC, bitcoin);
+    instances.set(UTXO_NAMESPACE, bitcoin);
   }
   if (sui && sui.isPhantom) {
-    instances.set(LegacyNetworks.SUI, sui);
+    instances.set(SUI_NAMESPACE, sui);
   }
 
   return instances;
@@ -48,7 +53,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmPhantom(): EvmProviderApi {
   const instances = phantom();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(
@@ -61,7 +66,7 @@ export function evmPhantom(): EvmProviderApi {
 
 export function solanaPhantom(): SolanaProviderApi {
   const instance = phantom();
-  const solanaInstance = instance?.get(LegacyNetworks.SOLANA);
+  const solanaInstance = instance?.get(SOLANA_NAMESPACE);
 
   if (!solanaInstance) {
     throw new Error(
@@ -74,7 +79,7 @@ export function solanaPhantom(): SolanaProviderApi {
 
 export function bitcoinPhantom(): SolanaProviderApi {
   const instance = phantom();
-  const bitcoinInstance = instance?.get(LegacyNetworks.BTC);
+  const bitcoinInstance = instance?.get(UTXO_NAMESPACE);
 
   if (!bitcoinInstance) {
     throw new Error(
@@ -86,7 +91,7 @@ export function bitcoinPhantom(): SolanaProviderApi {
 }
 export function suiPhantom(): SuiProviderApi {
   const instance = phantom();
-  const suiInstance = instance?.get(LegacyNetworks.SUI);
+  const suiInstance = instance?.get(SUI_NAMESPACE);
 
   if (!suiInstance) {
     throw new Error(

--- a/wallets/provider-rabby/package.json
+++ b/wallets/provider-rabby/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",
     "@rango-dev/wallets-core": "^0.60.1-next.1",

--- a/wallets/provider-rabby/src/signer.ts
+++ b/wallets/provider-rabby/src/signer.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
-import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
@@ -11,7 +11,7 @@ import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const evmProvider = getNetworkInstance(provider, Networks.ETHEREUM);
+  const evmProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-rabby/src/utils.ts
+++ b/wallets/provider-rabby/src/utils.ts
@@ -5,7 +5,7 @@ import {
   type ProviderAPI,
   utils,
 } from '@hub3js/evm';
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Provider = Record<string, any>;
@@ -18,7 +18,7 @@ export function rabby(): Provider | null {
 
   const instances = new Map();
 
-  instances.set(LegacyNetworks.ETHEREUM, ethereum);
+  instances.set(EVM_NAMESPACE, ethereum);
 
   return instances;
 }
@@ -26,7 +26,7 @@ export function rabby(): Provider | null {
 export function evmRabby(): EvmProviderApi {
   const instances = rabby();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(

--- a/wallets/provider-ready/package.json
+++ b/wallets/provider-ready/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@hub3js/core": "^0.61.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/starknet": "^0.2.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-starknet": "^0.42.0",

--- a/wallets/provider-ready/src/signer.ts
+++ b/wallets/provider-ready/src/signer.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { STARKNET_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
@@ -12,10 +12,7 @@ export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const starknetProvider = getNetworkInstance(
-    provider,
-    LegacyNetworks.STARKNET
-  );
+  const starknetProvider = getNetworkInstance(provider, STARKNET_NAMESPACE);
 
   const { DefaultStarknetSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-starknet')

--- a/wallets/provider-ready/src/types.ts
+++ b/wallets/provider-ready/src/types.ts
@@ -1,8 +1,8 @@
+import type { STARKNET_NAMESPACE } from '@hub3js/namespaces';
 import type { ProviderAPI as StarknetProviderAPI } from '@hub3js/starknet';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 
 export type ProviderObject = {
-  [LegacyNetworks.STARKNET]: StarknetProviderAPI;
+  [STARKNET_NAMESPACE]: StarknetProviderAPI;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-ready/src/utils.ts
+++ b/wallets/provider-ready/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { ProviderAPI as StarknetProviderAPI } from '@hub3js/starknet';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { STARKNET_NAMESPACE } from '@hub3js/namespaces';
 
 export function ready(): Provider | null {
   const instances: Provider = new Map();
@@ -11,7 +11,7 @@ export function ready(): Provider | null {
     return null;
   }
 
-  instances.set(LegacyNetworks.STARKNET, starknet_argentX);
+  instances.set(STARKNET_NAMESPACE, starknet_argentX);
 
   return instances;
 }
@@ -29,7 +29,7 @@ export function getInstanceOrThrow(): Provider {
 export function starknetReady(): StarknetProviderAPI {
   const instances = ready();
 
-  const evmInstance = instances?.get(LegacyNetworks.STARKNET);
+  const evmInstance = instances?.get(STARKNET_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(

--- a/wallets/provider-safepal/package.json
+++ b/wallets/provider-safepal/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",
     "@rango-dev/signer-solana": "^0.48.0",

--- a/wallets/provider-safepal/src/signer.ts
+++ b/wallets/provider-safepal/src/signer.ts
@@ -1,17 +1,17 @@
 import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-safepal/src/utils.ts
+++ b/wallets/provider-safepal/src/utils.ts
@@ -1,6 +1,6 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 import { isEvmAddress } from '@rango-dev/wallets-shared';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -12,7 +12,7 @@ export function safepal(): Provider | null {
   }
   const instances = new Map();
   if (safePalEvm) {
-    instances.set(LegacyNetworks.ETHEREUM, safePalEvm);
+    instances.set(EVM_NAMESPACE, safePalEvm);
   }
 
   return instances;
@@ -20,7 +20,7 @@ export function safepal(): Provider | null {
 
 export function evmSafepal(): EvmProviderApi {
   const instances = safepal();
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
   if (!evmInstance) {
     throw new Error(
       'Safepal not injected or EVM not enabled. Please check your wallet.'

--- a/wallets/provider-solflare/package.json
+++ b/wallets/provider-solflare/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@hub3js/core": "^0.61.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-solana": "^0.48.0",

--- a/wallets/provider-solflare/src/signer.ts
+++ b/wallets/provider-solflare/src/signer.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -11,7 +11,7 @@ export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const solProvider = getNetworkInstance(provider, LegacyNetworks.SOLANA);
+  const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
 
   signers.registerSigner(TxType.SOLANA, new SolflareSolanaSiger(solProvider));
   return signers;

--- a/wallets/provider-solflare/src/types.ts
+++ b/wallets/provider-solflare/src/types.ts
@@ -1,8 +1,8 @@
+import type { SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
 
 export type ProviderObject = {
-  [LegacyNetworks.SOLANA]: SolanaProviderApi;
+  [SOLANA_NAMESPACE]: SolanaProviderApi;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-solflare/src/utils.ts
+++ b/wallets/provider-solflare/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { SOLANA_NAMESPACE } from '@hub3js/namespaces';
 
 export function solflare(): Provider | null {
   const instances: Provider = new Map();
@@ -10,7 +10,7 @@ export function solflare(): Provider | null {
     return null;
   }
 
-  instances.set(LegacyNetworks.SOLANA, solflare);
+  instances.set(SOLANA_NAMESPACE, solflare);
 
   return instances;
 }
@@ -29,7 +29,7 @@ export function getInstanceOrThrow(): Provider {
 
 export function solanaSolflare(): SolanaProviderApi {
   const instance = solflare();
-  const solanaInstance = instance?.get(LegacyNetworks.SOLANA);
+  const solanaInstance = instance?.get(SOLANA_NAMESPACE);
 
   if (!solanaInstance) {
     throw new Error(

--- a/wallets/provider-taho/package.json
+++ b/wallets/provider-taho/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",
     "@rango-dev/wallets-core": "^0.60.1-next.1",

--- a/wallets/provider-taho/src/signer.ts
+++ b/wallets/provider-taho/src/signer.ts
@@ -1,17 +1,17 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType } from 'rango-types';
 
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-taho/src/types.ts
+++ b/wallets/provider-taho/src/types.ts
@@ -1,8 +1,8 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 export type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EvmProviderApi;
+  [EVM_NAMESPACE]: EvmProviderApi;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-taho/src/utils.ts
+++ b/wallets/provider-taho/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 export function taho(): Provider | null {
   const { tally } = window;
@@ -9,7 +9,7 @@ export function taho(): Provider | null {
     return null;
   }
   const instances: Provider = new Map();
-  instances.set(LegacyNetworks.ETHEREUM, tally);
+  instances.set(EVM_NAMESPACE, tally);
 
   return instances;
 }
@@ -27,7 +27,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmTaho(): EvmProviderApi {
   const instances = taho();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(

--- a/wallets/provider-tokenpocket/package.json
+++ b/wallets/provider-tokenpocket/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",
     "@rango-dev/wallets-core": "^0.60.1-next.1",

--- a/wallets/provider-tokenpocket/src/signer.ts
+++ b/wallets/provider-tokenpocket/src/signer.ts
@@ -1,17 +1,17 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType } from 'rango-types';
 
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-tokenpocket/src/types.ts
+++ b/wallets/provider-tokenpocket/src/types.ts
@@ -1,8 +1,8 @@
 import type { ProviderAPI } from '@hub3js/evm';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 export type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: ProviderAPI;
+  [EVM_NAMESPACE]: ProviderAPI;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-tokenpocket/src/utils.ts
+++ b/wallets/provider-tokenpocket/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { ProviderAPI } from '@hub3js/evm';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 export function tokenPocket(): Provider | null {
   const { tokenpocket } = window;
@@ -10,7 +10,7 @@ export function tokenPocket(): Provider | null {
     return null;
   }
   const instances: Provider = new Map();
-  instances.set(LegacyNetworks.ETHEREUM, ethereum);
+  instances.set(EVM_NAMESPACE, ethereum);
 
   return instances;
 }
@@ -30,7 +30,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmTokenPocket(): ProviderAPI {
   const instances = tokenPocket();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(

--- a/wallets/provider-tomo/package.json
+++ b/wallets/provider-tomo/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",
     "@rango-dev/wallets-core": "^0.60.1-next.1",

--- a/wallets/provider-tomo/src/signer.ts
+++ b/wallets/provider-tomo/src/signer.ts
@@ -1,17 +1,17 @@
-import type { LegacyNetworkProviderMap } from '@rango-dev/wallets-core/legacy';
+import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
-  provider: LegacyNetworkProviderMap
+  provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-evm')

--- a/wallets/provider-tomo/src/types.ts
+++ b/wallets/provider-tomo/src/types.ts
@@ -1,8 +1,8 @@
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 type ProviderObject = {
-  [LegacyNetworks.ETHEREUM]: EvmProviderApi;
+  [EVM_NAMESPACE]: EvmProviderApi;
 };
 
 export type Provider = Map<

--- a/wallets/provider-tomo/src/utils.ts
+++ b/wallets/provider-tomo/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 
-import { Networks } from '@rango-dev/wallets-shared';
+import { EVM_NAMESPACE } from '@hub3js/namespaces';
 
 export function tomo() {
   const { tomo_evm } = window;
@@ -12,7 +12,7 @@ export function tomo() {
 
   const instances = new Map();
 
-  instances.set(Networks.ETHEREUM, tomo_evm);
+  instances.set(EVM_NAMESPACE, tomo_evm);
 
   return instances;
 }
@@ -29,7 +29,7 @@ export function getInstanceOrThrow(): Provider {
 
 export function evmTomo(): EvmProviderApi {
   const instances = tomo();
-  const evmInstance = instances?.get(Networks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
   if (!evmInstance) {
     throw new Error(
       'Tomo not injected or EVM not enabled. Please check your wallet.'

--- a/wallets/provider-tonconnect/package.json
+++ b/wallets/provider-tonconnect/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@hub3js/core": "^0.61.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@hub3js/tvm": "^0.2.0",
     "@rango-dev/wallets-shared": "^0.61.1-next.1",

--- a/wallets/provider-tonconnect/src/signer.ts
+++ b/wallets/provider-tonconnect/src/signer.ts
@@ -1,17 +1,17 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
+import { TON_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
-  Networks,
 } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const tonProvider = getNetworkInstance(provider, Networks.TON);
+  const tonProvider = getNetworkInstance(provider, TON_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { CustomTonSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/ton.js')

--- a/wallets/provider-tonconnect/src/types.ts
+++ b/wallets/provider-tonconnect/src/types.ts
@@ -1,4 +1,4 @@
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { TON_NAMESPACE } from '@hub3js/namespaces';
 import type {
   TonConnectUI,
   TonConnectUiOptionsWithManifest,
@@ -7,7 +7,7 @@ import type {
 export type Environments = TonConnectUiOptionsWithManifest;
 
 type ProviderObject = {
-  [LegacyNetworks.TON]: TonConnectUI;
+  [TON_NAMESPACE]: TonConnectUI;
 };
 
 export type Provider = Map<

--- a/wallets/provider-tonconnect/src/utils.ts
+++ b/wallets/provider-tonconnect/src/utils.ts
@@ -1,6 +1,6 @@
 import type { Provider } from './types.js';
 
-import { Networks } from '@rango-dev/wallets-shared';
+import { TON_NAMESPACE } from '@hub3js/namespaces';
 
 import { TonConnectAdapter } from './tonConnectAdapter.js';
 
@@ -9,6 +9,6 @@ export const tonConnect = new TonConnectAdapter();
 export function getInstanceOrThrow(): Provider {
   const instance = tonConnect.getInstance();
 
-  const instances = new Map([[Networks.TON, instance]]);
+  const instances = new Map([[TON_NAMESPACE, instance]]);
   return instances as Provider;
 }

--- a/wallets/provider-tron-link/package.json
+++ b/wallets/provider-tron-link/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@hub3js/core": "^0.61.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-tron": "^0.41.0",
     "@rango-dev/wallets-core": "^0.60.1-next.1",

--- a/wallets/provider-tron-link/src/signer.ts
+++ b/wallets/provider-tron-link/src/signer.ts
@@ -1,9 +1,7 @@
+import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
-import {
-  type LegacyNetworkProviderMap,
-  LegacyNetworks,
-} from '@rango-dev/wallets-core/legacy';
+import { TRON_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
@@ -11,9 +9,9 @@ import {
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
-  provider: LegacyNetworkProviderMap
+  provider: Provider
 ): Promise<SignerFactory> {
-  const tronProvider = getNetworkInstance(provider, LegacyNetworks.TRON);
+  const tronProvider = getNetworkInstance(provider, TRON_NAMESPACE);
   const signers = new DefaultSignerFactory();
   const { DefaultTronSigner } = await dynamicImportWithRefinedError(
     async () => await import('@rango-dev/signer-tron')

--- a/wallets/provider-tron-link/src/types.ts
+++ b/wallets/provider-tron-link/src/types.ts
@@ -1,8 +1,8 @@
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { TRON_NAMESPACE } from '@hub3js/namespaces';
 import type { ProviderAPI as TronProviderApi } from '@rango-dev/wallets-core/namespaces/tron';
 
 export type ProviderObject = {
-  [LegacyNetworks.TRON]: TronProviderApi;
+  [TRON_NAMESPACE]: TronProviderApi;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-tron-link/src/utils.ts
+++ b/wallets/provider-tron-link/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { ProviderAPI as TronProviderApi } from '@rango-dev/wallets-core/namespaces/tron';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { TRON_NAMESPACE } from '@hub3js/namespaces';
 
 export function tronlink(): Provider | null {
   const instances: Provider = new Map();
@@ -11,7 +11,7 @@ export function tronlink(): Provider | null {
     return null;
   }
 
-  instances.set(LegacyNetworks.TRON, tronLink);
+  instances.set(TRON_NAMESPACE, tronLink);
 
   return instances;
 }
@@ -28,7 +28,7 @@ export function getInstanceOrThrow(): Provider {
 
 export function tronTronlink(): TronProviderApi {
   const instance = tronlink();
-  const tronInstance = instance?.get(LegacyNetworks.TRON);
+  const tronInstance = instance?.get(TRON_NAMESPACE);
 
   if (!tronInstance) {
     throw new Error(

--- a/wallets/provider-trustwallet/package.json
+++ b/wallets/provider-trustwallet/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/signer-evm": "^0.43.0",

--- a/wallets/provider-trustwallet/src/signer.ts
+++ b/wallets/provider-trustwallet/src/signer.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
-import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
@@ -11,8 +11,8 @@ import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const ethProvider = getNetworkInstance(provider, Networks.ETHEREUM);
-  const solProvider = getNetworkInstance(provider, Networks.SOLANA);
+  const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
+  const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
   const { DefaultEvmSigner } = await dynamicImportWithRefinedError(

--- a/wallets/provider-trustwallet/src/utils.ts
+++ b/wallets/provider-trustwallet/src/utils.ts
@@ -2,7 +2,7 @@ import type { Context } from '@hub3js/core';
 import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Provider = Record<string, any>;
 export function trustWallet(): Provider | null {
@@ -14,10 +14,10 @@ export function trustWallet(): Provider | null {
 
   const instances = new Map();
 
-  instances.set(LegacyNetworks.ETHEREUM, trustwallet);
+  instances.set(EVM_NAMESPACE, trustwallet);
   const { solana } = trustwallet;
   if (solana && solana.isTrustWallet) {
-    instances.set(LegacyNetworks.SOLANA, solana);
+    instances.set(SOLANA_NAMESPACE, solana);
   }
 
   return instances;
@@ -36,7 +36,7 @@ export function getInstanceOrThrow(): Provider {
 export function evmTrustWallet(): EvmProviderApi {
   const instances = trustWallet();
 
-  const evmInstance = instances?.get(LegacyNetworks.ETHEREUM);
+  const evmInstance = instances?.get(EVM_NAMESPACE);
 
   if (!evmInstance) {
     throw new Error(
@@ -49,7 +49,7 @@ export function evmTrustWallet(): EvmProviderApi {
 
 export function solanaTrustWallet(): SolanaProviderApi {
   const instance = trustWallet();
-  const solanaInstance = instance?.get(LegacyNetworks.SOLANA);
+  const solanaInstance = instance?.get(SOLANA_NAMESPACE);
 
   if (!solanaInstance) {
     throw new Error(

--- a/wallets/provider-unisat/package.json
+++ b/wallets/provider-unisat/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@hub3js/core": "^0.61.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/wallets-core": "^0.60.1-next.1",
     "@rango-dev/wallets-shared": "^0.61.1-next.1",

--- a/wallets/provider-unisat/src/signer.ts
+++ b/wallets/provider-unisat/src/signer.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
-import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
+import { UTXO_NAMESPACE } from '@hub3js/namespaces';
 import {
   dynamicImportWithRefinedError,
   getNetworkInstance,
@@ -11,7 +11,7 @@ import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const bitcoinInstance = getNetworkInstance(provider, Networks.BTC);
+  const bitcoinInstance = getNetworkInstance(provider, UTXO_NAMESPACE);
   const { BTCSigner } = await dynamicImportWithRefinedError(
     async () => await import('./signers/utxoSigner.js')
   );

--- a/wallets/provider-unisat/src/utils.ts
+++ b/wallets/provider-unisat/src/utils.ts
@@ -1,4 +1,4 @@
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { UTXO_NAMESPACE } from '@hub3js/namespaces';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ProviderAPI = Record<string, any>;
@@ -14,7 +14,7 @@ export function unisat(): Provider | null {
   const instances: Provider = new Map();
 
   if (unisat) {
-    instances.set(LegacyNetworks.BTC, unisat);
+    instances.set(UTXO_NAMESPACE, unisat);
   }
 
   return instances;
@@ -32,7 +32,7 @@ export function getInstanceOrThrow(): Provider {
 
 export function bitcoinUnisat(): ProviderAPI {
   const instances = unisat();
-  const bitcoinInstance = instances?.get(LegacyNetworks.BTC);
+  const bitcoinInstance = instances?.get(UTXO_NAMESPACE);
 
   if (!bitcoinInstance) {
     throw new Error('UniSat not injected. Please check your wallet.');

--- a/wallets/provider-vultisig/package.json
+++ b/wallets/provider-vultisig/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@hub3js/core": "^0.61.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/wallets-shared": "^0.61.1-next.1",
     "rango-types": "^0.5.0"

--- a/wallets/provider-vultisig/src/types.ts
+++ b/wallets/provider-vultisig/src/types.ts
@@ -1,4 +1,4 @@
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { UTXO_NAMESPACE } from '@hub3js/namespaces';
 
 export type SendTransactionArgs = {
   method: 'send_transaction';
@@ -19,7 +19,7 @@ export type VultisigZcashProviderApi = {
 };
 
 export type ProviderObject = {
-  [LegacyNetworks.ZCASH]: VultisigZcashProviderApi;
+  [UTXO_NAMESPACE]: VultisigZcashProviderApi;
 };
 
 export type Provider = Map<

--- a/wallets/provider-vultisig/src/utils.ts
+++ b/wallets/provider-vultisig/src/utils.ts
@@ -1,6 +1,6 @@
 import type { Provider, VultisigZcashProviderApi } from './types.js';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { UTXO_NAMESPACE } from '@hub3js/namespaces';
 
 export function vultisig(): Provider | null {
   const { vultisig } = window;
@@ -11,7 +11,7 @@ export function vultisig(): Provider | null {
   const instances: Provider = new Map();
 
   if (vultisig.zcash) {
-    instances.set(LegacyNetworks.ZCASH, vultisig.zcash);
+    instances.set(UTXO_NAMESPACE, vultisig.zcash);
   }
 
   return instances;
@@ -19,7 +19,7 @@ export function vultisig(): Provider | null {
 
 export function vultisigZcash(): VultisigZcashProviderApi {
   const instances = vultisig();
-  const zcashInstance = instances?.get(LegacyNetworks.ZCASH);
+  const zcashInstance = instances?.get(UTXO_NAMESPACE);
 
   if (!zcashInstance) {
     throw new Error('Vultisig not injected. Please check your wallet.');

--- a/wallets/provider-xverse/package.json
+++ b/wallets/provider-xverse/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@hub3js/core": "^0.61.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/std": "^0.2.0",
     "@rango-dev/wallets-core": "^0.60.1-next.1",
     "@rango-dev/wallets-shared": "^0.61.1-next.1",

--- a/wallets/provider-xverse/src/signer.ts
+++ b/wallets/provider-xverse/src/signer.ts
@@ -1,7 +1,7 @@
 import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
-import { LegacyNetworks as Networks } from '@rango-dev/wallets-core/legacy';
+import { UTXO_NAMESPACE } from '@hub3js/namespaces';
 import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
@@ -10,7 +10,7 @@ import { BTCSigner } from './signers/utxoSigner.js';
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
-  const bitcoinInstance = getNetworkInstance(provider, Networks.BTC);
+  const bitcoinInstance = getNetworkInstance(provider, UTXO_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
   signers.registerSigner(TxType.TRANSFER, new BTCSigner(bitcoinInstance));

--- a/wallets/provider-xverse/src/types.ts
+++ b/wallets/provider-xverse/src/types.ts
@@ -1,4 +1,4 @@
-import type { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import type { UTXO_NAMESPACE } from '@hub3js/namespaces';
 import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/utxo';
 
 type XVerseAddress = {
@@ -29,7 +29,7 @@ export type XVerseEvent = {
 };
 
 export type ProviderObject = {
-  [LegacyNetworks.BTC]: ProviderAPI;
+  [UTXO_NAMESPACE]: ProviderAPI;
 };
 export type Provider = Map<
   keyof ProviderObject,

--- a/wallets/provider-xverse/src/utils.ts
+++ b/wallets/provider-xverse/src/utils.ts
@@ -1,7 +1,7 @@
 import type { Provider, XVerseResponse } from './types.js';
 import type { ProviderAPI } from '@rango-dev/wallets-core/namespaces/utxo';
 
-import { LegacyNetworks } from '@rango-dev/wallets-core/legacy';
+import { UTXO_NAMESPACE } from '@hub3js/namespaces';
 
 export function xverse(): Provider | null {
   const { XverseProviders } = window;
@@ -13,7 +13,7 @@ export function xverse(): Provider | null {
   const instances: Provider = new Map();
 
   if (XverseProviders.BitcoinProvider) {
-    instances.set(LegacyNetworks.BTC, XverseProviders.BitcoinProvider);
+    instances.set(UTXO_NAMESPACE, XverseProviders.BitcoinProvider);
   }
 
   return instances;
@@ -31,7 +31,7 @@ export function getInstanceOrThrow(): Provider {
 
 export function bitcoinXverse(): ProviderAPI {
   const instances = xverse();
-  const bitcoinInstance = instances?.get(LegacyNetworks.BTC);
+  const bitcoinInstance = instances?.get(UTXO_NAMESPACE);
 
   if (!bitcoinInstance) {
     throw new Error('Xverse not injected. Please check your wallet.');

--- a/wallets/react/package.json
+++ b/wallets/react/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@hub3js/core": "^0.61.0",
     "@hub3js/evm": "^0.3.0",
-    "@hub3js/namespaces": "^0.2.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@hub3js/solana": "^0.3.0",
     "@hub3js/std": "^0.2.0",
     "@hub3js/sui": "^0.2.0",

--- a/wallets/shared/package.json
+++ b/wallets/shared/package.json
@@ -27,7 +27,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@hub3js/namespaces": "^0.2.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@rango-dev/wallets-core": "^0.60.1-next.1",
     "ethers": "^6.13.2",
     "rango-types": "^0.5.0"

--- a/widget/embedded/package.json
+++ b/widget/embedded/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@hub3js/core": "^0.61.0",
-    "@hub3js/namespaces": "^0.2.0",
+    "@hub3js/namespaces": "^0.2.2",
     "@lingui/core": "4.2.1",
     "@lingui/react": "4.2.1",
     "@rango-dev/logging-core": "^0.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2675,10 +2675,10 @@
     caip "^1.1.1"
     rango-types "^0.5.0"
 
-"@hub3js/namespaces@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@hub3js/namespaces/-/namespaces-0.2.0.tgz#41c5f46c56c858ce16fb10befac8546330c229a3"
-  integrity sha512-8omV7KpfTsAxL5wCBUnR9PJvKl8gKT57VV0kVslSbGtPgHQmPp99WsL6HDqG9x64ZpDxR2SGfaQPKKQecFGmmQ==
+"@hub3js/namespaces@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@hub3js/namespaces/-/namespaces-0.2.2.tgz#bb55a7cb54ce00695a5113d82cbd3933cb4dc68b"
+  integrity sha512-lOIlEKy8GIY0drxQwRJCIpcH8qnRQ1DvYlpMelmNbyKw+vuzg2thBCYW9M16rfT9oUA3xYQNcIqzqN19fJdjYg==
   dependencies:
     "@hub3js/evm" "^0.3.0"
     "@hub3js/solana" "^0.3.0"


### PR DESCRIPTION
# Summary

Every wallet provider exposes an instances map that the rest of the app uses to reach a chain-specific provider object. Until now that map was keyed by LegacyNetworks (ETH, SOLANA, BTC, …) — a per-chain enum that predates the namespace model. This PR switches all 28 providers to key those maps by namespace (EVM, Solana, UTXO, Tron, Starknet, Ton) from @hub3js/namespaces, and removes the legacy provider implementations that were the last reason for the old keying to exist.


# How did you test this change?

- tsc --noEmit passes for every touched package.


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
