### PR TITLE
fix(walletconnect): send eth_sendTransaction params as hex

### DIFF
--- a/signers/signer-evm/src/helper.ts
+++ b/signers/signer-evm/src/helper.ts
@@ -1,12 +1,13 @@
 import type { SignerError as SignerErrorType } from 'rango-types';
 
-import { isError } from 'ethers';
+import { isError, toQuantity } from 'ethers';
 import {
   RPCErrorCode as RangoRPCErrorCode,
   SignerError,
   SignerErrorCode,
 } from 'rango-types';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const cleanEvmError = (error: any): SignerErrorType => {
   if (!error) {
     return new SignerError(SignerErrorCode.SEND_TX_ERROR);
@@ -79,10 +80,22 @@ export async function getTenderlyError(
     }
     const data: TenderlyResponse = await response.json();
     return data?.error_message;
-  } catch (error) {
+  } catch {
     return;
   }
 }
+
+/**
+ * Convert a decimal or hex numeric string to an EIP-1474 hex QUANTITY.
+ *
+ * Needed wherever transaction params reach a wallet without passing through
+ * ethers first (WalletConnect's relay, TrezorConnect), since a wallet parsing
+ * a decimal string as the QUANTITY it's declared to be reads a wildly larger
+ * number. `toQuantity` accepts both "611580889" and "0x28984", handles values
+ * beyond Number.MAX_SAFE_INTEGER, and throws on inputs that aren't a valid
+ * QUANTITY (negatives, empty strings) instead of emitting a malformed one.
+ */
+export const toHexQuantity = (value: string): string => toQuantity(value);
 
 export const waitMs = async (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));

--- a/signers/signer-evm/src/index.ts
+++ b/signers/signer-evm/src/index.ts
@@ -1,2 +1,2 @@
 export { DefaultEvmSigner } from './signer.js';
-export { waitMs, cleanEvmError } from './helper.js';
+export { waitMs, cleanEvmError, toHexQuantity } from './helper.js';

--- a/wallets/provider-trezor/src/legacy/helpers.ts
+++ b/wallets/provider-trezor/src/legacy/helpers.ts
@@ -59,18 +59,6 @@ export async function getEthereumAccounts(): Promise<ProviderConnectResult> {
   };
 }
 
-/*
- * Using BigInt in the valueToHex function ensures that the function
- * can handle very large integer values that exceed the range of standard JavaScript number types.
- */
-export const valueToHex = (value: string) => {
-  const ZERO_BIGINT = BigInt(0);
-  const HEX_BASE = 16;
-  return BigInt(value) > ZERO_BIGINT
-    ? `0x${BigInt(value).toString(HEX_BASE)}`
-    : '0x0';
-};
-
 export const getTrezorNormalizedDerivationPath = (
   path: string // TrezorConnect needs master node to be added to derivation path
 ) => (path && !path.startsWith('m/') ? 'm/' + path : path);

--- a/wallets/provider-trezor/src/signers/ethereum.ts
+++ b/wallets/provider-trezor/src/signers/ethereum.ts
@@ -1,15 +1,11 @@
 import type { EvmTransaction } from 'rango-types/mainApi';
 
-import { cleanEvmError } from '@rango-dev/signer-evm';
+import { cleanEvmError, toHexQuantity } from '@rango-dev/signer-evm';
 import { DEFAULT_ETHEREUM_RPC_URL } from '@rango-dev/wallets-shared';
 import { JsonRpcProvider, Transaction } from 'ethers';
 import { type GenericSigner } from 'rango-types';
 
-import {
-  getTrezorModule,
-  trezorErrorMessages,
-  valueToHex,
-} from '../legacy/helpers.js';
+import { getTrezorModule, trezorErrorMessages } from '../legacy/helpers.js';
 import { getDerivationPath } from '../state.js';
 
 export function getTrezorErrorMessage(error: unknown) {
@@ -65,20 +61,20 @@ export class EthereumSigner implements GenericSigner<EvmTransaction> {
       const transactionCount = await provider.getTransactionCount(fromAddress); // Get nonce
       const additionalFields = isEIP1559
         ? {
-            maxFeePerGas: valueToHex(maxFeePerGas || '0'),
-            maxPriorityFeePerGas: valueToHex(maxPriorityFeePerGas || '0'),
+            maxFeePerGas: toHexQuantity(maxFeePerGas || '0'),
+            maxPriorityFeePerGas: toHexQuantity(maxPriorityFeePerGas || '0'),
           }
         : {
-            gasPrice: valueToHex(gasPrice || '0'),
+            gasPrice: toHexQuantity(gasPrice || '0'),
           };
 
       const transaction = {
         to: tx.to,
         data: tx.data || '0x',
-        value: valueToHex(tx.value?.toString() || '0'),
-        gasLimit: valueToHex(tx.gasLimit?.toString() || '0'),
+        value: toHexQuantity(tx.value?.toString() || '0'),
+        gasLimit: toHexQuantity(tx.gasLimit?.toString() || '0'),
         chainId: Number.parseInt(chainId),
-        nonce: valueToHex(transactionCount.toString()),
+        nonce: toHexQuantity(transactionCount.toString()),
         ...additionalFields,
       };
 

--- a/wallets/provider-walletconnect-2/src/signers/evm.ts
+++ b/wallets/provider-walletconnect-2/src/signers/evm.ts
@@ -2,7 +2,7 @@ import type { SignClient } from '@walletconnect/sign-client/dist/types/client';
 import type { SessionTypes } from '@walletconnect/types';
 import type { EvmTransaction } from 'rango-types/mainApi';
 
-import { cleanEvmError, DefaultEvmSigner } from '@rango-dev/signer-evm';
+import { cleanEvmError, toHexQuantity } from '@rango-dev/signer-evm';
 import * as encoding from '@walletconnect/encoding';
 import { AccountId, ChainId } from 'caip';
 import { type GenericSigner } from 'rango-types';
@@ -11,6 +11,18 @@ import { EthereumRPCMethods, NAMESPACES } from '../constants.js';
 
 const NAMESPACE_NAME = NAMESPACES.ETHEREUM;
 
+type WalletConnectEvmTx = {
+  from?: string;
+  to?: string;
+  data: string;
+  value: string;
+  gas?: string;
+  gasPrice?: string;
+  maxFeePerGas?: string;
+  maxPriorityFeePerGas?: string;
+  nonce?: string;
+};
+
 class EVMSigner implements GenericSigner<EvmTransaction> {
   private client: SignClient;
   private session: SessionTypes.Struct;
@@ -18,6 +30,49 @@ class EVMSigner implements GenericSigner<EvmTransaction> {
   constructor(client: SignClient, session: SessionTypes.Struct) {
     this.client = client;
     this.session = session;
+  }
+
+  /**
+   * Map Rango's EvmTransaction to WalletConnect eth_sendTransaction params.
+   *
+   * Unlike DefaultEvmSigner.buildTx (ethers TransactionRequest with gasLimit +
+   * decimal fee strings), WC sends params raw over the relay. Wallets like
+   * Ledger Live parse QUANTITY as hex, so decimal fees get inflated (~40x+).
+   *
+   * This builder:
+   *  - uses `gas` (JSON-RPC), not ethers' `gasLimit`
+   *  - hex-encodes gas, fees, value, and nonce
+   */
+  static buildTx(evmTx: EvmTransaction): WalletConnectEvmTx {
+    const tx: WalletConnectEvmTx = {
+      data: evmTx.data || '0x',
+      /*
+       * Approvals and many contract calls have value=null from the API.
+       * Some WC wallets reject missing value; send 0x0 explicitly.
+       */
+      value: evmTx.value ? toHexQuantity(evmTx.value) : '0x0',
+    };
+
+    if (evmTx.from) {
+      tx.from = evmTx.from;
+    }
+    if (evmTx.to) {
+      tx.to = evmTx.to;
+    }
+    if (evmTx.nonce) {
+      tx.nonce = toHexQuantity(evmTx.nonce);
+    }
+    if (evmTx.gasLimit) {
+      tx.gas = toHexQuantity(evmTx.gasLimit);
+    }
+    if (evmTx.maxFeePerGas && evmTx.maxPriorityFeePerGas) {
+      tx.maxFeePerGas = toHexQuantity(evmTx.maxFeePerGas);
+      tx.maxPriorityFeePerGas = toHexQuantity(evmTx.maxPriorityFeePerGas);
+    } else if (evmTx.gasPrice) {
+      tx.gasPrice = toHexQuantity(evmTx.gasPrice);
+    }
+
+    return tx;
   }
 
   public async signMessage(
@@ -71,7 +126,7 @@ class EVMSigner implements GenericSigner<EvmTransaction> {
         address,
         chainId,
       });
-      const transaction = DefaultEvmSigner.buildTx(tx);
+      const transaction = EVMSigner.buildTx(tx);
       const hash: string = await this.client.request({
         topic: this.session.topic,
         chainId: requestedFor.caipChainId,


### PR DESCRIPTION
# Summary

This PR does two things:

1. **Fixes a ~43x gas fee inflation on WalletConnect**, reported on Ledger Live.
2. **Removes a duplicated hex-encoding helper**, promoting Trezor's existing
   local copy into `@rango-dev/signer-evm` so both signers share one
   implementation.

## The bug

`signAndSendTx` reused `DefaultEvmSigner.buildTx`, which builds an ethers
`TransactionRequest`. That is fine under ethers, which normalizes the object
before it reaches the RPC. WalletConnect does no normalization — the params
object crosses the relay verbatim and the peer wallet parses it — so two
ethers-specific details leaked through:

| Field | Sent before | Expected (EIP-1474) |
| --- | --- | --- |
| gas limit | `gasLimit: "500000"` | `gas: "0x7a120"` |
| gasPrice | `"611580889"` | `"0x2473fbd9"` |
| value | `"1000000000000000"` | `"0x38d7ea4c68000"` |

A wallet reading `"611580889"` as the hex QUANTITY it's declared to be gets
`0x611580889` = `26060785801` — 42.6x the intended gas price.

## The fix

A WalletConnect-specific `EVMSigner.buildTx` that:

- emits `gas` (JSON-RPC) rather than ethers' `gasLimit`
- hex-encodes gas, fees, value and nonce
- always sends `value`, defaulting to `0x0`, since approvals come back with
  `value: null` and some wallets reject the field being absent entirely

Field-gating otherwise mirrors the original: EIP-1559 fees when both are
present, `gasPrice` as fallback, optional fields omitted when absent.

## Removing the duplicated helper

Trezor had already hit this problem and solved it locally with `valueToHex` in
`provider-trezor/src/legacy/helpers.ts`. Writing a second copy inside the
WalletConnect signer would have left two identical implementations of the same
non-obvious encoding rule in two packages — the kind of thing that drifts.

So instead of duplicating it:

- `toHexQuantity` now lives in `signer-evm/src/helper.ts` and is exported from
  the package index
- `provider-trezor` imports it and its local `valueToHex` is deleted
- `provider-walletconnect-2` imports the same helper

Both packages already depended on `@rango-dev/signer-evm` for `cleanEvmError`,
so this adds no new dependency. `valueToHex` was module-internal and never
re-exported, so removing it is not a breaking change for consumers.

The shared version drops the original's `BigInt(v) > 0 ? hex : '0x0'` ternary.
Both branches were identical for every non-negative input — `BigInt("0")
.toString(16)` is already `"0"` — and every Trezor call site passes a `|| '0'`
fallback, so **Trezor's output is byte-identical to before**.

## Scope

Only WalletConnect was affected by the bug. Injected wallets and Safe go
through ethers' `BrowserProvider`, and the Ledger provider serializes via
`Transaction.from()` over USB — none of them hand a raw JSON object to a wallet
for parsing.

Two unrelated lint fixes in `signer-evm/src/helper.ts` (an `eslint-disable` for
the pre-existing `any` in `cleanEvmError`, and an unused `catch` binding) are
included to get the package linting clean; happy to split them out if you'd
rather keep the diff tight.

## Behavior change to be aware of

Wallets previously ignored the unrecognized `gasLimit` key and estimated gas
themselves. They now receive an explicit `gas` and will honor it, so a low
estimate from our API reaches the wallet instead of being silently replaced.

Note that `signer-evm` gains a new public export, so it needs a version bump
alongside the two providers when publishing.


# How did you test this change?

Static checks (run locally):

- [x] `ts-check` and `lint` clean on `provider-walletconnect-2` and `provider-trezor`
- [x] `signer-evm` test suite passes (4/4)

Wallet testing still needed before merge:

- [ ] Ledger Live over WalletConnect: swap shows the correct gas fee
- [ ] MetaMask over WalletConnect: approval + swap, gas estimate unchanged vs. `main`
- [ ] Rainbow: EIP-1559 chain and a legacy `gasPrice` chain
- [ ] Trezor: confirm the helper swap is a no-op (regression check)
- [ ] Native transfer (non-null `value`) and an approval (`value: null`)


# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
