### PR TITLE
refactor(wallets): drop getSolanaAccounts in favor of the hub connect action

### DIFF
--- a/wallets/provider-phantom/src/namespaces/solana.ts
+++ b/wallets/provider-phantom/src/namespaces/solana.ts
@@ -1,18 +1,9 @@
 import type { SolanaActions } from '@hub3js/solana';
-import type { CaipAccount } from '@hub3js/std/types';
 
 import { ActionBuilder, NamespaceBuilder } from '@hub3js/core';
-import {
-  actions,
-  builders,
-  CAIP_NAMESPACE,
-  CAIP_SOLANA_CHAIN_ID,
-  hooks,
-} from '@hub3js/solana';
+import { actions, builders, hooks } from '@hub3js/solana';
 import * as commonBuilders from '@hub3js/std/builders';
 import { standardizeAndThrowError } from '@hub3js/std/operators';
-import { getSolanaAccounts } from '@rango-dev/wallets-shared';
-import { AccountId } from 'caip';
 
 import { WALLET_ID } from '../constants.js';
 import { solanaPhantom } from '../utils.js';
@@ -28,31 +19,7 @@ const [changeAccountSubscriber, changeAccountCleanup] =
  */
 const connect = builders
   .connect()
-  .action(async function () {
-    const solanaInstance = solanaPhantom();
-    const result = await getSolanaAccounts({
-      instance: solanaInstance,
-      meta: [],
-    });
-    if (Array.isArray(result)) {
-      throw new Error(
-        'Expecting solana response to be a single value, not an array.'
-      );
-    }
-
-    const formatAccounts = result.accounts.map(
-      (account) =>
-        AccountId.format({
-          address: account,
-          chainId: {
-            namespace: CAIP_NAMESPACE,
-            reference: CAIP_SOLANA_CHAIN_ID,
-          },
-        }) as CaipAccount
-    );
-
-    return formatAccounts;
-  })
+  .action(actions.connect(solanaPhantom))
   .before(changeAccountSubscriber)
   .or(changeAccountCleanup)
   .or(standardizeAndThrowError)

--- a/wallets/shared/src/helpers.ts
+++ b/wallets/shared/src/helpers.ts
@@ -1,14 +1,11 @@
 import type {
   AddEthereumChainParameter,
-  Connect,
   EvmNetworksChainInfo,
   InstallObjects,
   Network,
   Wallet,
 } from './rango.js';
 import type { EvmBlockchainMeta } from 'rango-types';
-
-import { Networks } from './rango.js';
 
 export { isAddress as isEvmAddress } from 'ethers';
 
@@ -148,22 +145,6 @@ export const evmChainsToRpcMap = (
       })
     )
   );
-};
-
-export const getSolanaAccounts: Connect = async ({ instance }) => {
-  let account = '';
-  if (instance.isConnected && instance.publicKey) {
-    account = instance.publicKey.toString();
-  } else {
-    // Asking for account from wallet if not connected or no public key available.
-    const solanaResponse = await instance.connect();
-    account = solanaResponse.publicKey.toString();
-  }
-
-  return {
-    accounts: [account],
-    chainId: Networks.SOLANA,
-  };
 };
 
 export function sortWalletsBasedOnState(wallets: Wallet[]): Wallet[] {


### PR DESCRIPTION
## Summary

`getSolanaAccounts` in `wallets-shared` had exactly one caller left — Phantom's Solana namespace — but it was never a Phantom-specific difference. It was the generic legacy Solana connect path, and Phantom was the first wallet migrated to the hub, back before `actions.connect` existed in the Solana namespace, so it inlined an action around the helper and was never revisited while every later migration moved off it. Phantom now uses the standard action and the helper is gone.

## Changes

- Point Phantom's Solana `connect` at `actions.connect(solanaPhantom)`, matching Brave/Ctrl/OKX and the other Solana providers
- Delete `getSolanaAccounts` from `wallets-shared` along with its now-unused `Connect` and `Networks` imports

## How tested

`yarn build:all` (61 projects) and `vitest run` (17 files, 152 passed) both green.
The connect functionality was the same as before.


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
