### PR TITLE
fix(signers): remove extra ton transaction fields

### DIFF
--- a/signers/signer-ton/src/signer.ts
+++ b/signers/signer-ton/src/signer.ts
@@ -1,7 +1,14 @@
-import type { GenericSigner, TonTransaction } from 'rango-types';
+import type { GenericSigner, TonMessage, TonTransaction } from 'rango-types';
 
 import { Address, Cell } from '@ton/core';
-import { SignerError } from 'rango-types';
+import { SignerError, TonChainID } from 'rango-types';
+
+export type TonTransactionPayload = {
+  valid_until: number;
+  network: TonChainID;
+  from?: string;
+  messages: TonMessage[];
+};
 
 export class DefaultTonSigner implements GenericSigner<TonTransaction> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -9,26 +16,33 @@ export class DefaultTonSigner implements GenericSigner<TonTransaction> {
     this.provider = provider;
   }
 
+  static buildTx(tonTx: TonTransaction): TonTransactionPayload {
+    const { validUntil, network, from, messages } = tonTx;
+
+    let tx: TonTransactionPayload = {
+      valid_until: validUntil,
+      network: network ?? TonChainID.MAINNET,
+      messages: messages.map(({ address, amount, stateInit, payload }) => ({
+        address,
+        amount,
+        ...(stateInit != null && { stateInit }),
+        ...(payload != null && { payload }),
+      })),
+    };
+    if (from) {
+      tx = { ...tx, from: Address.parse(from).toRawString() };
+    }
+    return tx;
+  }
+
   async signMessage(): Promise<string> {
     throw SignerError.UnimplementedError('signMessage');
   }
 
   async signAndSendTx(tx: TonTransaction): Promise<{ hash: string }> {
-    const { type, blockChain, from, messages, ...rest } = tx;
-
-    const transactionObjectForSign = {
-      ...rest,
-      ...(from && { from: Address.parse(from).toRawString() }),
-      messages: messages.map(({ stateInit, payload, ...msg }) => ({
-        ...msg,
-        ...(stateInit != null && { stateInit }),
-        ...(payload != null && { payload }),
-      })),
-    };
-
     const { result } = await this.provider.send({
       method: 'sendTransaction',
-      params: [JSON.stringify(transactionObjectForSign)],
+      params: [JSON.stringify(DefaultTonSigner.buildTx(tx))],
     });
 
     const hash = Cell.fromBase64(result).hash().toString('hex');

--- a/wallets/provider-okx/package.json
+++ b/wallets/provider-okx/package.json
@@ -33,6 +33,7 @@
     "@rango-dev/signer-evm": "^0.45.1-next.1",
     "@rango-dev/signer-solana": "^0.49.0",
     "@rango-dev/signer-sui": "^0.11.0",
+    "@rango-dev/signer-ton": "^0.29.0",
     "@rango-dev/signer-tron": "^0.42.0",
     "@rango-dev/wallets-core": "^0.61.1-next.2",
     "@ton/core": "^0.59.0",

--- a/wallets/provider-okx/src/signers/ton.ts
+++ b/wallets/provider-okx/src/signers/ton.ts
@@ -4,7 +4,8 @@ import type {
 } from '../namespaces/ton/types.js';
 import type { GenericSigner, TonTransaction } from 'rango-types';
 
-import { SignerError, SignerErrorCode, TonChainID } from 'rango-types';
+import { DefaultTonSigner } from '@rango-dev/signer-ton';
+import { SignerError, SignerErrorCode } from 'rango-types';
 
 import { TON_CONNECT_USER_REJECTED_CODE } from '../constants.js';
 import { nextTonRequestId } from '../namespaces/ton/utils.js';
@@ -29,20 +30,9 @@ export class OKXTonSigner implements GenericSigner<TonTransaction> {
   }
 
   async signAndSendTx(tx: TonTransaction): Promise<{ hash: string }> {
-    const { validUntil, network, from, messages } = tx;
+    const { Cell } = await import('@ton/core');
 
-    const { Address, Cell } = await import('@ton/core');
-
-    const transactionPayload = {
-      valid_until: validUntil,
-      network: network ?? TonChainID.MAINNET,
-      ...(from && { from: Address.parse(from).toRawString() }),
-      messages: messages.map(({ stateInit, payload, ...message }) => ({
-        ...message,
-        ...(stateInit != null && { stateInit }),
-        ...(payload != null && { payload }),
-      })),
-    };
+    const transactionPayload = DefaultTonSigner.buildTx(tx);
 
     try {
       const response = await this.provider.send({

--- a/wallets/provider-tonconnect/package.json
+++ b/wallets/provider-tonconnect/package.json
@@ -25,6 +25,7 @@
     "@hub3js/namespaces": "^0.5.1",
     "@hub3js/std": "^0.4.0",
     "@hub3js/tvm": "^0.4.0",
+    "@rango-dev/signer-ton": "^0.29.0",
     "@ton/core": "^0.59.0",
     "@ton/crypto": "^3.3.0",
     "@tonconnect/ui": "^2.0.9",

--- a/wallets/provider-tonconnect/src/signers/ton.ts
+++ b/wallets/provider-tonconnect/src/signers/ton.ts
@@ -1,9 +1,15 @@
 import type { TonConnectUI } from '@tonconnect/ui';
 import type { GenericSigner, TonTransaction } from 'rango-types';
 
-import { Address, Cell } from '@ton/core';
+import { DefaultTonSigner } from '@rango-dev/signer-ton';
+import { Cell } from '@ton/core';
 import { CHAIN } from '@tonconnect/ui';
-import { SignerError } from 'rango-types';
+import { SignerError, TonChainID } from 'rango-types';
+
+const NETWORKS: Record<TonChainID, CHAIN> = {
+  [TonChainID.MAINNET]: CHAIN.MAINNET,
+  [TonChainID.TESTNET]: CHAIN.TESTNET,
+};
 
 export class CustomTonSigner implements GenericSigner<TonTransaction> {
   private provider: TonConnectUI;
@@ -17,16 +23,13 @@ export class CustomTonSigner implements GenericSigner<TonTransaction> {
   }
 
   async signAndSendTx(tx: TonTransaction): Promise<{ hash: string }> {
-    const { blockChain, type, from, messages, ...rest } = tx;
+    const transaction = DefaultTonSigner.buildTx(tx);
+    const { valid_until, network, ...restTransactionFields } = transaction;
+
     const result = await this.provider.sendTransaction({
-      ...rest,
-      ...(from && { from: Address.parse(from).toRawString() }),
-      messages: messages.map(({ stateInit, payload, ...msg }) => ({
-        ...msg,
-        ...(stateInit != null && { stateInit }),
-        ...(payload != null && { payload }),
-      })),
-      network: CHAIN.MAINNET,
+      ...restTransactionFields,
+      validUntil: valid_until,
+      network: NETWORKS[network],
     });
 
     const hash = Cell.fromBase64(result.boc).hash().toString('hex');


### PR DESCRIPTION
## Summary

The three TON signers each spread the `tx` object into the payload they sent for signing, so unrelated fields leaked through and each one built a slightly different shape. Adds a static `DefaultTonSigner.buildTx` — mirroring `DefaultEvmSigner.buildTx` — that explicitly extracts `validUntil`, `network`, `from` and `messages` and returns the standard TON Connect bridge payload, and routes all three signers through it.


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
