### PR TITLE
ci: fix deploy job skipped in hotfix release flow

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -46,6 +46,7 @@ jobs:
 
   deploy:
     needs: publish
+    if: ${{ !cancelled() && needs.publish.result == 'success' }}
     environment: production
     runs-on: ubuntu-latest
     env:          


### PR DESCRIPTION
# Summary

Fix the `deploy` job being skipped in hotfix releases.

Jobs without an `if` get an implicit `success()` condition, which fails when any job in the `needs` chain is skipped, so the intentionally skipped `sync-prod` also skipped `deploy`. Added an explicit condition so `deploy` only depends on the `publish` result:

```yml
if: ${{ !cancelled() && needs.publish.result == 'success' }}
```
‍‍‍
Refs: [needs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds), [status check functions](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#status-check-functions)


##How did you test this change?

Validated the workflow with actionlint.
Verified the failed hotfix run ([#30444496870](https://github.com/rango-exchange/rango-client/actions/runs/30444496870)): publish succeeded but deploy was skipped, matching the described cause.
After merge: dispatch Production Release from main with the hotfix checkbox deploy runs; normal releases are unaffected.

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
