### PR TITLE
fix(widget): prevent namespace account address from wrapping

### DIFF
--- a/widget/embedded/src/components/NamespaceItem/NamespaceItem.styles.ts
+++ b/widget/embedded/src/components/NamespaceItem/NamespaceItem.styles.ts
@@ -80,6 +80,7 @@ export const NamespaceItemErrorDropdownToggle = styled('div', {
 
 export const NamespaceAccountAddress = styled(Typography, {
   maxWidth: '100px',
+  whiteSpace: 'nowrap',
 });
 
 export const NamespaceLogo = styled(Image, {


### PR DESCRIPTION
# Summary

Wallet addresses in the namespace list could render across two lines. Fixed by
forcing a single line on the address element.


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
