### PR TITLE
fix(unisat): send JSON content type when broadcasting BTC transactions

### DIFF
--- a/wallets/provider-unisat/src/signers/utxoSigner.ts
+++ b/wallets/provider-unisat/src/signers/utxoSigner.ts
@@ -71,6 +71,7 @@ export class BTCSigner implements GenericSigner<Transfer> {
     // 5. Broadcast PSBT to rpc node
     const response = await fetch(BTC_RPC_URL, {
       method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         method: 'sendrawtransaction',
         params: [finalPsbtBaseHex],


### PR DESCRIPTION
# Summary

BTC swaps on UniSat intermittently failed at broadcast with -32600 Invalid Request. The full RPC response gives the reason: "Content-Type must be application/json".

The broadcast set no content type, so fetch sent the string body as text/plain;charset=UTF-8. The RPC provider load-balances across backends and only some enforce JSON, hence the intermittency. The transaction is already signed by then, so the swap dies at the final step.

One-line fix: set the header explicitly. It does make the request preflighted — verified the endpoint returns 200 on OPTIONS with content-type allowed.


# How did you test this change?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Implemented a user interface (UI) change, referencing our Figma design to ensure pixel-perfect precision.
