### PR TITLE
ci: add hotfix option to production release workflow

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,9 +1,30 @@
 name: Production Release
+run-name: ${{ inputs.hotfix && 'Production Hotfix Release' || 'Production Release' }}
 on:
   workflow_dispatch:
+    inputs:
+      hotfix:
+        description: 'Hotfix: skip the next -> main sync and release main as-is'
+        type: boolean
+        required: false
+        default: false
+
+concurrency:
+  group: production-release
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure workflow is dispatched from 'main'
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "::error::Production Release must be dispatched from 'main' (got '${{ github.ref }}'). Aborting."
+          exit 1
+
   sync-prod:
+    needs: guard
+    if: ${{ !inputs.hotfix }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -18,7 +39,8 @@ jobs:
           prod: true
 
   publish:
-    needs: sync-prod
+    needs: [guard, sync-prod]
+    if: ${{ !cancelled() && needs.guard.result == 'success' && (needs.sync-prod.result == 'success' || needs.sync-prod.result == 'skipped') }}
     uses: ./.github/workflows/publish.yml
     secrets: inherit
 
@@ -54,6 +76,7 @@ jobs:
 
   sync-next:
     needs: deploy
+    if: ${{ !inputs.hotfix }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/release.md
+++ b/docs/release.md
@@ -77,7 +77,7 @@ A publish to **Preview** is triggered automatically when a Pull Request is merge
 **Note:** Ensure that all modifications to the `Production Release` workflow are implemented as a hotfix to the `main` branch to guarantee that we have the most recent updates while executing the workflow.
 
 
-Run the **`Production Release`** workflow.
+Run the **`Production Release`** workflow from the `main` branch (the workflow fails fast if dispatched from any other branch).
 
 
 It will:
@@ -116,6 +116,21 @@ It will:
   ```
 
   Open a PR to ensure all examples are on the latest version.
+
+---
+
+### **Hotfix (Production)**
+
+Use this flow when a fix must reach production without releasing what is currently on `next` (staging):
+
+1. Merge the fix directly into `main`.
+2. Run the **`Production Release`** workflow from `main` with the **hotfix** checkbox checked.
+
+With the hotfix option enabled:
+
+* The **Sync `main` with `next`** step is skipped, so `main` is released as-is — no staging commits are pulled in.
+* Publish and Deploy run exactly as in a normal production release.
+* **Sync `next` with `main`** is also skipped — `next` contains unreleased work, so this merge is likely to conflict. After the hotfix release, merge `main` back into `next` manually (e.g. via a PR) to carry the hotfix and version-bump commits to staging and resolve any conflicts deliberately.
 
 ---
 


### PR DESCRIPTION
# Summary

Adds a hotfix path to the `Production Release` workflow:

- New `hotfix` checkbox on manual dispatch (default: off)
- When checked, `sync-prod` (next → main) and `sync-next` (main → next)
  are skipped — main is published and deployed as-is
- New `guard` job fails the run if dispatched from any branch other
  than `main` (previously this silently produced an experimental release)
- `concurrency` group queues a second dispatch instead of racing on main
- Docs: hotfix section added to `docs/release.md`

Fixes # (issue)

Hotfix commits are merged directly into `main` and must be released
without pulling in unreleased work from `next`. Syncing main back to
next after a hotfix is done manually, since it usually conflicts.


# How did you test this change?

- Dispatch from `next` → guard fails, all other jobs skipped (no side effects)
- Normal release (box unchecked) → behaves exactly as before
- Hotfix release (box checked, from `main`) → sync jobs skipped, publish + deploy run


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
