### PR TITLE
Refactor/rc 362 drop demo wallet configs

### DIFF
--- a/queue-manager/queue-manager-demo/src/components/Wallets/index.tsx
+++ b/queue-manager/queue-manager-demo/src/components/Wallets/index.tsx
@@ -1,26 +1,34 @@
 import { useWallets } from '@rango-dev/wallets-react';
 import React from 'react';
 
+import { walletTypes } from '../../providers';
+
 function Wallets() {
-  const { connect, providers, state, disconnect } = useWallets();
-  const list = Object.keys(providers());
+  const { connect, state, disconnect, getWalletInfo } = useWallets();
   return (
     <div>
       <h3>Available Wallets</h3>
       <div className="wallets">
-        {list.map((type) => {
+        {walletTypes.map((type) => {
           const wallet_type = type;
           const wallet_state = state(wallet_type);
+          const namespaces = getWalletInfo(
+            wallet_type
+          ).needsNamespace?.data.map((namespace) => ({
+            namespace: namespace.value,
+            network: undefined,
+          }));
           return (
             <div className="wallet" key={type}>
               <h5>{wallet_type}</h5>
               <p>Address: {wallet_state.accounts?.join(',')}</p>
               <button
+                id={`${wallet_type}-connect`}
                 onClick={() => {
                   if (wallet_state.connected) {
                     void disconnect(wallet_type);
                   } else {
-                    void connect(wallet_type);
+                    void connect(wallet_type, namespaces);
                   }
                 }}>
                 {wallet_state.connected ? 'Disconnect' : 'Connect'}

--- a/queue-manager/queue-manager-demo/src/configs.ts
+++ b/queue-manager/queue-manager-demo/src/configs.ts
@@ -22,7 +22,7 @@ export function getConfig(name: keyof Configs) {
   return configs[name];
 }
 
-export function setConfig(name: keyof Configs, value: any) {
+export function setConfig<K extends keyof Configs>(name: K, value: Configs[K]) {
   configs[name] = value;
 
   return value;

--- a/queue-manager/queue-manager-demo/src/index.tsx
+++ b/queue-manager/queue-manager-demo/src/index.tsx
@@ -1,7 +1,7 @@
 import type { WalletType } from '@hub3js/core';
 import type { BlockchainMeta } from 'rango-types';
 
-import { allProviders } from '@rango-dev/provider-all';
+import { WalletTypes } from '@rango-dev/provider-all';
 import { Events, Provider } from '@rango-dev/wallets-react';
 import { RangoClient } from 'rango-sdk';
 import React, { useEffect, useState } from 'react';
@@ -13,14 +13,7 @@ import {
   TREZOR_MANIFEST,
   WC_PROJECT_ID,
 } from './configs';
-
-const providers = allProviders({
-  walletconnect2: {
-    WC_PROJECT_ID: WC_PROJECT_ID,
-  },
-  trezorManifest: TREZOR_MANIFEST,
-  tonconnect: { manifestUrl: TON_CONNECT_MANIFEST_URL },
-});
+import { providers } from './providers';
 
 function AppContainer() {
   const [connectedWallets, setConnectedWallets] = useState<WalletType[]>([]);
@@ -46,6 +39,19 @@ function AppContainer() {
     <Provider
       providers={providers}
       allBlockChains={blockchains}
+      configs={{
+        walletOptions: {
+          [WalletTypes.TON_CONNECT]: {
+            provider: { manifestUrl: TON_CONNECT_MANIFEST_URL },
+          },
+          [WalletTypes.TREZOR]: {
+            provider: { manifest: TREZOR_MANIFEST },
+          },
+          [WalletTypes.WALLET_CONNECT_2]: {
+            provider: { WC_PROJECT_ID },
+          },
+        },
+      }}
       onUpdateState={(type, event, value, coreState) => {
         if (event === Events.ACCOUNTS && coreState.connected) {
           if (coreState.connected) {

--- a/queue-manager/queue-manager-demo/src/providers.ts
+++ b/queue-manager/queue-manager-demo/src/providers.ts
@@ -1,0 +1,11 @@
+import type { Provider } from '@hub3js/core';
+
+import { pickVersion } from '@hub3js/core/utils';
+import { allProviders } from '@rango-dev/provider-all';
+import { HUB_VERSION } from '@rango-dev/wallets-react';
+
+export const providers = allProviders().map((build) => build());
+
+export const walletTypes = providers.map(
+  (provider) => (pickVersion(provider, HUB_VERSION)[1] as Provider).id
+);

--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.Wallets.tsx
@@ -32,7 +32,7 @@ export function WalletSection() {
   } = useMetaStore();
 
   const { externalWallets, wallets, multiWallets } = config;
-  const allWalletList = getWalletsList(config, blockchains);
+  const allWalletList = getWalletsList(blockchains);
 
   const onChangeExternalWallet = (checked: boolean) => {
     if (!checked) {

--- a/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.utils.ts
+++ b/widget/playground/src/containers/FunctionalLayout/FunctionalLayout.utils.ts
@@ -1,6 +1,5 @@
 import type { MapSupportedList } from '../../components/MultiSelect/MultiSelect.types';
 import type { Provider } from '@hub3js/core';
-import type { WidgetConfig } from '@rango-dev/widget-embedded';
 import type { BlockchainMeta } from 'rango-sdk';
 
 import { pickVersion, type VersionedProviders } from '@hub3js/core/utils';
@@ -13,19 +12,9 @@ import { excludedWallets } from '../../utils/common';
 
 // Considering that the wallets list of the config used for `WidgetProvider` gets filtered by the selected wallets here, we can not directly use `getWalletInfo` of `useWallets` to get the info related to each wallet item because the required provider for an unselected wallet item will not be passed to `Provider`.
 export function getWalletsList(
-  config: WidgetConfig,
   blockchains: BlockchainMeta[]
 ): MapSupportedList[] {
-  const envs = {
-    selectedProviders: config.wallets,
-    trezor: config?.trezorManifest
-      ? { manifest: config.trezorManifest }
-      : undefined,
-    tonConnect: config?.tonConnect?.manifestUrl
-      ? { manifestUrl: config?.tonConnect.manifestUrl }
-      : undefined,
-  };
-  const allProviders = getAllProviders(envs);
+  const allProviders = getAllProviders();
   const allBuiltProviders = allProviders.map((build) => build());
   const walletsList: MapSupportedList[] = [];
   allBuiltProviders.forEach((versionedProvider: VersionedProviders) => {


### PR DESCRIPTION
## Summary

`allProviders` takes no arguments, so the demo and the playground stop building config objects for it, and `WC_PROJECT_ID`, `TREZOR_MANIFEST` and `TON_CONNECT_MANIFEST_URL` lose their only reader. Also gives `setConfig` a real value type so the file passes lint.

## Changes

- Demo calls `allProviders()` and drops the three constants behind the old argument
- Playground's `getWalletsList` loses its `config` parameter and the `envs` object it existed to build

## How tested

`yarn install` + `yarn clean` + `yarn build:all` (59/59) and `yarn vitest run` (157/157).


# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
