### PR TITLE
fix(bitget): broadcast UTXO transactions directly to an RPC node

### DIFF
--- a/wallets/provider-bitget/package.json
+++ b/wallets/provider-bitget/package.json
@@ -30,6 +30,7 @@
     "@rango-dev/signer-evm": "^0.45.1-next.1",
     "@rango-dev/signer-tron": "^0.42.0",
     "@rango-dev/wallets-core": "^0.61.1-next.3",
+    "bitcoinjs-lib": "^6.1.7",
     "rango-types": "^0.5.0"
   },
   "publishConfig": {

--- a/wallets/provider-bitget/src/signers/utxo.ts
+++ b/wallets/provider-bitget/src/signers/utxo.ts
@@ -2,7 +2,10 @@ import type { ProviderAPI } from '@hub3js/bip122';
 import type { GenericSigner, Transfer } from 'rango-types';
 
 import { isBitcoinBlockchain } from '@rango-dev/internal-blockchains';
+import * as bitcoin from 'bitcoinjs-lib';
 import { SignerError } from 'rango-types';
+
+const BTC_RPC_URL = 'https://go.getblock.io/f37bad28a991436483c0a3679a3acbee';
 
 export class BitgetUTXOSigner implements GenericSigner<Transfer> {
   private provider: ProviderAPI;
@@ -38,20 +41,51 @@ export class BitgetUTXOSigner implements GenericSigner<Transfer> {
         signingIndexes.map((index) => ({ index, address }))
     );
 
+    // 3. Sign (& auto-finalize)
+    let signedPsbtHex: string;
     try {
-      // 3. Sign (& auto-finalize)
-      const signedPsbtHex = await this.provider.signPsbt(psbtHex, {
+      signedPsbtHex = await this.provider.signPsbt(psbtHex, {
         autoFinalized: true,
         toSignInputs,
       });
-
-      // 4. Push signed psbt
-      const transactionHash = await this.provider.pushPsbt(signedPsbtHex);
-
-      return { hash: transactionHash };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       throw new Error(error?.message || 'Error during signing transaction');
     }
+
+    // 4. Parse the PSBT hex and extract the raw transaction
+    const psbtObject = bitcoin.Psbt.fromHex(signedPsbtHex);
+    const finalPsbtBaseHex = psbtObject.extractTransaction().toHex();
+
+    /*
+     * 5. Broadcast the raw transaction to the rpc node.
+     * Broadcasting through Bitget's `pushPsbt` fails, so we submit the raw
+     * transaction ourselves, the same way the UniSat signer does.
+     */
+    const response = await fetch(BTC_RPC_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        method: 'sendrawtransaction',
+        params: [finalPsbtBaseHex],
+      }),
+    });
+
+    if (!response.ok) {
+      // Handle network and fetch errors
+      const errorText = await response.text();
+      throw new Error(`Error broadcasting transaction: ${errorText}`);
+    }
+
+    const data = await response.json();
+
+    if (!data.result) {
+      // Handle Bitcoin specific errors
+      throw new Error(
+        `Error broadcasting transaction. Error Code ${data.error.code}: ${data.error.message}`
+      );
+    }
+
+    return { hash: data.result };
   }
 }


### PR DESCRIPTION
# Summary

Bitcoin swaps through Bitget fail at the broadcast step, after the user has already signed the PSBT. BitgetUTXOSigner relied on the injected provider's pushPsbt to broadcast, which doesn't reliably submit the transaction.

This replaces that call with a direct RPC broadcast: parse the auto-finalized PSBT with bitcoinjs-lib, extract the raw transaction, and POST sendrawtransaction to the GetBlock node — the same flow the UniSat and Phantom signers already use.

The try/catch now wraps only signPsbt. It previously wrapped the broadcast as well and collapsed failures into a generic error?.message, hiding the node's error code; broadcast rejections (-26: dust, -25: missing inputs, …) now surface with their real code.

Adds bitcoinjs-lib@^6.1.7 to provider-bitget — already used by three other providers and hoisted at the repo root, so no lockfile churn.


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
