### PR TITLE
Refactor/rc 395 remove dynamic import from wallets shared

### DIFF
--- a/wallets/provider-binance/src/signer.ts
+++ b/wallets/provider-binance/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -13,9 +10,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const evmProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(evmProvider));
   return signers;
 }

--- a/wallets/provider-bitget/src/signer.ts
+++ b/wallets/provider-bitget/src/signer.ts
@@ -6,10 +6,7 @@ import {
   TRON_NAMESPACE,
   UTXO_NAMESPACE,
 } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { BitgetUTXOSigner } from './signers/utxo.js';
@@ -22,12 +19,8 @@ export default async function getSigners(
   const utxoProvider = getNetworkInstance(provider, UTXO_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
-  const { DefaultTronSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-tron')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
+  const { DefaultTronSigner } = await import('@rango-dev/signer-tron');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.TRON, new DefaultTronSigner(tronProvider));
   signers.registerSigner(TxType.TRANSFER, new BitgetUTXOSigner(utxoProvider));

--- a/wallets/provider-braavos/src/signer.ts
+++ b/wallets/provider-braavos/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { STARKNET_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType } from 'rango-types';
 
 export default async function getSigners(
@@ -15,9 +12,7 @@ export default async function getSigners(
 
   const starknetProvider = getNetworkInstance(provider, STARKNET_NAMESPACE);
 
-  const { DefaultStarknetSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-starknet')
-  );
+  const { DefaultStarknetSigner } = await import('@rango-dev/signer-starknet');
   signers.registerSigner(
     TransactionType.STARKNET,
     new DefaultStarknetSigner(starknetProvider)

--- a/wallets/provider-brave/src/signer.ts
+++ b/wallets/provider-brave/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { BraveSolanaSigner } from './signers/solana.js';
@@ -16,9 +13,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new BraveSolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-coin98/src/signer.ts
+++ b/wallets/provider-coin98/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { Coin98SolanaSigner } from './signers/solana.js';
@@ -16,9 +13,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new Coin98SolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-coinbase/src/signer.ts
+++ b/wallets/provider-coinbase/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { CustomSolanaSigner } from './signers/solana-signer.js';
@@ -16,9 +13,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-default/src/signer.ts
+++ b/wallets/provider-default/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -13,9 +10,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const evmProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(evmProvider));
   return signers;
 }

--- a/wallets/provider-enkrypt/src/signer.ts
+++ b/wallets/provider-enkrypt/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType } from 'rango-types';
 
 export default async function getSigners(
@@ -13,9 +10,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(
     TransactionType.EVM,
     new DefaultEvmSigner(ethProvider)

--- a/wallets/provider-exodus/src/signer.ts
+++ b/wallets/provider-exodus/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { ExodusSolanaSigner } from './signers/solana.js';
@@ -16,9 +13,7 @@ export default async function getSigners(
   const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new ExodusSolanaSigner(solProvider));
   return signers;

--- a/wallets/provider-ledger/src/signers/ethereum.ts
+++ b/wallets/provider-ledger/src/signers/ethereum.ts
@@ -2,10 +2,7 @@ import type { TransactionLike } from 'ethers';
 import type { GenericSigner } from 'rango-types';
 import type { EvmTransaction } from 'rango-types/mainApi';
 
-import {
-  DEFAULT_ETHEREUM_RPC_URL,
-  dynamicImportWithRefinedError,
-} from '@rango-dev/wallets-shared';
+import { DEFAULT_ETHEREUM_RPC_URL } from '@rango-dev/wallets-shared';
 import { JsonRpcProvider, Transaction } from 'ethers';
 import { SignerError, SignerErrorCode } from 'rango-types';
 
@@ -20,11 +17,7 @@ export class EthereumSigner implements GenericSigner<EvmTransaction> {
   async signMessage(msg: string): Promise<string> {
     try {
       const transport = await transportConnect();
-      const LedgerAppEth = (
-        await dynamicImportWithRefinedError(
-          async () => await import('@ledgerhq/hw-app-eth')
-        )
-      ).default;
+      const LedgerAppEth = (await import('@ledgerhq/hw-app-eth')).default;
       const eth = new LedgerAppEth(transport);
 
       const result = await eth.signPersonalMessage(
@@ -68,9 +61,7 @@ export class EthereumSigner implements GenericSigner<EvmTransaction> {
         Transaction.from(transaction).unsignedSerialized.substring(2); // Create unsigned transaction
 
       const transport = await transportConnect();
-      const LedgerHqAppEth = await dynamicImportWithRefinedError(
-        async () => await import('@ledgerhq/hw-app-eth')
-      );
+      const LedgerHqAppEth = await import('@ledgerhq/hw-app-eth');
 
       const LedgerAppEth = LedgerHqAppEth.default;
       const eth = new LedgerAppEth(transport);

--- a/wallets/provider-ledger/src/signers/solana.ts
+++ b/wallets/provider-ledger/src/signers/solana.ts
@@ -3,7 +3,6 @@ import type { Transaction, VersionedTransaction } from '@solana/web3.js';
 import type { GenericSigner, SolanaTransaction } from 'rango-types';
 
 import { generalSolanaTransactionExecutor } from '@rango-dev/signer-solana';
-import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { PublicKey } from '@solana/web3.js';
 import { SignerError, SignerErrorCode } from 'rango-types';
 
@@ -24,11 +23,7 @@ export class SolanaSigner implements GenericSigner<SolanaTransaction> {
   async signMessage(msg: string): Promise<string> {
     try {
       const transport = await transportConnect();
-      const LedgerAppSolana = (
-        await dynamicImportWithRefinedError(
-          async () => await import('@ledgerhq/hw-app-solana')
-        )
-      ).default;
+      const LedgerAppSolana = (await import('@ledgerhq/hw-app-solana')).default;
       const solana = new LedgerAppSolana(transport);
 
       const result = await solana.signOffchainMessage(
@@ -47,11 +42,8 @@ export class SolanaSigner implements GenericSigner<SolanaTransaction> {
         solanaWeb3Transaction: Transaction | VersionedTransaction
       ) => {
         const transport = await transportConnect();
-        const LedgerAppSolana = (
-          await dynamicImportWithRefinedError(
-            async () => await import('@ledgerhq/hw-app-solana')
-          )
-        ).default;
+        const LedgerAppSolana = (await import('@ledgerhq/hw-app-solana'))
+          .default;
         const solana = new LedgerAppSolana(transport);
 
         let signResult;

--- a/wallets/provider-ledger/src/utils.ts
+++ b/wallets/provider-ledger/src/utils.ts
@@ -4,7 +4,6 @@ import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
 import { CAIP_SOLANA_CHAIN_ID } from '@hub3js/solana';
 import { getAltStatusMessage } from '@ledgerhq/errors';
 import {
-  dynamicImportWithRefinedError,
   ETHEREUM_CHAIN_ID,
   type ProviderConnectResult,
 } from '@rango-dev/wallets-shared';
@@ -65,11 +64,7 @@ export function standardizeAndThrowLedgerError(_: unknown, error: unknown) {
 export async function getEthereumAccounts(): Promise<ProviderConnectResult> {
   try {
     const transport = await transportConnect();
-    const LedgerAppEth = (
-      await dynamicImportWithRefinedError(
-        async () => await import('@ledgerhq/hw-app-eth')
-      )
-    ).default;
+    const LedgerAppEth = (await import('@ledgerhq/hw-app-eth')).default;
     const eth = new LedgerAppEth(transport);
     const derivationPath = getDerivationPath();
 
@@ -93,11 +88,7 @@ export async function getEthereumAccounts(): Promise<ProviderConnectResult> {
 export async function getSolanaAccounts(): Promise<ProviderConnectResult> {
   try {
     const transport = await transportConnect();
-    const LedgerAppSolana = (
-      await dynamicImportWithRefinedError(
-        async () => await import('@ledgerhq/hw-app-solana')
-      )
-    ).default;
+    const LedgerAppSolana = (await import('@ledgerhq/hw-app-solana')).default;
     const solana = new LedgerAppSolana(transport);
     const derivationPath = getDerivationPath();
 
@@ -121,11 +112,8 @@ export async function getSolanaAccounts(): Promise<ProviderConnectResult> {
 let transportConnection: Transport | null = null;
 
 export async function transportConnect() {
-  const TransportWebHID = (
-    await dynamicImportWithRefinedError(
-      async () => await import('@ledgerhq/hw-transport-webhid')
-    )
-  ).default;
+  const TransportWebHID = (await import('@ledgerhq/hw-transport-webhid'))
+    .default;
 
   transportConnection = await TransportWebHID.create();
 

--- a/wallets/provider-math-wallet/src/signer.ts
+++ b/wallets/provider-math-wallet/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -15,12 +12,8 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
-  const { DefaultSolanaSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-solana')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
+  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
 
   if (!!ethProvider) {
     signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));

--- a/wallets/provider-metamask/src/signer.ts
+++ b/wallets/provider-metamask/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { MetamaskSolanaSigner } from './signers/solana.js';
@@ -17,9 +14,7 @@ export default async function getSigners(
   const solanaProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(
     TxType.SOLANA,

--- a/wallets/provider-okx/src/namespaces/ton/utils.ts
+++ b/wallets/provider-okx/src/namespaces/ton/utils.ts
@@ -7,7 +7,6 @@ import type {
 import type { CaipAccount } from '@hub3js/std/types';
 
 import { utils as tonCoreUtils } from '@hub3js/tvm';
-import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 
 export function isTonConnectEventSuccess(
   event: TonConnectEvent
@@ -67,9 +66,7 @@ export async function connectEventToCAIP(
     return tonCoreUtils.formatAccountsToCAIP([]);
   }
 
-  const { Address } = await dynamicImportWithRefinedError(
-    async () => await import('@ton/core')
-  );
+  const { Address } = await import('@ton/core');
   const userFriendlyAddress = Address.parseRaw(addressItem.address).toString({
     bounceable: false,
     urlSafe: true,

--- a/wallets/provider-okx/src/provider.ts
+++ b/wallets/provider-okx/src/provider.ts
@@ -5,10 +5,10 @@ import { ProviderBuilder } from '@hub3js/core';
 import { metadata, WALLET_ID } from './constants.js';
 import { evm } from './namespaces/evm.js';
 import { solana } from './namespaces/solana.js';
+import { sui } from './namespaces/sui.js';
 import { ton } from './namespaces/ton/ton.js';
 import { setEnvironments } from './namespaces/ton/utils.js';
 import { tron } from './namespaces/tron.js';
-import { sui } from './namespaces/sui.js';
 import { utxo } from './namespaces/utxo.js';
 import { okx as okxInstance } from './utils.js';
 

--- a/wallets/provider-okx/src/signer.ts
+++ b/wallets/provider-okx/src/signer.ts
@@ -4,14 +4,11 @@ import type { SignerFactory } from 'rango-types';
 import {
   EVM_NAMESPACE,
   SOLANA_NAMESPACE,
-  UTXO_NAMESPACE,
   TON_NAMESPACE,
   TRON_NAMESPACE,
+  UTXO_NAMESPACE,
 } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { OKXSolanaSigner } from './signers/solana.js';
@@ -29,12 +26,8 @@ export default async function getSigners(
   const tronProvider = getNetworkInstance(provider, TRON_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
-  const { DefaultTronSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-tron')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
+  const { DefaultTronSigner } = await import('@rango-dev/signer-tron');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new OKXSolanaSigner(solProvider));
   signers.registerSigner(TxType.TRANSFER, new OKXUTXOSigner(utxoProvider));
@@ -43,9 +36,7 @@ export default async function getSigners(
 
   const suiProvider = suiWalletInstance();
   if (suiProvider) {
-    const { DefaultSuiSigner } = await dynamicImportWithRefinedError(
-      async () => await import('@rango-dev/signer-sui')
-    );
+    const { DefaultSuiSigner } = await import('@rango-dev/signer-sui');
     signers.registerSigner(TxType.SUI, new DefaultSuiSigner(suiProvider));
   }
 

--- a/wallets/provider-okx/src/signers/ton.ts
+++ b/wallets/provider-okx/src/signers/ton.ts
@@ -4,7 +4,6 @@ import type {
 } from '../namespaces/ton/types.js';
 import type { GenericSigner, TonTransaction } from 'rango-types';
 
-import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { SignerError, SignerErrorCode, TonChainID } from 'rango-types';
 
 import { TON_CONNECT_USER_REJECTED_CODE } from '../constants.js';
@@ -32,9 +31,7 @@ export class OKXTonSigner implements GenericSigner<TonTransaction> {
   async signAndSendTx(tx: TonTransaction): Promise<{ hash: string }> {
     const { validUntil, network, from, messages } = tx;
 
-    const { Address, Cell } = await dynamicImportWithRefinedError(
-      async () => await import('@ton/core')
-    );
+    const { Address, Cell } = await import('@ton/core');
 
     const transactionPayload = {
       valid_until: validUntil,

--- a/wallets/provider-okx/src/types.ts
+++ b/wallets/provider-okx/src/types.ts
@@ -3,9 +3,9 @@ import type { ProviderAPI as EvmProviderApi } from '@hub3js/evm';
 import type {
   EVM_NAMESPACE,
   SOLANA_NAMESPACE,
-  UTXO_NAMESPACE,
   TON_NAMESPACE,
   TRON_NAMESPACE,
+  UTXO_NAMESPACE,
 } from '@hub3js/namespaces';
 import type { ProviderAPI as SolanaProviderApi } from '@hub3js/solana';
 import type { ProviderAPI as TronProviderApi } from '@rango-dev/wallets-core/namespaces/tron';

--- a/wallets/provider-phantom/src/signer.ts
+++ b/wallets/provider-phantom/src/signer.ts
@@ -7,10 +7,7 @@ import {
   UTXO_NAMESPACE,
 } from '@hub3js/namespaces';
 import { getInstance as getSuiInstance } from '@hub3js/sui';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { WALLET_NAME_IN_WALLET_STANDARD } from './constants.js';
@@ -24,18 +21,10 @@ export default async function getSigners(
 
   const suiProvider = getSuiInstance(WALLET_NAME_IN_WALLET_STANDARD);
 
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
-  const { DefaultSolanaSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-solana')
-  );
-  const { BTCSigner } = await dynamicImportWithRefinedError(
-    async () => await import('./signers/utxoSigner.js')
-  );
-  const { DefaultSuiSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-sui')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
+  const { DefaultSolanaSigner } = await import('@rango-dev/signer-solana');
+  const { BTCSigner } = await import('./signers/utxoSigner.js');
+  const { DefaultSuiSigner } = await import('@rango-dev/signer-sui');
   const signers = new DefaultSignerFactory();
   signers.registerSigner(TxType.SOLANA, new DefaultSolanaSigner(solProvider));
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(evmProvider));

--- a/wallets/provider-rabby/src/signer.ts
+++ b/wallets/provider-rabby/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -13,9 +10,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const evmProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(evmProvider));
   return signers;
 }

--- a/wallets/provider-ready/src/signer.ts
+++ b/wallets/provider-ready/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { STARKNET_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType } from 'rango-types';
 
 export default async function getSigners(
@@ -14,9 +11,7 @@ export default async function getSigners(
   const signers = new DefaultSignerFactory();
   const starknetProvider = getNetworkInstance(provider, STARKNET_NAMESPACE);
 
-  const { DefaultStarknetSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-starknet')
-  );
+  const { DefaultStarknetSigner } = await import('@rango-dev/signer-starknet');
   signers.registerSigner(
     TransactionType.STARKNET,
     new DefaultStarknetSigner(starknetProvider)

--- a/wallets/provider-safe/src/signer.ts
+++ b/wallets/provider-safe/src/signer.ts
@@ -1,16 +1,13 @@
 import type { ProviderAPI } from '@hub3js/evm';
 import type { SignerFactory } from 'rango-types';
 
-import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: ProviderAPI
 ): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { CustomEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('./signers/evm.js')
-  );
+  const { CustomEvmSigner } = await import('./signers/evm.js');
   signers.registerSigner(TxType.EVM, new CustomEvmSigner(provider));
 
   return signers;

--- a/wallets/provider-safepal/src/signer.ts
+++ b/wallets/provider-safepal/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -13,9 +10,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   return signers;
 }

--- a/wallets/provider-slush/package.json
+++ b/wallets/provider-slush/package.json
@@ -28,7 +28,6 @@
     "@mysten/wallet-standard": "^0.13.26",
     "@rango-dev/signer-sui": "^0.11.0",
     "@rango-dev/wallets-core": "^0.61.0",
-    "@rango-dev/wallets-shared": "^0.62.1-next.1",
     "rango-types": "^0.5.0"
   },
   "publishConfig": {

--- a/wallets/provider-slush/src/signer.ts
+++ b/wallets/provider-slush/src/signer.ts
@@ -1,7 +1,6 @@
 import type { SignerFactory } from 'rango-types';
 
 import { getInstanceOrThrow } from '@hub3js/sui';
-import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { WALLET_NAME_IN_WALLET_STANDARD } from './constants.js';
@@ -9,9 +8,7 @@ import { WALLET_NAME_IN_WALLET_STANDARD } from './constants.js';
 export default async function getSigners(): Promise<SignerFactory> {
   const suiWalletProvider = getInstanceOrThrow(WALLET_NAME_IN_WALLET_STANDARD);
 
-  const { DefaultSuiSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-sui')
-  );
+  const { DefaultSuiSigner } = await import('@rango-dev/signer-sui');
   const signers = new DefaultSignerFactory();
   signers.registerSigner(TxType.SUI, new DefaultSuiSigner(suiWalletProvider));
   return signers;

--- a/wallets/provider-taho/src/signer.ts
+++ b/wallets/provider-taho/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType } from 'rango-types';
 
 export default async function getSigners(
@@ -13,9 +10,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(
     TransactionType.EVM,
     new DefaultEvmSigner(ethProvider)

--- a/wallets/provider-tokenpocket/src/signer.ts
+++ b/wallets/provider-tokenpocket/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType } from 'rango-types';
 
 export default async function getSigners(
@@ -13,9 +10,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(
     TransactionType.EVM,
     new DefaultEvmSigner(ethProvider)

--- a/wallets/provider-tomo/src/signer.ts
+++ b/wallets/provider-tomo/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -13,9 +10,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const ethProvider = getNetworkInstance(provider, EVM_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   return signers;
 }

--- a/wallets/provider-tonconnect/src/signer.ts
+++ b/wallets/provider-tonconnect/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { TON_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -13,9 +10,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const tonProvider = getNetworkInstance(provider, TON_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { CustomTonSigner } = await dynamicImportWithRefinedError(
-    async () => await import('./signers/ton.js')
-  );
+  const { CustomTonSigner } = await import('./signers/ton.js');
   signers.registerSigner(TxType.TON, new CustomTonSigner(tonProvider));
   return signers;
 }

--- a/wallets/provider-tonconnect/src/tonConnectAdapter.ts
+++ b/wallets/provider-tonconnect/src/tonConnectAdapter.ts
@@ -1,8 +1,6 @@
 import type { Environments } from './types.js';
 import type * as TonConnectUIModule from '@tonconnect/ui';
 
-import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
-
 export class TonConnectAdapter {
   #tonModule?: typeof TonConnectUIModule;
   #tonConnectInstance?: TonConnectUIModule.TonConnectUI;
@@ -12,9 +10,7 @@ export class TonConnectAdapter {
       throw new Error('Environments are not set');
     }
 
-    this.#tonModule = await dynamicImportWithRefinedError(
-      async () => await import('@tonconnect/ui')
-    );
+    this.#tonModule = await import('@tonconnect/ui');
     const { TonConnectUI } = this.#tonModule;
     this.#tonConnectInstance = new TonConnectUI(env);
   }

--- a/wallets/provider-trezor/src/signer.ts
+++ b/wallets/provider-trezor/src/signer.ts
@@ -1,16 +1,11 @@
 import type { SignerFactory } from 'rango-types';
 
-import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(): Promise<SignerFactory> {
   const signers = new DefaultSignerFactory();
-  const { EthereumSigner } = await dynamicImportWithRefinedError(
-    async () => await import('./signers/ethereum.js')
-  );
-  const { BTCSigner } = await dynamicImportWithRefinedError(
-    async () => await import('./signers/utxo.js')
-  );
+  const { EthereumSigner } = await import('./signers/ethereum.js');
+  const { BTCSigner } = await import('./signers/utxo.js');
   signers.registerSigner(TxType.EVM, new EthereumSigner());
   signers.registerSigner(TxType.TRANSFER, new BTCSigner());
   return signers;

--- a/wallets/provider-trezor/src/utils.ts
+++ b/wallets/provider-trezor/src/utils.ts
@@ -1,7 +1,6 @@
 import type { TrezorConnect } from '@trezor/connect-web';
 
 import {
-  dynamicImportWithRefinedError,
   ETHEREUM_CHAIN_ID,
   type ProviderConnectResult,
 } from '@rango-dev/wallets-shared';
@@ -14,9 +13,7 @@ export const trezorErrorMessages: { [statusCode: string]: string } = {
 
 // `@trezor/connect-web` is commonjs, when we are importing it dynamically, it has some differences in different tooling. for example vite (you can check widget-examples), goes throw error. this is a workaround for solving this interop issue.
 export async function getTrezorModule() {
-  const mod = await dynamicImportWithRefinedError(
-    async () => await import('@trezor/connect-web')
-  );
+  const mod = await import('@trezor/connect-web');
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   if (mod.default.default) {

--- a/wallets/provider-tron-link/src/signer.ts
+++ b/wallets/provider-tron-link/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './types.js';
 import type { SignerFactory } from 'rango-types';
 
 import { TRON_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -13,9 +10,7 @@ export default async function getSigners(
 ): Promise<SignerFactory> {
   const tronProvider = getNetworkInstance(provider, TRON_NAMESPACE);
   const signers = new DefaultSignerFactory();
-  const { DefaultTronSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-tron')
-  );
+  const { DefaultTronSigner } = await import('@rango-dev/signer-tron');
   signers.registerSigner(TxType.TRON, new DefaultTronSigner(tronProvider));
   return signers;
 }

--- a/wallets/provider-trustwallet/src/signer.ts
+++ b/wallets/provider-trustwallet/src/signer.ts
@@ -2,10 +2,7 @@ import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
 import { EVM_NAMESPACE, SOLANA_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
@@ -15,12 +12,8 @@ export default async function getSigners(
   const solProvider = getNetworkInstance(provider, SOLANA_NAMESPACE);
 
   const signers = new DefaultSignerFactory();
-  const { DefaultEvmSigner } = await dynamicImportWithRefinedError(
-    async () => await import('@rango-dev/signer-evm')
-  );
-  const { CustomSolanaSigner } = await dynamicImportWithRefinedError(
-    async () => await import('./signers/solanaSigner.js')
-  );
+  const { DefaultEvmSigner } = await import('@rango-dev/signer-evm');
+  const { CustomSolanaSigner } = await import('./signers/solanaSigner.js');
 
   signers.registerSigner(TxType.EVM, new DefaultEvmSigner(ethProvider));
   signers.registerSigner(TxType.SOLANA, new CustomSolanaSigner(solProvider));

--- a/wallets/provider-unisat/src/signer.ts
+++ b/wallets/provider-unisat/src/signer.ts
@@ -2,19 +2,14 @@ import type { Provider } from './utils.js';
 import type { SignerFactory } from 'rango-types';
 
 import { UTXO_NAMESPACE } from '@hub3js/namespaces';
-import {
-  dynamicImportWithRefinedError,
-  getNetworkInstance,
-} from '@rango-dev/wallets-shared';
+import { getNetworkInstance } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 export default async function getSigners(
   provider: Provider
 ): Promise<SignerFactory> {
   const bitcoinInstance = getNetworkInstance(provider, UTXO_NAMESPACE);
-  const { BTCSigner } = await dynamicImportWithRefinedError(
-    async () => await import('./signers/utxoSigner.js')
-  );
+  const { BTCSigner } = await import('./signers/utxoSigner.js');
   const signers = new DefaultSignerFactory();
   signers.registerSigner(TxType.TRANSFER, new BTCSigner(bitcoinInstance));
   return signers;

--- a/wallets/provider-walletconnect-2/src/signer.ts
+++ b/wallets/provider-walletconnect-2/src/signer.ts
@@ -1,6 +1,5 @@
 import type { SignerFactory } from 'rango-types';
 
-import { dynamicImportWithRefinedError } from '@rango-dev/wallets-shared';
 import { DefaultSignerFactory, TransactionType as TxType } from 'rango-types';
 
 import { getAdapter } from './adapter/registry.js';
@@ -14,11 +13,7 @@ export default async function getSigners(): Promise<SignerFactory> {
   const client = await adapter.getClient();
 
   const signers = new DefaultSignerFactory();
-  const EVMSigner = (
-    await dynamicImportWithRefinedError(
-      async () => await import('./signers/evm.js')
-    )
-  ).default;
+  const EVMSigner = (await import('./signers/evm.js')).default;
   signers.registerSigner(
     TxType.EVM,
     new EVMSigner(client, () => adapter.getSession('evm'))

--- a/wallets/shared/src/helpers.ts
+++ b/wallets/shared/src/helpers.ts
@@ -192,24 +192,3 @@ export function detectMobileScreens(): boolean {
     navigator.userAgent
   );
 }
-
-/**
- * Dynamically import a module and refine the error.
- *
- * @param importer - lazy import callback.
- * @returns A promise resolving to the imported module.
- */
-export async function dynamicImportWithRefinedError<T>(
-  importer: () => Promise<T>
-): Promise<T> {
-  try {
-    return await importer();
-  } catch (error) {
-    throw new Error(
-      'A network error occurred while processing your request. Please check your internet connection or refresh the page and try again.',
-      {
-        cause: error,
-      }
-    );
-  }
-}

--- a/widget/embedded/src/QueueManager.tsx
+++ b/widget/embedded/src/QueueManager.tsx
@@ -19,6 +19,7 @@ import { eventEmitter } from './services/eventEmitter';
 import { useAppStore } from './store/AppStore';
 import { useUiStore } from './store/ui';
 import { getConfig } from './utils/configs';
+import { tryRefineError } from './utils/errors';
 import { walletAndSupportedChainsNames } from './utils/wallets';
 
 function QueueManager(props: PropsWithChildren<{ apiKey?: string }>) {
@@ -92,7 +93,13 @@ function QueueManager(props: PropsWithChildren<{ apiKey?: string }>) {
         convertEvmBlockchainMetaToEvmChainInfo(evmBasedChains),
       getSupportedChainNames,
     },
-    getSigners,
+    getSigners: async (type: WalletType) => {
+      try {
+        return await getSigners(type);
+      } catch (error) {
+        throw tryRefineError(error) ?? error;
+      }
+    },
     wallets,
     providers: allProviders,
     switchNetwork,

--- a/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
+++ b/widget/embedded/src/components/SwapDetails/SwapDetails.tsx
@@ -36,6 +36,7 @@ import { useNotificationStore } from '../../store/notification';
 import { useQuoteStore } from '../../store/quote';
 import { UiEventTypes } from '../../types';
 import { getContainer } from '../../utils/common';
+import { tryRefineError } from '../../utils/errors';
 import { emitUiEvent } from '../../utils/events';
 import {
   numberToString,
@@ -185,7 +186,9 @@ export function SwapDetails(props: SwapDetailsProps) {
           handleShowSwitchNetworkSucceeded();
         })
         .catch((error: unknown) => {
-          handleShowSwitchNetworkFailed(error as Error);
+          handleShowSwitchNetworkFailed(
+            tryRefineError(error) ?? (error as Error)
+          );
         });
     }
   };

--- a/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.ConnectWallet.tsx
+++ b/widget/embedded/src/components/SwapDetailsModal/SwapDetailsModal.ConnectWallet.tsx
@@ -16,6 +16,7 @@ import React, { useState } from 'react';
 
 import { useWalletList } from '../../hooks/useWalletList';
 import { useUiStore } from '../../store/ui';
+import { tryRefineError } from '../../utils/errors';
 import { getConciseAddress } from '../../utils/wallets';
 import { NamespaceItem } from '../NamespaceItem';
 
@@ -89,7 +90,7 @@ export const ConnectWalletContent = (props: ConnectWalletContentProps) => {
           : undefined
       );
     } catch (error) {
-      setError(error as Error);
+      setError(tryRefineError(error) ?? (error as Error));
     }
   };
 

--- a/widget/embedded/src/components/WalletStatefulConnect/NamespaceDetachedItem.tsx
+++ b/widget/embedded/src/components/WalletStatefulConnect/NamespaceDetachedItem.tsx
@@ -4,6 +4,7 @@ import { i18n } from '@lingui/core';
 import { Button, Spinner } from '@rango-dev/ui';
 import React, { useLayoutEffect, useRef, useState } from 'react';
 
+import { tryRefineError } from '../../utils/errors';
 import { getConciseAddress } from '../../utils/wallets';
 import { NamespaceItem } from '../NamespaceItem';
 
@@ -39,7 +40,7 @@ export function NamespaceDetachedItem(props: NamespaceDetachedItemPropTypes) {
       processingConnectAttempt.current = true;
       await handleConnect(options);
     } catch (error) {
-      setError(error as Error);
+      setError(tryRefineError(error) ?? (error as Error));
     } finally {
       processingConnectAttempt.current = false;
     }

--- a/widget/embedded/src/constants/errors.ts
+++ b/widget/embedded/src/constants/errors.ts
@@ -7,6 +7,9 @@ import { QuoteErrorType } from '../types';
 export const errorMessages = () => {
   return {
     genericServerError: i18n.t('Failed Network, Please retry your swap.'),
+    moduleLoadError: i18n.t(
+      'A network error occurred while processing your request. Please check your internet connection or refresh the page and try again.'
+    ),
     liquiditySourcesError: {
       title: i18n.t('Please reset your liquidity sources.'),
       description: i18n.t(

--- a/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
+++ b/widget/embedded/src/hooks/useStatefulConnect/useStatefulConnect.ts
@@ -8,6 +8,7 @@ import { useWallets } from '@rango-dev/wallets-react';
 import { useReducer } from 'react';
 
 import { isOnDetached } from '../../components/StatefulConnectModal';
+import { tryRefineErrorMessage } from '../../utils/errors';
 import { type ExtendedModalWalletInfo } from '../../utils/wallets';
 
 import {
@@ -75,9 +76,12 @@ export function useStatefulConnect(): UseStatefulConnect {
       return { status: ResultStatus.Connected };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
-      const message = e?.message
-        ? `Error: ${e.message}`
-        : 'An unknown error happened during connecting wallet.';
+      const message = tryRefineErrorMessage(
+        e,
+        e?.message
+          ? `Error: ${e.message}`
+          : 'An unknown error happened during connecting wallet.'
+      );
 
       if (options?.disconnectOnError) {
         try {

--- a/widget/embedded/src/utils/errors.test.ts
+++ b/widget/embedded/src/utils/errors.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  isModuleLoadError,
+  tryRefineError,
+  tryRefineErrorMessage,
+} from './errors';
+
+describe('error refinement', () => {
+  describe('recognizing a failed dynamic import', () => {
+    test('should match a thrown error', () => {
+      const error = new TypeError(
+        'Failed to fetch dynamically imported module: https://cdn.example/signer.js'
+      );
+
+      expect(isModuleLoadError(error)).toBe(true);
+    });
+
+    test('should match webpack failures named instead of worded', () => {
+      const error = new Error('Loading failed');
+      error.name = 'ChunkLoadError';
+
+      expect(isModuleLoadError(error)).toBe(true);
+    });
+
+    test('should match a message that was already stringified', () => {
+      expect(
+        isModuleLoadError('TypeError: importing a module script failed')
+      ).toBe(true);
+    });
+  });
+
+  describe('leaving unrecognized failures alone', () => {
+    test('should not match an unrelated error', () => {
+      expect(
+        isModuleLoadError(new Error('User rejected the transaction'))
+      ).toBe(false);
+    });
+
+    test('should not match empty input', () => {
+      expect(isModuleLoadError(null)).toBe(false);
+      expect(isModuleLoadError(undefined)).toBe(false);
+      expect(isModuleLoadError('')).toBe(false);
+    });
+  });
+
+  describe('refining into a user facing error', () => {
+    test('should keep the original as the cause', () => {
+      const error = new TypeError('failed to load module script');
+      const refined = tryRefineError(error);
+
+      expect(refined).toBeInstanceOf(Error);
+      expect(refined?.cause).toBe(error);
+      expect(refined?.message).not.toBe(error.message);
+    });
+
+    test('should return null for an unrecognized failure', () => {
+      expect(tryRefineError(new Error('boom'))).toBeNull();
+    });
+
+    test('should fall back to the given message', () => {
+      const fallback = 'An unknown error happened during connecting wallet.';
+
+      expect(tryRefineErrorMessage(new Error('boom'), fallback)).toBe(fallback);
+    });
+
+    test('should refine instead of falling back when recognized', () => {
+      const fallback = 'An unknown error happened during connecting wallet.';
+
+      expect(
+        tryRefineErrorMessage(
+          new TypeError('loading chunk 42 failed'),
+          fallback
+        )
+      ).not.toBe(fallback);
+    });
+  });
+});

--- a/widget/embedded/src/utils/errors.ts
+++ b/widget/embedded/src/utils/errors.ts
@@ -1,0 +1,69 @@
+import { errorMessages } from '../constants/errors';
+
+/*
+ * A failed `import()` has no standard error, so each engine and bundler words
+ * it differently. Lowercase, they are matched against a lowercased message.
+ */
+const MODULE_LOAD_ERROR_MESSAGES = [
+  // Chromium
+  'failed to fetch dynamically imported module',
+  // Firefox
+  'error loading dynamically imported module',
+  // Safari
+  'importing a module script failed',
+  // A stale chunk answered with the index page instead of a module
+  'failed to load module script',
+  // Vite
+  'unable to preload css',
+  // Webpack
+  'loading chunk',
+  'loading css chunk',
+  'chunkloaderror',
+];
+
+function toMessage(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    // Webpack names its failures rather than wording them.
+    return `${value.name} ${value.message}`;
+  }
+
+  return '';
+}
+
+export function isModuleLoadError(value: unknown): boolean {
+  const message = toMessage(value).toLowerCase();
+
+  return (
+    !!message &&
+    MODULE_LOAD_ERROR_MESSAGES.some((candidate) => message.includes(candidate))
+  );
+}
+
+/**
+ * Replace a failure we recognize with one worth showing to a user.
+ *
+ * Every place the widget calls into another package routes its failures through
+ * here, so a new class of failure only has to be taught to the widget once.
+ *
+ * @param error - a thrown error, or a message already stringified from one.
+ * @returns a user facing error keeping the original as `cause`, or `null` when
+ * the failure is not one we recognize.
+ */
+export function tryRefineError(error: unknown): Error | null {
+  if (isModuleLoadError(error)) {
+    return new Error(errorMessages().moduleLoadError, { cause: error });
+  }
+
+  return null;
+}
+
+export function tryRefineErrorMessage(
+  error: unknown,
+  fallback: string
+): string {
+  return tryRefineError(error)?.message ?? fallback;
+}

--- a/widget/embedded/src/utils/swap.ts
+++ b/widget/embedded/src/utils/swap.ts
@@ -49,6 +49,7 @@ import {
   TOKEN_AMOUNT_MIN_DECIMALS,
 } from '../constants/routing';
 
+import { tryRefineError } from './errors';
 import { getBlockchainShortNameFor, isValidTokenAddress } from './meta';
 import { numberToString } from './numbers';
 import { getRequiredBalanceOfWallet } from './quote';
@@ -737,6 +738,12 @@ export function getSwapMessages(
   }
   detailedMessage = detailedMessage || '';
   message = message || '';
+  const refined = tryRefineError(message) ?? tryRefineError(detailedMessage);
+  if (refined) {
+    detailedMessage = [message, detailedMessage].filter(Boolean).join('\n');
+    message = refined.message;
+  }
+
   const isRpc =
     message?.indexOf('code') !== -1 && message?.indexOf('reason') !== -1;
 


### PR DESCRIPTION
**You should only review the last commit. Other changes are related to the rebase with the Walletconnect branch.**

## Summary

`dynamicImportWithRefinedError` lived in `@rango-dev/wallets-shared` but has nothing wallet-specific about it — it just runs a lazy import and rethrows failures with a user-friendly message. This adds a domain-neutral `@rango-dev/common-core` package and moves it there.

## Changes

- Add `common/core` (`@rango-dev/common-core`) and register `common/*` as a workspace group
- Repoint 34 files across 28 provider packages to the new import
- Drop the now-unused `@rango-dev/wallets-shared` dependency from `provider-slush`

## How tested

`build:all` (54/54 buildable projects), `yarn test` (17 files, 151 passed), and lint across all touched packages.


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
