### PR TITLE
fix(signer-sui): throw SignerError on sign rejection

### DIFF
--- a/signers/signer-sui/src/signer.ts
+++ b/signers/signer-sui/src/signer.ts
@@ -7,7 +7,7 @@ import {
   type SuiFeatures,
   type WalletWithFeatures,
 } from '@mysten/wallet-standard';
-import { SignerError } from 'rango-types';
+import { SignerError, SignerErrorCode } from 'rango-types';
 
 export type SuiWalletStandard = WalletWithFeatures<SuiFeatures>;
 
@@ -45,16 +45,20 @@ export class DefaultSuiSigner implements GenericSigner<SuiTransaction> {
       );
     }
 
-    const signed = await this.provider.features[
-      'sui:signAndExecuteTransaction'
-    ].signAndExecuteTransaction({
-      account,
-      transaction,
-      chain: SUI_MAINNET_CHAIN,
-    });
+    try {
+      const signed = await this.provider.features[
+        'sui:signAndExecuteTransaction'
+      ].signAndExecuteTransaction({
+        account,
+        transaction,
+        chain: SUI_MAINNET_CHAIN,
+      });
 
-    return {
-      hash: signed.digest,
-    };
+      return {
+        hash: signed.digest,
+      };
+    } catch (error) {
+      throw new SignerError(SignerErrorCode.SEND_TX_ERROR, undefined, error);
+    }
   }
 }


### PR DESCRIPTION
# Summary

Throws a `SignerError` on signing errors instead of the original RPC error object to handle it properly in the queue manager.

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
