### PR TITLE
fix: pass the envs during the build

### DIFF
--- a/.github/actions/build-deploy/action.yml
+++ b/.github/actions/build-deploy/action.yml
@@ -44,6 +44,9 @@ runs:
       # dependencies (^build) are restored from the nx cache produced by
       # build-libs, so only the apps themselves are compiled.
       run: node ./scripts/build-clients/command.mjs
+      env:
+        REACT_APP_PLAYGROUND_RANGO_API_KEY: ${{ inputs.PLAYGROUND_RANGO_API_KEY }}
+        REACT_APP_RANGO_API_KEY: ${{ inputs.RANGO_API_KEY }}
 
     - name: Deploy Clients
       id: deploy-clients
@@ -59,7 +62,5 @@ runs:
         VERCEL_PROJECT_WIDGET_CONFIG: ${{ inputs.VERCEL_PROJECT_WIDGET_CONFIG }}
         VERCEL_PROJECT_WIDGET_APP: ${{ inputs.VERCEL_PROJECT_WIDGET_APP }}
         VERCEL_PROJECT_Q: ${{ inputs.VERCEL_PROJECT_Q }}
-        REACT_APP_PLAYGROUND_RANGO_API_KEY: ${{ inputs.PLAYGROUND_RANGO_API_KEY }}
-        REACT_APP_RANGO_API_KEY: ${{ inputs.RANGO_API_KEY }}
-        ENABLE_PREVIEW_DEPLOY: ${{ inputs.ENABLE_PREVIEW_DEPLOY }}       
+        ENABLE_PREVIEW_DEPLOY: ${{ inputs.ENABLE_PREVIEW_DEPLOY }}
 


### PR DESCRIPTION
# Summary

We only need API key envs during the build

Fixes # (issue)
Fixed deploy workflow

# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
