### PR TITLE
fix(widget): use unique keys for token list skeleton items

### DIFF
--- a/widget/embedded/src/components/TokenList/LoadingTokenList.tsx
+++ b/widget/embedded/src/components/TokenList/LoadingTokenList.tsx
@@ -8,9 +8,9 @@ import { End, List } from './TokenList.styles';
 export function LoadingTokenList(props: LoadingTokenListProps) {
   return (
     <List>
-      {Array.from(Array(props.size), (e) => (
+      {Array.from(Array(props.size), (_, index) => (
         <ListItem
-          key={e}
+          key={index}
           hasDivider
           start={<Skeleton variant="circular" width={35} height={35} />}
           end={


### PR DESCRIPTION
# Summary

Token list skeleton items used undefined as their React key because Array.from was mapping empty slots.
Use each item’s index as the key so the loading list renders with unique keys.


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
