### PR TITLE
Calculate total payable fee by using feesGroup

### DIFF
--- a/widget/embedded/src/components/Quote/Quote.tsx
+++ b/widget/embedded/src/components/Quote/Quote.tsx
@@ -362,7 +362,6 @@ export function Quote(props: QuoteProps) {
           quote={quote}
           fullExpandedMode
           time={totalTime}
-          fee={totalFee}
           feeWarning={feeWarning}
           timeWarning={timeWarning}
           showModalFee={showModalFee}
@@ -415,7 +414,6 @@ export function Quote(props: QuoteProps) {
           <QuoteCostDetails
             quote={quote}
             time={totalTime}
-            fee={totalFee}
             feeWarning={feeWarning}
             timeWarning={timeWarning}
             showModalFee={showModalFee}

--- a/widget/embedded/src/components/Quote/Quote.types.ts
+++ b/widget/embedded/src/components/Quote/Quote.types.ts
@@ -1,6 +1,5 @@
 import type { QuoteError, QuoteWarning, SelectedQuote } from '../../types';
 import type { Step } from '@rango-dev/ui';
-import type BigNumber from 'bignumber.js';
 import type { ReactNode } from 'react';
 
 export type QuoteProps = {
@@ -46,7 +45,6 @@ export type QuoteTriggerImagesProps = {
 export type QuoteCostDetailsProps = {
   quote: SelectedQuote | null;
   steps: number;
-  fee: BigNumber;
   time: string;
   feeWarning?: boolean;
   timeWarning?: boolean;

--- a/widget/embedded/src/components/Quote/QuoteCostDetails.tsx
+++ b/widget/embedded/src/components/Quote/QuoteCostDetails.tsx
@@ -1,6 +1,5 @@
 import type { QuoteCostDetailsProps } from './Quote.types';
 import type { NameOfFees } from '../../constants/quote';
-import type BigNumber from 'bignumber.js';
 
 import { i18n } from '@lingui/core';
 import {
@@ -12,6 +11,7 @@ import {
   QuoteCost,
   Typography,
 } from '@rango-dev/ui';
+import BigNumber from 'bignumber.js';
 import React, { useState } from 'react';
 
 import { getFeeLabel } from '../../constants/quote';
@@ -62,7 +62,6 @@ export function QuoteCostDetails(props: QuoteCostDetailsProps) {
   const {
     steps,
     quote,
-    fee,
     time,
     feeWarning,
     timeWarning,
@@ -73,8 +72,20 @@ export function QuoteCostDetails(props: QuoteCostDetailsProps) {
   const container = fullExpandedMode ? getExpanded() : getContainer();
 
   const feesGroup = getFeesGroup(swaps);
+
+  /*
+   * The "Total Payable Fee" must reflect only the fees the user actually pays
+   * (feesGroup.payable). We sum the USD value of every payable fee group and use
+   * it for both the collapsed summary and the itemized rows in the modal, so the
+   * two never disagree.
+   */
+  const totalPayableFee = Object.values(feesGroup.payable).reduce(
+    (acc: BigNumber, fees) => acc.plus(getTotalFeesInUsd(fees)),
+    new BigNumber(0)
+  );
+
   const roundedFee = numberToString(
-    fee,
+    totalPayableFee,
     GAS_FEE_MIN_DECIMALS,
     GAS_FEE_MAX_DECIMALS
   );
@@ -181,7 +192,7 @@ export function QuoteCostDetails(props: QuoteCostDetailsProps) {
             <Typography variant="label" size="medium">
               $
               {numberToString(
-                fee,
+                totalPayableFee,
                 USD_VALUE_MIN_DECIMALS,
                 USD_VALUE_MAX_DECIMALS
               )}


### PR DESCRIPTION
## Summary

Fixed a bug where the **Total Payable Fee** row in the quote cost details rendered a generic fee prop instead of calculating the true sum of all payable fees for the route.

### Changes Included

* **Fee Calculation**: Computed `totalPayableFee` by reducing over `feesGroup.payable` and accumulating each group's value in USD via `getTotalFeesInUsd`.
* **Import Fix**: Updated the `BigNumber` import from a type-only import (`import type { BigNumber }`) to a value import since it is now instantiated (`new BigNumber(0)`) for the reducer's initial value.

---

## How Was This Tested?

Verified in the widget UI by opening the quote cost details and confirming that the rendered **Total Payable Fee** matches the manual sum of individual payable fee rows across multi-step routes.

* [x] Verified the Total Payable Fee equals the sum of all payable fee entries for a single-step route
* [x] Verified the Total Payable Fee equals the sum of all payable fee entries for a multi-step route
* [x] Verified non-payable fees are excluded from the total and still render separately

---

## Checklist

* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision