### PR TITLE
chore(deps): upgrade rangutopia to ^0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "patch-package": "^8.0.0",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.7.1",
-    "rangutopia": "^0.3.0",
+    "rangutopia": "^0.3.1",
     "rimraf": "^5.0.1",
     "semver-parser": "^4.1.4",
     "typescript-eslint": "^8.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13644,10 +13644,10 @@ rango-types@^0.5.0:
   resolved "https://registry.yarnpkg.com/rango-types/-/rango-types-0.5.0.tgz#688374a0400a710d23f07a5c4ad01a31db432a6b"
   integrity sha512-S0XZCx2Fy4+f+az++8JCiYAXRfVXiKU6MHbM/JNAW3/gh1+i0FDrjH7YJUesX5hYf/FEPvi6/B0BPg/UJTufyw==
 
-rangutopia@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/rangutopia/-/rangutopia-0.3.0.tgz#5813f58354f497de194cb08ef856a5e6b5bb0d3b"
-  integrity sha512-WocHFpBM7xCRhTGur0w5ZpG6jr2mx+jjcUA9jbsnVW1RjYpi9XJEf3oHE3AhOwtdVtsMyOb3zrXEYUy/2zyDKg==
+rangutopia@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/rangutopia/-/rangutopia-0.3.1.tgz#1eb90a8f03bb9346648028bd8e8e1b7c25a88032"
+  integrity sha512-VFrGLEXJBUz59tJcdinBEu9we3vWDr0cdQa7T+q1ALYd/N/y+ivEjUrbP38SgiJa5SwVn88i2vWQZDr88srZcQ==
   dependencies:
     "@actions/core" "^3.0.1"
     "@conventional-changelog/git-client" "^2.6.0"


### PR DESCRIPTION
Upgrades `rangutopia` from `^0.3.0` to `^0.3.1`.

`0.3.1` makes `rangutopia library build` print the full `tsc` and `esbuild` output when a build fails, instead of a bare `Command failed with exit code 2`. Since every package here builds through it, failures will now show the actual diagnostics.

No source changes — only the dependency bump and the resulting lockfile update.